### PR TITLE
Add cleanup finalizer for ClusterGroupUpgrade CRs

### DIFF
--- a/controllers/actions.go
+++ b/controllers/actions.go
@@ -156,7 +156,12 @@ func (r *ClusterGroupUpgradeReconciler) deleteResources(
 	if err != nil {
 		return fmt.Errorf("Failed to delete Policies for CGU %s: %v", clusterGroupUpgrade.Name, err)
 	}
-	err = utils.DeleteMultiCloudObjects(ctx, r.Client, clusterGroupUpgrade)
+
+	clusters, err := r.getAllClustersForUpgrade(ctx, clusterGroupUpgrade)
+	if err != nil {
+		return fmt.Errorf("Cannot obtain all the details about the clusters in the CR: %s", err)
+	}
+	err = utils.DeleteMultiCloudObjects(ctx, r.Client, clusterGroupUpgrade, clusters)
 	if err != nil {
 		return fmt.Errorf("Failed to delete MultiCloud objects for CGU %s: %v", clusterGroupUpgrade.Name, err)
 	}

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -79,3 +79,15 @@ const (
 const (
 	MaxNumberOfClustersForUpgrade = 100
 )
+
+// Reconciling instructions.
+const (
+	ReconcileNow    = 0
+	StopReconciling = 1
+	DontReconcile   = 2
+)
+
+// Finalizers
+const (
+	CleanupFinalizer = "ran.openshift.io/cleanup-finalizer"
+)


### PR DESCRIPTION
Description:
- Bug 2054421
- add cleanup finalizer for ClusterGroupUpgrade CRs so that managedClusterViews created in different namespaces than the CGU are deleted when the CGU is deleted.
- upon reconciling, check if CGU is marked for deletion and if so, look at the cleanup finalizer. If the cleanup finalizer is still
  present, do the needed cleanup and remove the finalizer.
- if the cleanup finalizer doesn't exist, add it