### PR TITLE
Update precache image tag in csv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
+	hack/patch-precache-image.py config/manifests/pre-cache-image-patch.yaml $(PRECACHE_IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle
 

--- a/hack/patch-precache-image.py
+++ b/hack/patch-precache-image.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python3
+import yaml
+import sys
+
+file = sys.argv[1]
+pull = sys.argv[2]
+with open(file,'r') as f:
+    obj = yaml.safe_load(f)
+for item in obj.get('spec',{}).get('relatedImages',{}):
+    if item.get('name','') == "pre-caching-workload":
+        item['image'] = pull
+    break
+with open(file,'w') as f:
+    yaml.dump(obj, f)


### PR DESCRIPTION
Automatically patch pre-cache image tag in csv
to the operator version.

Signed-off-by: Vitaly Grinberg <vgrinber@redhat.com>
/cc @imiller0 @nishant-parekh @irinamihai 