### PR TITLE
Remove k8s.io/apiextensions-apiserver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/open-cluster-management/governance-policy-propagator v0.0.0-20211209191640-b399eb8a0bf2
 	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.21.3
-	k8s.io/apiextensions-apiserver v0.21.3 // indirect
 	k8s.io/apimachinery v0.21.3
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v1.0.0


### PR DESCRIPTION
This commit removes k8s.io/apiextensions-apiserver from go mod as not
needed anymore.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>