### PR TITLE
BZ #2055309 - Include PKI folder when precaching against untrusted registries

### DIFF
--- a/pre-cache/copy-env.sh
+++ b/pre-cache/copy-env.sh
@@ -19,4 +19,5 @@ done
 # Copy containers policy and cacert of disconnected registries if present
 cp /host/etc/containers/policy.json /etc/containers/policy.json
 cp -a /host/etc/docker /etc/ || true
-
+cp -a /host/etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/source/ && update-ca-trust || true
+cp -a /host/etc/pki/ca-trust/extracted/pem /etc/pki/ca-trust/extracted/ || true

--- a/pre-cache/olm
+++ b/pre-cache/olm
@@ -24,7 +24,7 @@ export_index(){
     # copy pull secret to the default runtime dir - opm doesn't accept authfile as an arg
     [ ! -d "$podman_pull_path" ] && mkdir -p "$podman_pull_path"
     cp $pull_secret_path "$podman_pull_path/auth.json"
-    capath="/etc/docker/certs.d/${index%/*}/ca.crt"
+    capath="/host/etc/docker/certs.d/${index%/*}/ca.crt"
     # opm doesn't accept cacert as an arg
     if [[ -f "$capath" ]]; then
         cp $capath /etc/pki/ca-trust/source/anchors/ 


### PR DESCRIPTION
This PR tries to fix the problem I found when running precache task against an untrusted registry. My environment is disconnected so the registry and so the upgrade graph.

```
oc adm upgrade
Upstream: http://graph.apps.cnf20.cloud.lab.eng.bos.redhat.com/api/upgrades_info/v1/graph
```

When creating a CGU that enables precaching the precache job does not have the K8S node certificates available. I believe that the precache task contacts the untrusted registry before chrooting.

```
$ oc logs -f pre-cache--1-plmqp
Error: Error initializing source docker://fx2-1a.cloud.lab.eng.bos.redhat.com:8443/test/release@sha256:fd96300600f9585e5847f5855ca14e2b3cafbce12aefe3b3f52c5da10c4476eb: error pinging docker registry fx2-1a.cloud.lab.eng.bos.redhat.com:8443: Get "https://fx2-1a.cloud.lab.eng.bos.redhat.com:8443/v2/": x509: certificate signed by unknown authority`
```

Basically, I just mount the directory where the K8S node has the untrusted registry certificates into the precache container image using a hostPath since a hostPath mounting /host is already configured. Once done, the precache works as expected


Signed-off-by: Alberto Losada <alosadag@redhat.com>