### PR TITLE
Find the namespaces for each managed policy

### DIFF
--- a/api/v1alpha1/clustergroupupgrade_types.go
+++ b/api/v1alpha1/clustergroupupgrade_types.go
@@ -103,9 +103,10 @@ type ClusterGroupUpgradeStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 	PlacementBindings []string           `json:"placementBindings,omitempty"`
 	PlacementRules    []string           `json:"placementRules,omitempty"`
-	Policies          []string           `json:"policies,omitempty"`
+	CopiedPolicies    []string           `json:"copiedPolicies,omitempty"`
 	Conditions        []metav1.Condition `json:"conditions,omitempty"`
 	RemediationPlan   [][]string         `json:"remediationPlan,omitempty"`
+	ManagedPoliciesNs map[string]string  `json:"managedPoliciesNs,omitempty"`
 	Status            UpgradeStatus      `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -132,8 +132,8 @@ func (in *ClusterGroupUpgradeStatus) DeepCopyInto(out *ClusterGroupUpgradeStatus
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.Policies != nil {
-		in, out := &in.Policies, &out.Policies
+	if in.CopiedPolicies != nil {
+		in, out := &in.CopiedPolicies, &out.CopiedPolicies
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
@@ -153,6 +153,13 @@ func (in *ClusterGroupUpgradeStatus) DeepCopyInto(out *ClusterGroupUpgradeStatus
 				*out = make([]string, len(*in))
 				copy(*out, *in)
 			}
+		}
+	}
+	if in.ManagedPoliciesNs != nil {
+		in, out := &in.ManagedPoliciesNs, &out.ManagedPoliciesNs
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 	in.Status.DeepCopyInto(&out.Status)

--- a/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
+++ b/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
@@ -155,6 +155,14 @@ spec:
                   - type
                   type: object
                 type: array
+              copiedPolicies:
+                items:
+                  type: string
+                type: array
+              managedPoliciesNs:
+                additionalProperties:
+                  type: string
+                type: object
               placementBindings:
                 description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
                   of cluster Important: Run "make" to regenerate code after modifying
@@ -163,10 +171,6 @@ spec:
                   type: string
                 type: array
               placementRules:
-                items:
-                  type: string
-                type: array
-              policies:
                 items:
                   type: string
                 type: array

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -99,7 +99,11 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 	} else if readyCondition.Status == metav1.ConditionFalse {
 		if readyCondition.Reason == "UpgradeNotStarted" || readyCondition.Reason == "UpgradeCannotStart" {
 			// Before starting the upgrade check that all the managed policies exist.
-			allManagedPoliciesExist, managedPoliciesMissing, managedPoliciesPresent := r.doManagedPoliciesExist(ctx, clusterGroupUpgrade)
+			allManagedPoliciesExist, managedPoliciesMissing, managedPoliciesPresent, err := r.doManagedPoliciesExist(ctx, clusterGroupUpgrade)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
 			if allManagedPoliciesExist == true {
 				// Create the needed resources for starting the upgrade.
 				err = r.reconcileResources(ctx, clusterGroupUpgrade, managedPoliciesPresent)
@@ -182,7 +186,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 				clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt = metav1.Time{}
 
 				// If we haven't reached the last batch yet, move to the next batch.
-				if clusterGroupUpgrade.Status.Status.CurrentBatch < len(clusterGroupUpgrade.Status.Policies) {
+				if clusterGroupUpgrade.Status.Status.CurrentBatch <= len(clusterGroupUpgrade.Status.RemediationPlan) {
 					clusterGroupUpgrade.Status.Status.CurrentBatch++
 				}
 			} else {
@@ -206,7 +210,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 						})
 					} else {
 						r.Log.Info("Batch upgrade timed out")
-						if clusterGroupUpgrade.Status.Status.CurrentBatch < len(clusterGroupUpgrade.Status.Policies) {
+						if clusterGroupUpgrade.Status.Status.CurrentBatch <= len(clusterGroupUpgrade.Status.RemediationPlan) {
 							clusterGroupUpgrade.Status.Status.CurrentBatch++
 						}
 					}
@@ -215,7 +219,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 
 			isUpgradeComplete := false
 			// If the batch is complete and it was the last batch in the remediationPlan, then the whole upgrade is complete.
-			if isBatchComplete == true && clusterGroupUpgrade.Status.Status.CurrentBatch == len(clusterGroupUpgrade.Status.Policies) {
+			if isBatchComplete == true && clusterGroupUpgrade.Status.Status.CurrentBatch == len(clusterGroupUpgrade.Status.RemediationPlan) {
 				isUpgradeComplete = true
 			}
 			if err != nil {
@@ -474,30 +478,87 @@ func (r *ClusterGroupUpgradeReconciler) getPolicyByName(ctx context.Context, pol
    returns: true/false                   if all the policies exist or not
             []string                     with the missing managed policy names
 			[]*unstructured.Unstructured a list of the managedPolicies present on the system
+			error
 */
-func (r *ClusterGroupUpgradeReconciler) doManagedPoliciesExist(ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) (bool, []string, []*unstructured.Unstructured) {
+func (r *ClusterGroupUpgradeReconciler) doManagedPoliciesExist(ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) (bool, []string, []*unstructured.Unstructured, error) {
+	var childPoliciesList []string
+	allClustersForUpgrade, err := r.getAllClustersForUpgrade(ctx, clusterGroupUpgrade)
+	if err != nil {
+		return false, nil, nil, err
+	}
+
+	// Make a list with all the child policies in the cluster's namespaces.
+	for _, clusterName := range allClustersForUpgrade {
+		listOpts := []client.ListOption{
+			client.InNamespace(clusterName),
+		}
+		policiesList := &unstructured.UnstructuredList{}
+		policiesList.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "policy.open-cluster-management.io",
+			Kind:    "PolicyList",
+			Version: "v1",
+		})
+		if err := r.List(ctx, policiesList, listOpts...); err != nil {
+			return false, nil, nil, err
+		}
+
+		for _, policy := range policiesList.Items {
+			labels := policy.GetLabels()
+			if labels == nil {
+				continue
+			}
+			// If we can find the child policy specific label, add the child policy name to the list.
+			if _, ok := labels[utils.ChildPolicyLabel]; ok {
+				childPoliciesList = append(childPoliciesList, policy.GetName())
+			}
+		}
+	}
+
+	r.Log.Info("[doManagedPoliciesExist]", "childPoliciesList", childPoliciesList)
+
+	// Go through all the child policies and split the namespace from the policy name.
+	// A child policy name has the name format parent_policy_namespace.parent_policy_name
+	// The policy map we are creating will be of format {"policy_name": "policy_namespace"}
+	policyMap := make(map[string]string)
+	for _, childPolicyName := range childPoliciesList {
+		policyNameArr := strings.SplitN(childPolicyName, ".", 2)
+		policyMap[policyNameArr[1]] = policyNameArr[0]
+	}
+	r.Log.Info("[doManagedPoliciesExist]", "policyMap", policyMap)
+
+	// Go through the managedPolicies in the CR, make sure they exist and save them to the upgrade's status together with
+	// their namespace.
 	var managedPoliciesMissing []string
 	var managedPoliciesPresent []*unstructured.Unstructured
+	clusterGroupUpgrade.Status.ManagedPoliciesNs = make(map[string]string)
+	for _, managedPolicyName := range clusterGroupUpgrade.Spec.ManagedPolicies {
+		if managedPolicyNamespace, ok := policyMap[managedPolicyName]; ok {
+			// Make sure the parent policy exists and nothing happened between querying the child policies above and now.
+			foundPolicy, err := r.getPolicyByName(ctx, managedPolicyName, managedPolicyNamespace)
 
-	// Go through the managedPolicies in the CR and make sure they exist.
-	for _, managedPolicy := range clusterGroupUpgrade.Spec.ManagedPolicies {
-		foundPolicy, err := r.getPolicyByName(ctx, managedPolicy, clusterGroupUpgrade.Namespace)
-
-		if err != nil {
-			if errors.IsNotFound(err) {
-				managedPoliciesMissing = append(managedPoliciesMissing, managedPolicy)
+			if err != nil {
+				// If the parent policy was not found, add its name to the list of missing policies.
+				if errors.IsNotFound(err) {
+					managedPoliciesMissing = append(managedPoliciesMissing, managedPolicyName)
+				} else {
+					// If another error happened, return it.
+					return false, nil, nil, err
+				}
 			}
-		} else {
+			// Add the policy to the list of present policies and update the status with the policy's namespace.
 			managedPoliciesPresent = append(managedPoliciesPresent, foundPolicy)
+			clusterGroupUpgrade.Status.ManagedPoliciesNs[managedPolicyName] = managedPolicyNamespace
+		} else {
+			managedPoliciesMissing = append(managedPoliciesMissing, managedPolicyName)
 		}
 	}
 
 	// If there are missing managed policies, return.
 	if len(managedPoliciesMissing) != 0 {
-		return false, managedPoliciesMissing, managedPoliciesPresent
+		return false, managedPoliciesMissing, managedPoliciesPresent, nil
 	}
 
-	return true, nil, managedPoliciesPresent
+	return true, nil, managedPoliciesPresent, nil
 }
 
 func (r *ClusterGroupUpgradeReconciler) copyManagedInformPolicy(
@@ -660,7 +721,8 @@ func (r *ClusterGroupUpgradeReconciler) getNextNonCompliantPolicyForCluster(
 	for {
 		// Get the name of the managed policy matching the current index.
 		currentManagedPolicyName := clusterGroupUpgrade.Spec.ManagedPolicies[currentPolicyIndex]
-		currentManagedPolicy, err := r.getPolicyByName(ctx, currentManagedPolicyName, clusterGroupUpgrade.Namespace)
+		currentManagedPolicyNamespace := clusterGroupUpgrade.Status.ManagedPoliciesNs[currentManagedPolicyName]
+		currentManagedPolicy, err := r.getPolicyByName(ctx, currentManagedPolicyName, currentManagedPolicyNamespace)
 		if err != nil {
 			return utils.NoPolicyIndex, err
 		}
@@ -697,7 +759,7 @@ func (r *ClusterGroupUpgradeReconciler) getNextNonCompliantPolicyForCluster(
 */
 func (r *ClusterGroupUpgradeReconciler) isUpgradeComplete(ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) (bool, error) {
 	// If we are not at the last batch, the upgrade clearly didn't complete.
-	if clusterGroupUpgrade.Status.Status.CurrentBatch < len(clusterGroupUpgrade.Status.Policies) {
+	if clusterGroupUpgrade.Status.Status.CurrentBatch < len(clusterGroupUpgrade.Status.CopiedPolicies) {
 		return false, nil
 	}
 
@@ -846,7 +908,7 @@ func (r *ClusterGroupUpgradeReconciler) getPlacementBindings(ctx context.Context
 	return placementBindingsList, nil
 }
 
-func (r *ClusterGroupUpgradeReconciler) getPolicies(ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) (*unstructured.UnstructuredList, error) {
+func (r *ClusterGroupUpgradeReconciler) getCopiedPolicies(ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) (*unstructured.UnstructuredList, error) {
 	var policyLabels = map[string]string{"openshift-cluster-group-upgrades/clusterGroupUpgrade": clusterGroupUpgrade.Name}
 	listOpts := []client.ListOption{
 		client.InNamespace(clusterGroupUpgrade.Namespace),
@@ -868,7 +930,7 @@ func (r *ClusterGroupUpgradeReconciler) getPolicies(ctx context.Context, cluster
 func (r *ClusterGroupUpgradeReconciler) getManagedPolicies(ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) ([]unstructured.Unstructured, error) {
 	var policies []unstructured.Unstructured
 	for _, policyName := range clusterGroupUpgrade.Spec.ManagedPolicies {
-		policy, err := r.getPolicyByName(ctx, policyName, clusterGroupUpgrade.Namespace)
+		policy, err := r.getPolicyByName(ctx, policyName, clusterGroupUpgrade.Status.ManagedPoliciesNs[policyName])
 		if err != nil {
 			return nil, err
 		}
@@ -1220,15 +1282,15 @@ func (r *ClusterGroupUpgradeReconciler) updateStatus(ctx context.Context, cluste
 		}
 		clusterGroupUpgrade.Status.PlacementBindings = placementBindingsStatus
 
-		policies, err := r.getPolicies(ctx, clusterGroupUpgrade)
+		copiedPolicies, err := r.getCopiedPolicies(ctx, clusterGroupUpgrade)
 		if err != nil {
 			return err
 		}
 		policiesStatus := make([]string, 0)
-		for _, policy := range policies.Items {
+		for _, policy := range copiedPolicies.Items {
 			policiesStatus = append(policiesStatus, policy.GetName())
 		}
-		clusterGroupUpgrade.Status.Policies = policiesStatus
+		clusterGroupUpgrade.Status.CopiedPolicies = policiesStatus
 
 		err = r.Status().Update(ctx, clusterGroupUpgrade)
 

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -11,4 +11,6 @@ const (
 
 	NoPolicyIndex        = -1
 	AllPoliciesValidated = -2
+
+	ChildPolicyLabel = "policy.open-cluster-management.io/root-policy"
 )


### PR DESCRIPTION
Description:
- in the Upgrade CR status keep all the managed policies with their namespaces which are probably different from the default namespace and from the namespace of the Upgrade CR
- in order to find the namespace for each managed policy, look for child policies in the namespaces that have the same name as the clusters from the Upgrade CR. Use the child policy name format to determine the namespace for each managed policy