### PR TITLE
Bug 2037904: Remove pod limits from operator

### DIFF
--- a/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -185,9 +185,6 @@ spec:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                 resources:
-                  limits:
-                    cpu: 100m
-                    memory: 30Mi
                   requests:
                     cpu: 100m
                     memory: 20Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -46,9 +46,6 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
Operators should have only requests, not limits set. This patch fixes
the issue where the operator is killed by OOMKiller due to memory use
over the 30M specified limit.

Signed-off-by: Ian Miller <imiller@redhat.com>