### PR TITLE
Use copied policies to decide if clusters are compliant or not

### DIFF
--- a/api/v1alpha1/clustergroupupgrade_types.go
+++ b/api/v1alpha1/clustergroupupgrade_types.go
@@ -100,6 +100,7 @@ type ClusterGroupUpgradeStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:path=clustergroupupgrades,shortName=cgu
 
 // ClusterGroupUpgrade is the Schema for the ClusterGroupUpgrades API
 type ClusterGroupUpgrade struct {

--- a/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
+++ b/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
@@ -13,6 +13,8 @@ spec:
     kind: ClusterGroupUpgrade
     listKind: ClusterGroupUpgradeList
     plural: clustergroupupgrades
+    shortNames:
+    - cgu
     singular: clustergroupupgrade
   scope: Namespaced
   versions:

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -2,6 +2,12 @@ package utils
 
 const (
 	RemediationActionEnforce = "enforce"
-	StatusNonCompliant       = "NonCompliant"
-	StatusCompliant          = "Compliant"
+	RemediationActionInform  = "inform"
+
+	StatusNonCompliant = "NonCompliant"
+	StatusCompliant    = "Compliant"
+
+	NoPolicyIndex = -1
+
+	WaitingTimeForPoliciesUpdatedStatusSeconds = 30
 )


### PR DESCRIPTION
Description:
- before setting enable to true, use the copied policies to decide which clusters need to be in the remediation plan
- once enable is set to true and the upgrade starts, add each cluster in the placement rule for each policy, one at a time, thus ensuring all clusters in the batch are compliant with all the policies
- if an upgrade timed out, use the copied policies to check if by any change the upgrade completed meanwhile