### PR TITLE
Update Makefile to support PATH containing spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,9 @@ endif
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
-PATH  := $(PATH):$(PWD)/bin
+export PATH  := $(PATH):$(PWD)/bin
 GOFLAGS := -mod=mod
-SHELL = /usr/bin/env PATH=$(PATH) GOFLAGS=$(GOFLAGS) bash -o pipefail
+SHELL = /usr/bin/env GOFLAGS=$(GOFLAGS) bash -o pipefail
 
 .SHELLFLAGS = -ec
 


### PR DESCRIPTION
Prior to this update, the PATH variable is being modified and passed
on the SHELL command line. In an environment with spaces in the PATH,
such as WSL2, this causes the SHELL to be interpreted incorrectly and
causes all make commands to fail.

This update exports the modified PATH to make it available in the
environment, rather than passing it on the SHELL command line.

Signed-off-by: Don Penney <dpenney@redhat.com>