### PR TITLE
Use conditions for controlling the reconcile loop

### DIFF
--- a/api/v1alpha1/clustergroupupgrade_types.go
+++ b/api/v1alpha1/clustergroupupgrade_types.go
@@ -75,8 +75,9 @@ type ClusterGroupUpgradeStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 	PlacementBindings []string           `json:"placementBindings"`
 	PlacementRules    []string           `json:"placementRules"`
-	Policies          []PolicyStatus     `json:"policies"`
+	Policies          []string           `json:"policies"`
 	Conditions        []metav1.Condition `json:"conditions"`
+	RemediationPlan   [][]string         `json:"remediationPlan"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -134,7 +134,7 @@ func (in *ClusterGroupUpgradeStatus) DeepCopyInto(out *ClusterGroupUpgradeStatus
 	}
 	if in.Policies != nil {
 		in, out := &in.Policies, &out.Policies
-		*out = make([]PolicyStatus, len(*in))
+		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
 	if in.Conditions != nil {
@@ -142,6 +142,17 @@ func (in *ClusterGroupUpgradeStatus) DeepCopyInto(out *ClusterGroupUpgradeStatus
 		*out = make([]v1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.RemediationPlan != nil {
+		in, out := &in.RemediationPlan, &out.RemediationPlan
+		*out = make([][]string, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = make([]string, len(*in))
+				copy(*out, *in)
+			}
 		}
 	}
 }

--- a/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
+++ b/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
@@ -174,19 +174,20 @@ spec:
                 type: array
               policies:
                 items:
-                  description: PolicyStatus defines the observed state of a Policy
-                  properties:
-                    complianceState:
-                      type: string
-                    name:
-                      type: string
-                  type: object
+                  type: string
+                type: array
+              remediationPlan:
+                items:
+                  items:
+                    type: string
+                  type: array
                 type: array
             required:
             - conditions
             - placementBindings
             - placementRules
             - policies
+            - remediationPlan
             type: object
         type: object
     served: true

--- a/samples/clustergroupupgrade1.yaml
+++ b/samples/clustergroupupgrade1.yaml
@@ -19,7 +19,7 @@ spec:
   platformUpgrade:
     channel: stable-4.8
     desiredUpdate:
-      version: 4.8.2
-      image: quay.io/openshift-release-dev/ocp-release:4.8.2-x86_64
+      version: 4.8.6
+      image: quay.io/openshift-release-dev/ocp-release:4.8.6-x86_64
       force: true
     upstream: https://amd64.ocp.releases.ci.openshift.org/graph

--- a/samples/clustergroupupgrade3.yaml
+++ b/samples/clustergroupupgrade3.yaml
@@ -19,8 +19,8 @@ spec:
   platformUpgrade:
     channel: stable-4.8
     desiredUpdate:
-      version: 4.8.2
-      image: quay.io/openshift-release-dev/ocp-release:4.8.2-x86_64
+      version: 4.8.5
+      image: quay.io/openshift-release-dev/ocp-release:4.8.5-x86_64
       force: true
     upstream: https://amd64.ocp.releases.ci.openshift.org/graph
   operatorUpgrades:


### PR DESCRIPTION
This removes superfluous update events and makes the reconcile
code easier to understand.