### PR TITLE
Split dockerfile to enable CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,20 +19,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot as operator_image
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]
-
-FROM registry.access.redhat.com/ubi8-minimal:latest as precache_image
-RUN mkdir /opt/precache
-COPY pre-cache/release \
-     pre-cache/common \
-     pre-cache/olm \
-     pre-cache/parse_index.py \
-     pre-cache/pull \
-     pre-cache/precache.sh \
-     /opt/precache
-ENV PATH="/opt/precache:${PATH}"

--- a/Dockerfile.precache
+++ b/Dockerfile.precache
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/ubi8-minimal:latest
+RUN mkdir /opt/precache
+COPY pre-cache/release \
+     pre-cache/common \
+     pre-cache/olm \
+     pre-cache/parse_index.py \
+     pre-cache/pull \
+     pre-cache/precache.sh \
+     /opt/precache
+ENV PATH="/opt/precache:${PATH}"

--- a/Makefile
+++ b/Makefile
@@ -162,13 +162,13 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 docker-build: ## Build docker image with the manager.
-	docker build -t ${IMG} --target operator_image .
+	docker build -t ${IMG} -f Dockerfile .
 
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 
 docker-build-precache: ## Build pre-cache workload docker image.
-	docker build -t ${PRECACHE_IMG} --target precache_image .
+	docker build -t ${PRECACHE_IMG} -f Dockerfile.precache .
 
 docker-push-precache: ## push pre-cache workload docker image.
 	docker push ${PRECACHE_IMG}


### PR DESCRIPTION
Specifying a target is not supported on OpenShift Builds
that ci-operator is using to build images.
(https://docs.openshift.com/container-platform/4.9/rest_api/workloads_apis/build-build-openshift-io-v1.html)
/cc @browsell @irinamihai 