### PR TITLE
Fix policy content parsing

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -909,15 +909,16 @@ func (r *ClusterGroupUpgradeReconciler) getPolicyContent(
 			objectDefinitionMetadataContent := innerObjectDefinitionContent["metadata"].(map[string]interface{})
 			// Save the kind, name and namespace if they exist and if kind is of Subscription type.
 			// If kind is missing, log and skip.
-			_, ok := innerObjectDefinitionContent["kind"]
+			kind, ok := innerObjectDefinitionContent["kind"]
 			if ok == false {
 				r.Log.Info(
 					"[getPolicyContent] Policy is missing its spec.policy-templates.objectDefinition.spec.object-templates.kind",
 					"policyName", managedPolicyName)
 				continue
 			}
+
 			// Filter only Subscription templates.
-			if innerObjectDefinitionContent["kind"] != utils.PolicyTypeSubscription {
+			if kind != utils.PolicyTypeSubscription {
 				r.Log.Info(
 					"[getPolicyContent] Policy spec.policy-templates.objectDefinition.spec.object-templates.kind is not of Subscription kind",
 					"policyName", managedPolicyName)


### PR DESCRIPTION
Description:
- handle the case where the policy template content is missing  metadata fields: if either kind, metadata.name or   metadata.namespace is missing, log the info and move to the next content template
- filter only the Subscription type templates