### PR TITLE
Add Daniel Mellado to OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,6 +10,7 @@ aliases:
     - nishant-parekh
     - serngawy
     - vitus133
+    - danielmellado
   upgrades-operator-approvers:
     - browsell
     - rcarrillocruz
@@ -18,3 +19,4 @@ aliases:
     - nishant-parekh
     - serngawy
     - vitus133
+    - danielmellado


### PR DESCRIPTION
This commit adds Daniel Mellado to OWNERS_ALIASES.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>