### PR TITLE
Bug 2056375: Allow clusterserviceversion access

### DIFF
--- a/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -101,6 +101,14 @@ spec:
           verbs:
           - update
         - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - policy.open-cluster-management.io
           resources:
           - placementbindings

--- a/bundle/manifests/ran.openshift.io_clustergroupupgrades.yaml
+++ b/bundle/manifests/ran.openshift.io_clustergroupupgrades.yaml
@@ -119,7 +119,7 @@ spec:
                 description: This field determines when the upgrade starts. While
                   false, the upgrade doesn't start. The policies, placement rules
                   and placement bindings are created, but clusters are not added to
-                  the placement rule. Once set to true, the clusters start being upgrades,
+                  the placement rule. Once set to true, the clusters start being upgraded,
                   one batch at a time.
                 type: boolean
               managedPolicies:
@@ -147,11 +147,17 @@ spec:
                   timeout:
                     default: 240
                     type: integer
+                required:
+                - maxConcurrency
                 type: object
+            required:
+            - remediationStrategy
             type: object
           status:
             description: ClusterGroupUpgradeStatus defines the observed state of ClusterGroupUpgrade
             properties:
+              computedMaxConcurrency:
+                type: integer
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
@@ -225,10 +231,27 @@ spec:
                 items:
                   type: string
                 type: array
+              managedPoliciesCompliantBeforeUpgrade:
+                items:
+                  type: string
+                type: array
               managedPoliciesContent:
                 additionalProperties:
                   type: string
                 type: object
+              managedPoliciesForUpgrade:
+                description: Contains the managed policies (and the namespaces) that
+                  have NonCompliant clusters that require updating.
+                items:
+                  description: ManagedPolicyForUpgrade defines the observed state
+                    of a Policy
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+                type: array
               managedPoliciesNs:
                 additionalProperties:
                   type: string

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -67,6 +67,14 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - operators.coreos.com
+  resources:
+  - clusterserviceversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - policy.open-cluster-management.io
   resources:
   - placementbindings

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -62,6 +62,7 @@ type ClusterGroupUpgradeReconciler struct {
 //+kubebuilder:rbac:groups=action.open-cluster-management.io,resources=managedclusteractions,verbs=create;update;delete;get;list;watch;patch
 //+kubebuilder:rbac:groups=view.open-cluster-management.io,resources=managedclusterviews,verbs=create;update;delete;get;list;watch;patch
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+//+kubebuilder:rbac:groups=operators.coreos.com,resources=clusterserviceversions,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
Add "clusterserviceversions.operators.coreos.com" read access.
This is required for getting the precaching workload image
pull spec

Signed-off-by: Vitaly Grinberg <vgrinber@redhat.com>