### PR TITLE
Update ClusterGroupUpgrades CRD

### DIFF
--- a/api/v1alpha1/clustergroupupgrade_types.go
+++ b/api/v1alpha1/clustergroupupgrade_types.go
@@ -61,6 +61,9 @@ type ClusterGroupUpgradeSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 	Clusters            []string                 `json:"clusters,omitempty"`
 	RemediationStrategy *RemediationStrategySpec `json:"remediationStrategy,omitempty"`
+	ManagedPolicy       []string                 `json:"managedPolicy,omitempty"`
+	//+kubebuilder:default=false
+	Enable bool `json:"enable,omitempty"`
 	//+kubebuilder:validation:Enum=inform;enforce
 	//+kubebuilder:default=inform
 	RemediationAction         string                `json:"remediationAction,omitempty"`

--- a/api/v1alpha1/clustergroupupgrade_types.go
+++ b/api/v1alpha1/clustergroupupgrade_types.go
@@ -61,7 +61,7 @@ type ClusterGroupUpgradeSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 	Clusters            []string                 `json:"clusters,omitempty"`
 	RemediationStrategy *RemediationStrategySpec `json:"remediationStrategy,omitempty"`
-	ManagedPolicy       []string                 `json:"managedPolicy,omitempty"`
+	ManagedPolicies     []string                 `json:"managedPolicies,omitempty"`
 	//+kubebuilder:default=false
 	Enable bool `json:"enable,omitempty"`
 	//+kubebuilder:validation:Enum=inform;enforce

--- a/api/v1alpha1/clustergroupupgrade_types.go
+++ b/api/v1alpha1/clustergroupupgrade_types.go
@@ -59,17 +59,17 @@ type OperatorUpgradeSpec struct {
 type ClusterGroupUpgradeSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	Clusters            []string                 `json:"clusters,omitempty"`
-	RemediationStrategy *RemediationStrategySpec `json:"remediationStrategy,omitempty"`
-	ManagedPolicies     []string                 `json:"managedPolicies,omitempty"`
-	//+kubebuilder:default=false
-	Enable bool `json:"enable,omitempty"`
 	//+kubebuilder:validation:Enum=inform;enforce
 	//+kubebuilder:default=inform
-	RemediationAction         string                `json:"remediationAction,omitempty"`
-	PlatformUpgrade           *PlatformUpgradeSpec  `json:"platformUpgrade,omitempty"`
-	OperatorUpgrades          []OperatorUpgradeSpec `json:"operatorUpgrades,omitempty"`
-	DeleteObjectsOnCompletion bool                  `json:"deleteObjectsOnCompletion,omitempty"`
+	RemediationAction string `json:"remediationAction,omitempty"`
+	//+kubebuilder:default=false
+	Enable                    bool                     `json:"enable,omitempty"`
+	Clusters                  []string                 `json:"clusters,omitempty"`
+	RemediationStrategy       *RemediationStrategySpec `json:"remediationStrategy,omitempty"`
+	ManagedPolicies           []string                 `json:"managedPolicies,omitempty"`
+	PlatformUpgrade           *PlatformUpgradeSpec     `json:"platformUpgrade,omitempty"`
+	OperatorUpgrades          []OperatorUpgradeSpec    `json:"operatorUpgrades,omitempty"`
+	DeleteObjectsOnCompletion bool                     `json:"deleteObjectsOnCompletion,omitempty"`
 }
 
 // UpgradeStatus defines the observed state of the upgrade

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -97,8 +97,8 @@ func (in *ClusterGroupUpgradeSpec) DeepCopyInto(out *ClusterGroupUpgradeSpec) {
 		*out = new(RemediationStrategySpec)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.ManagedPolicy != nil {
-		in, out := &in.ManagedPolicy, &out.ManagedPolicy
+	if in.ManagedPolicies != nil {
+		in, out := &in.ManagedPolicies, &out.ManagedPolicies
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -97,6 +97,11 @@ func (in *ClusterGroupUpgradeSpec) DeepCopyInto(out *ClusterGroupUpgradeSpec) {
 		*out = new(RemediationStrategySpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ManagedPolicy != nil {
+		in, out := &in.ManagedPolicy, &out.ManagedPolicy
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.PlatformUpgrade != nil {
 		in, out := &in.PlatformUpgrade, &out.PlatformUpgrade
 		*out = new(PlatformUpgradeSpec)

--- a/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
+++ b/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
@@ -48,7 +48,7 @@ spec:
               enable:
                 default: false
                 type: boolean
-              managedPolicy:
+              managedPolicies:
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
+++ b/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
@@ -38,8 +38,6 @@ spec:
             description: ClusterGroupUpgradeSpec defines the desired state of ClusterGroupUpgrade
             properties:
               clusters:
-                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                  Important: Run "make" to regenerate code after modifying this file'
                 items:
                   type: string
                 type: array
@@ -87,6 +85,8 @@ spec:
                 type: object
               remediationAction:
                 default: inform
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "make" to regenerate code after modifying this file'
                 enum:
                 - inform
                 - enforce

--- a/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
+++ b/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
@@ -45,6 +45,13 @@ spec:
                 type: array
               deleteObjectsOnCompletion:
                 type: boolean
+              enable:
+                default: false
+                type: boolean
+              managedPolicy:
+                items:
+                  type: string
+                type: array
               operatorUpgrades:
                 items:
                   description: OperatorUpgradeSpec defines the configuration of an

--- a/deploy/upgrades/canaries/clustergroupupgrade.yaml
+++ b/deploy/upgrades/canaries/clustergroupupgrade.yaml
@@ -11,6 +11,10 @@ spec:
   - spoke4
   - spoke5
   - spoke6
+  managedPolicy:
+  - dummy-platform-policy
+  - dummy-ptp-sub-policy
+  enable: false
   remediationAction: inform
   remediationStrategy:
     canaries:

--- a/deploy/upgrades/canaries/clustergroupupgrade.yaml
+++ b/deploy/upgrades/canaries/clustergroupupgrade.yaml
@@ -11,7 +11,7 @@ spec:
   - spoke4
   - spoke5
   - spoke6
-  managedPolicy:
+  managedPolicies:
   - dummy-platform-policy
   - dummy-ptp-sub-policy
   enable: false

--- a/deploy/upgrades/parallel/clustergroupupgrade.yaml
+++ b/deploy/upgrades/parallel/clustergroupupgrade.yaml
@@ -11,6 +11,10 @@ spec:
   - spoke4
   - spoke5
   - spoke6
+  managedPolicy:
+  - dummy-platform-policy
+  - dummy-ptp-sub-policy
+  enable: false
   remediationAction: inform
   remediationStrategy:
     maxConcurrency: 6

--- a/deploy/upgrades/parallel/clustergroupupgrade.yaml
+++ b/deploy/upgrades/parallel/clustergroupupgrade.yaml
@@ -11,7 +11,7 @@ spec:
   - spoke4
   - spoke5
   - spoke6
-  managedPolicy:
+  managedPolicies:
   - dummy-platform-policy
   - dummy-ptp-sub-policy
   enable: false

--- a/deploy/upgrades/serial/clustergroupupgrade.yaml
+++ b/deploy/upgrades/serial/clustergroupupgrade.yaml
@@ -11,6 +11,10 @@ spec:
   - spoke4
   - spoke5
   - spoke6
+  managedPolicy:
+  - dummy-platform-policy
+  - dummy-ptp-sub-policy
+  enable: false
   remediationAction: inform
   remediationStrategy:
     maxConcurrency: 1

--- a/deploy/upgrades/serial/clustergroupupgrade.yaml
+++ b/deploy/upgrades/serial/clustergroupupgrade.yaml
@@ -11,7 +11,7 @@ spec:
   - spoke4
   - spoke5
   - spoke6
-  managedPolicy:
+  managedPolicies:
   - dummy-platform-policy
   - dummy-ptp-sub-policy
   enable: false


### PR DESCRIPTION
Description:
- Update ClusterGroupUpgrades CRD to include ManagedPolicy and Enable in the ClusterGroupUpgradeSpec
- Update existing tests with dummy entries for the new members of the CRD
- Note: Current CRD members haven't been removed. We'll cleanup the CRD members that we won't be using (like PlatformUpgrade and OperatorUpgrade) as we're removing the functionality from the operator.
- KUTTL tests have been run locally.