### PR TITLE
Add universal index processing

### DIFF
--- a/pre-cache/olm
+++ b/pre-cache/olm
@@ -4,18 +4,18 @@ cwd="${cwd:-/opt/precache}"
 . $cwd/common
 
 podman_pull_path="${podman_pull_path:-/run/containers/0}"
-index_download_path="${index_download_path:-/cache/downloaded}"
+rendered_index_path="${rendered_index_path:-/tmp/index.json}"
 
 
 extract_pull_spec(){
-    index_download_path=$1
+    rendered_index=$1
     operators_spec_file=$2
     pull_spec_file=$3
-    /host/usr/libexec/platform-python /opt/precache/parse_index.py "${index_download_path}" "${operators_spec_file}" "${pull_spec_file}"
+    /host/usr/libexec/platform-python /opt/precache/parse_index.py "${rendered_index}" "${operators_spec_file}" "${pull_spec_file}"
     return $?
 }
 
-export_index(){
+render_index(){
     index=$1
     pull_secret_path=$2
     packages=$3
@@ -35,10 +35,12 @@ export_index(){
     else
         opm_bin=$image_mount/bin/opm
     fi
-    $opm_bin index export -i $index -p $packages -c podman -f $index_download_path
+
+    $opm_bin render $index > $rendered_index_path
     if [[ $? -ne 0 ]]; then
         return 1
     fi
+
 }
 
 extract_packages(){
@@ -53,7 +55,6 @@ extract_packages(){
 }
 
 olm_main(){
-    declare -i ret_val=0
     if ! [[ -n $(sort -u $config_volume_path/operators.indexes) ]]; then
       log_debug "Operators index is not specified. Operators won't be pre-cached"
       return 0
@@ -62,37 +63,36 @@ olm_main(){
     for index in $(sort -u $config_volume_path/operators.indexes) ; do
 
         image_id=$(pull_index $index $pull_secret_path)
-        rv=$? && ret_val=ret_val+$rv
-        [[ $rv -eq 0 ]] || continue
+        if [[ $? -ne 0 ]]; then
+          log_debug "pull_index failed for index $index"
+          return 1
+        fi
         log_debug "$index image ID is $image_id"
         image_mount=$(mount_index $image_id)
-        rv=$? && ret_val=ret_val+$rv
-        [[ $rv -eq 0 ]] || continue
+        if [[ $? -ne 0 ]]; then
+          log_debug "mount_index failed for index $index"
+          return 1
+        fi
         log_debug "Image mount: $image_mount"
-        
         packages=$(extract_packages)
         if ! [[ -n $packages ]]; then
-          log_debug "Operators index is set, but no packages provided - inconsistent configuration"
+          log_debug "operators index is set, but no packages provided - inconsistent configuration"
           return 1
         fi
-        export_index $index $pull_secret_path $packages $image_mount
+        render_index $index $pull_secret_path $packages $image_mount
         if [[ $? -ne 0 ]]; then
-          log_debug "export_index failed: OLM index export failed for index $index, package(s) $packages"
+          log_debug "render_index failed: OLM index render failed for index $index, package(s) $packages"
           return 1
         fi
-
         operators_spec_file="$config_volume_path/operators.packagesAndChannels"
-        extract_pull_spec $index_download_path $operators_spec_file $pull_spec_file
+        extract_pull_spec $rendered_index_path $operators_spec_file $pull_spec_file
         if [[ $? -ne 0 ]]; then
           log_debug "extract_pull_spec failed"
           return 1
         fi
         unmount_index $image_id
     done
-    if [[ $ret_val -ne 0 ]]; then
-        log_debug "Some of the OLM index extractions failed."
-    fi
-    return $ret_val
+    return 0
 }
 
 if [[ "${BASH_SOURCE[0]}" = "${0}" ]]; then

--- a/pre-cache/parse_index.py
+++ b/pre-cache/parse_index.py
@@ -1,16 +1,15 @@
 import sys
-import os
-import yaml
+import json
 import argparse
 import traceback
-from difflib import SequenceMatcher
-
 
 def parse_args():
+    """ Parse the command line arguments """
     parser = argparse.ArgumentParser(
         description='Extract list of related images from operator index.')
-    parser.add_argument('index_download_path', nargs='?',
-                        help="Path where opm index is exportrd")
+    parser.add_argument('rendered_index', nargs='?',
+                        type=argparse.FileType('r'),
+                        help="Path where opm index is exported")
     parser.add_argument('operators_spec_file', nargs='?',
                         type=argparse.FileType('r'),
                         help="Path to the list of packages file, \
@@ -27,59 +26,76 @@ def parse_args():
     return args
 
 
-def extract_bundle_names(args):
-    bundles = []
+def extract_images(args, objects):
+    """ Extract related images from the rendered index
+    
+    Input parameters:
+    args: command line arguments, contain operators_spec_file.name
+    objects: a list of parsed index objects that comply to OLM schema
+
+    Processing:
+    1. Create a structure of packages and channels from the pre-caching
+        spec (mounted in the container as args.operators_spec_file.name)
+    2. Create a list of bundles for the given packages by taking the latest
+        bundle in the channel
+    3. For the selected bundles, extract the related images and return them
+        as a list
+
+    Returns: list of image pull specifications
+    """
+    bundles, packages, images = [], [], []
+    channels = {}
+    # 1. Form the operators packages and channels structure
     with open(args.operators_spec_file.name, 'r') as p:
+        # "records" is a list of list: [package, channel] items
         records = [i.split(":") for i in p.read().splitlines() if len(i) > 0]
+    
     for item in records:
-        pkg_name = item[0].strip()
-        path = os.path.join(args.index_download_path, pkg_name, 'package.yaml')
-        with open(path, 'r') as f:
-            package = yaml.safe_load(f)
-            csv_name = [p.get("currentCSV") for p in
-                        package.get("channels")
-                        if p.get("name") ==
-                        item[1].strip()][0].strip(f"{pkg_name}.")
-        with os.scandir(os.path.join(args.index_download_path, pkg_name)) as it:
-            bundle_dirs = [entry.name for entry in it if entry.is_dir()]
-        bundle_dir = sorted(
-            bundle_dirs, key=lambda dir_name: SequenceMatcher(
-                None, csv_name, dir_name).ratio())[-1]
-        bundles.append(os.path.join(
-            args.index_download_path, pkg_name, bundle_dir))
-    return bundles
+        if len(item) != 2:
+            print(f"operators record {item} is malformed, skipping...")
+            continue
+        package, channel = [i.strip() for i in item]
+        channels[package] = channel
+        packages.append(package)
+        print(f"will process package {package} channel {channel}")
+    # 2. Find the right channels for our packages and get the latest bundle
+    for item in objects:
+        if item.get("schema") == "olm.channel":
+            if item.get("package") in packages and item.get("name") == channels[item.get("package")]:
+                latest = item.get("entries")[-1].get("name")
+                bundles.append(latest)
+    # 3. extract related images from our bundles
+    for item in objects:
+        if item.get("schema") == "olm.bundle":
+            if item.get("name") in bundles and item.get("package") in packages:
+                images.extend([elem.get("image") for elem in item.get("relatedImages")])
+    return images
 
 
-def extract_images(bundles):
-    images = []
-    try:
-        for path in bundles:
-            with os.scandir(path) as it:
-                csv_file = [entry for entry in it if entry.name.endswith(
-                    '.clusterserviceversion.yaml')][-1]
-            with open(csv_file.path, 'r') as f:
-                csv = yaml.safe_load(f)
-            images.extend([im.get('image') for im in csv.get(
-                'spec').get('relatedImages')])
-    except Exception as e:
-        print(e, csv_file)
-        traceback.print_exc(file=sys.stdout)
-        raise Exception("Failed to extract related images", e)
-    finally:
-        return images
+def load_rendered_index():
+    with open(args.rendered_index.name, args.rendered_index.mode) as f:
+        data = f.read().lstrip()
+    # Rendered index is not a valid json, but a list
+    # of concatenated json blocks. Hence the raw decoder and the loop
+    decoder = json.JSONDecoder()
+    objects = []
+    while data:
+        obj, index = decoder.raw_decode(data)
+        objects.append(obj)
+        data = data[index:].lstrip()
+    return objects
 
 
 if __name__ == "__main__":
     try:
         args = parse_args()
-
-        bundles = extract_bundle_names(args)
-        images = extract_images(bundles)
+        data = load_rendered_index()
+        images = extract_images(args, data)
         with open(args.img_list_file.name, args.img_list_file.mode) as f:
             f.write('\n'.join(images))
             f.write('\n')
-        exit(0)
+        sys.exit(0)
     except Exception as e:
         print(e)
         traceback.print_exc(file=sys.stdout)
-        exit(1)
+        sys.exit(1)


### PR DESCRIPTION
OLM catalogs are switching from sqlite-based to file-system based
index format (also referenced as FBC). The enhancement is described in
https://github.com/operator-framework/enhancements/blob/master/enhancements/declarative-index-config.md
Additional information is available here:
https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/512
The switch of default Red Hat catalogs to FBC is expected to occur in Openshift 4.11.
This commit changes the way catalog processing is
done by pre-caching workload to extract 
packages-bundles-channels relations from the
index image. It is switching to a new opm command
(`opm render`), that works for both sqlite-based catalogs and FBC. The command is supported
by opm included in catalogs starting from 4.9 onwards

/cc @browsell @irinamihai @imiller0 @rcarrillocruz @danielmellado 