### PR TITLE
Add group upgrade timeout and canaries timeout logic

### DIFF
--- a/api/v1alpha1/clustergroupupgrade_types.go
+++ b/api/v1alpha1/clustergroupupgrade_types.go
@@ -28,6 +28,8 @@ type RemediationStrategySpec struct {
 	// Canaries defines the list of managed clusters that should be remediated first when remediateAction is set to enforce
 	Canaries       []string `json:"canaries,omitempty"`
 	MaxConcurrency int      `json:"maxConcurrency,omitempty"`
+	//+kubebuilder:default=240
+	Timeout int `json:"timeout,omitempty"`
 }
 
 // DesiredUpdateSpec models the desiredUpdate field of ClusterVersion

--- a/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
+++ b/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
@@ -91,6 +91,9 @@ spec:
                     type: array
                   maxConcurrency:
                     type: integer
+                  timeout:
+                    default: 240
+                    type: integer
                 type: object
             type: object
           status:


### PR DESCRIPTION
By default, the group upgrade as a whole will default to 4h but
it can be set with the new timeout field.
If canaries are used and that canaries batch takes too long, then
not move to next batch but move directly to upgrade timed out state.