### PR TITLE
Use inform policies

### DIFF
--- a/api/v1alpha1/clustergroupupgrade_types.go
+++ b/api/v1alpha1/clustergroupupgrade_types.go
@@ -111,6 +111,7 @@ type ClusterGroupUpgradeStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:path=clustergroupupgrades,shortName=cgu
 
 // ClusterGroupUpgrade is the Schema for the ClusterGroupUpgrades API
 type ClusterGroupUpgrade struct {

--- a/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
+++ b/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
@@ -13,6 +13,8 @@ spec:
     kind: ClusterGroupUpgrade
     listKind: ClusterGroupUpgradeList
     plural: clustergroupupgrades
+    shortNames:
+    - cgu
     singular: clustergroupupgrade
   scope: Namespaced
   versions:

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -2,6 +2,13 @@ package utils
 
 const (
 	RemediationActionEnforce = "enforce"
-	StatusNonCompliant       = "NonCompliant"
-	StatusCompliant          = "Compliant"
+	RemediationActionInform  = "inform"
+
+	StatusNonCompliant          = "NonCompliant"
+	StatusCompliant             = "Compliant"
+	ClusterNotMatchedWithPolicy = "NotMatchedWithPolicy"
+	StatusUnknown               = "StatusUnknown"
+
+	NoPolicyIndex        = -1
+	AllPoliciesValidated = -2
 )


### PR DESCRIPTION
Description:

- use the inform policies to decide both the clusters from the remediation plan and the next policy to enforce for a cluster
- when we are upgrading a cluster we start with the first policy for which the cluster is NonCompliant. Once the cluster is
  Compliant with a policy, we move to the next one for which the cluster is NonCompliant and so on until the batch is completed
- to decide of a cluster is Compliant or NonCompliant with an informed policy, we look for the cluster name in the policy's
  status.status. All the clusters present in the policy's placement rule should appear there, either as Compliant or as NonCompliant
- if an Upgrade timed out, check if the batch finished meanwhile. We are doing this by checking if the clusters in the batch
  (which should be the last batch for this check to even make sense) are Compliant or not matched with the remaining managed policies
- add short name for the CR: cgu