### PR TITLE
Add clusterSelector

### DIFF
--- a/api/v1alpha1/clustergroupupgrade_types.go
+++ b/api/v1alpha1/clustergroupupgrade_types.go
@@ -64,8 +64,19 @@ type ClusterGroupUpgradeSpec struct {
 	// placement rules and placement bindings are created, but clusters are not added to the placement rule.
 	// Once set to true, the clusters start being upgrades, one batch at a time.
 	//+kubebuilder:default=true
-	Enable                    bool                     `json:"enable,omitempty"`
-	Clusters                  []string                 `json:"clusters,omitempty"`
+	Enable   bool     `json:"enable,omitempty"`
+	Clusters []string `json:"clusters,omitempty"`
+	// This field holds a label common to multiple clusters that will be updated.
+	// The expected format is as follows:
+	// clusterSelector:
+	//   - label1Name=label1Value
+	//   - label2Name=label2Value
+	// If the value is empty, then the expected format is:
+	// clusterSelector:
+	//   - label1Name
+	// All the clusters matching the labels specified in clusterSelector will be included
+	// in the update plan.
+	ClusterSelector           []string                 `json:"clusterSelector,omitempty"`
 	RemediationStrategy       *RemediationStrategySpec `json:"remediationStrategy,omitempty"`
 	ManagedPolicies           []string                 `json:"managedPolicies,omitempty"`
 	DeleteObjectsOnCompletion bool                     `json:"deleteObjectsOnCompletion,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -92,6 +92,11 @@ func (in *ClusterGroupUpgradeSpec) DeepCopyInto(out *ClusterGroupUpgradeSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ClusterSelector != nil {
+		in, out := &in.ClusterSelector, &out.ClusterSelector
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.RemediationStrategy != nil {
 		in, out := &in.RemediationStrategy, &out.RemediationStrategy
 		*out = new(RemediationStrategySpec)

--- a/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
+++ b/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
@@ -37,6 +37,16 @@ spec:
           spec:
             description: ClusterGroupUpgradeSpec defines the desired state of ClusterGroupUpgrade
             properties:
+              clusterSelector:
+                description: 'This field holds a label common to multiple clusters
+                  that will be updated. The expected format is as follows: clusterSelector:   -
+                  label1Name=label1Value   - label2Name=label2Value If the value is
+                  empty, then the expected format is: clusterSelector:   - label1Name
+                  All the clusters matching the labels specified in clusterSelector
+                  will be included in the update plan.'
+                items:
+                  type: string
+                type: array
               clusters:
                 items:
                   type: string


### PR DESCRIPTION
Description:
- add new clusterSelector label to CRD
- adapt controller logic to get all the clusters matching the requested label(s) and include them when computing the remediation
  plan
- ensure a cluster doesn't end up more than once in the final list of clusters