### PR TITLE
Add golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,95 @@
+---
+run:
+  concurrency: 6
+  deadline: 5m
+  skip-files:
+    - ".*_test\\.go"
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - depguard
+    - goconst
+    - gocritic
+    - revive
+    - gofmt
+    - goimports
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - varcheck
+    - gocyclo
+linters-settings:
+  revive:
+    rules:
+      - name: if-return
+        severity: warning
+        disabled: true
+  gocritic:
+    enabled-checks:
+      # Diagnostic
+      - argOrder
+      - badCond
+      - caseOrder
+      - codegenComment
+      - commentedOutCode
+      - deprecatedComment
+      - dupArg
+      - dupBranchBody
+      - dupCase
+      - dupSubExpr
+      - exitAfterDefer
+      - flagDeref
+      - flagName
+      - nilValReturn
+      - offBy1
+      - weakCond
+      - octalLiteral
+      - sloppyReassign
+
+      # Performance
+      - equalFold
+      - indexAlloc
+      - rangeExprCopy
+      - appendCombine
+
+      # Style
+      - assignOp
+      - boolExprSimplify
+      - captLocal
+      - commentFormatting
+      - commentedOutImport
+      - defaultCaseOrder
+      - docStub
+      - elseif
+      - emptyFallthrough
+      - emptyStringTest
+      - hexLiteral
+      - methodExprCall
+      - regexpMust
+      - singleCaseSwitch
+      - sloppyLen
+      - stringXbytes
+      - switchTrue
+      - typeAssertChain
+      - typeSwitchVar
+      - underef
+      - unlabelStmt
+      - unlambda
+      - unslice
+      - valSwap
+      - yodaStyleExpr
+      - wrapperFunc
+
+      # Opinionated
+      - initClause
+      - nestingReduce
+      - ptrToRefParam
+      - typeUnparen
+      - unnecessaryBlock
+      - paramTypeCombine

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,11 @@ fmt: ## Run go fmt against code.
 	@echo "Running go fmt"
 	go fmt ./...
 
+.PHONY: golangci-lint
+golangci-lint: ## Run golangci-lint against code.
+	@echo "Running golangci-lint"
+	hack/golangci-lint.sh
+
 .PHONY: vet
 vet: ## Run go vet against code.
 	@echo "Running go vet"
@@ -136,7 +141,7 @@ common-deps-update:	controller-gen kustomize
 	go mod tidy
 
 .PHONY: ci-job
-ci-job: common-deps-update fmt vet lint unittests
+ci-job: common-deps-update fmt vet lint golangci-lint unittests
 
 .PHONY: shellcheck
 shellcheck: ## Run shellcheck

--- a/controllers/actions.go
+++ b/controllers/actions.go
@@ -82,10 +82,10 @@ func (r *ClusterGroupUpgradeReconciler) manageClusterLabels(
 			return err
 		}
 		if err := r.addClusterLabels(ctx, managedCluster, labels["add"]); err != nil {
-			return fmt.Errorf("Fail to add labels for cluster %s: %v", managedCluster.Name, err)
+			return fmt.Errorf("fail to add labels for cluster %s: %v", managedCluster.Name, err)
 		}
 		if err := r.deleteClusterLabels(ctx, managedCluster, labels["delete"]); err != nil {
-			return fmt.Errorf("Fail to delete labels for cluster %s: %v", managedCluster.Name, err)
+			return fmt.Errorf("fail to delete labels for cluster %s: %v", managedCluster.Name, err)
 		}
 	}
 	return nil
@@ -108,6 +108,7 @@ func (r *ClusterGroupUpgradeReconciler) addClusterLabels(
 	}
 	cluster.SetLabels(currentLabels)
 
+	//nolint:revive
 	if err := r.Update(ctx, cluster); err != nil {
 		return err
 	}
@@ -134,6 +135,7 @@ func (r *ClusterGroupUpgradeReconciler) deleteClusterLabels(
 	}
 	cluster.SetLabels(currentLabels)
 
+	//nolint:revive
 	if err := r.Update(ctx, cluster); err != nil {
 		return err
 	}
@@ -146,24 +148,24 @@ func (r *ClusterGroupUpgradeReconciler) deleteResources(
 	labels := map[string]string{"openshift-cluster-group-upgrades/clusterGroupUpgrade": clusterGroupUpgrade.Name}
 	err := utils.DeletePlacementRules(ctx, r.Client, clusterGroupUpgrade.Namespace, labels)
 	if err != nil {
-		return fmt.Errorf("Failed to delete PlacementRules for CGU %s: %v", clusterGroupUpgrade.Name, err)
+		return fmt.Errorf("failed to delete PlacementRules for CGU %s: %v", clusterGroupUpgrade.Name, err)
 	}
 	err = utils.DeletePlacementBindings(ctx, r.Client, clusterGroupUpgrade.Namespace, labels)
 	if err != nil {
-		return fmt.Errorf("Failed to delete PlacementBindings for CGU %s: %v", clusterGroupUpgrade.Name, err)
+		return fmt.Errorf("failed to delete PlacementBindings for CGU %s: %v", clusterGroupUpgrade.Name, err)
 	}
 	err = utils.DeletePolicies(ctx, r.Client, clusterGroupUpgrade.Namespace, labels)
 	if err != nil {
-		return fmt.Errorf("Failed to delete Policies for CGU %s: %v", clusterGroupUpgrade.Name, err)
+		return fmt.Errorf("failed to delete Policies for CGU %s: %v", clusterGroupUpgrade.Name, err)
 	}
 
 	clusters, err := r.getAllClustersForUpgrade(ctx, clusterGroupUpgrade)
 	if err != nil {
-		return fmt.Errorf("Cannot obtain all the details about the clusters in the CR: %s", err)
+		return fmt.Errorf("cannot obtain all the details about the clusters in the CR: %s", err)
 	}
 	err = utils.DeleteMultiCloudObjects(ctx, r.Client, clusterGroupUpgrade, clusters)
 	if err != nil {
-		return fmt.Errorf("Failed to delete MultiCloud objects for CGU %s: %v", clusterGroupUpgrade.Name, err)
+		return fmt.Errorf("failed to delete MultiCloud objects for CGU %s: %v", clusterGroupUpgrade.Name, err)
 	}
 
 	return nil

--- a/controllers/managedclusterForCGU_controller.go
+++ b/controllers/managedclusterForCGU_controller.go
@@ -65,7 +65,7 @@ type ManagedClusterForCguReconciler struct {
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile the managed cluster auto create ClusterGroupUpgrade
-// - Controller watches for create event of managed cluster object. Reconcilation
+// - Controller watches for create event of managed cluster object. Reconciliation
 //   is triggered when a new managed cluster is created
 // - When a new managed cluster is created, create ClusterGroupUpgrade CR for the
 //   cluster only when it's ready and its child policies are available
@@ -130,7 +130,7 @@ func (r *ManagedClusterForCguReconciler) Reconcile(ctx context.Context, req ctrl
 		}
 
 		// create clusterGroupUpgrade
-		if err = r.newClusterGroupUpgrade(ctx, managedCluster, policies); err != nil {
+		if err := r.newClusterGroupUpgrade(ctx, managedCluster, policies); err != nil {
 			return ctrl.Result{}, err
 		}
 	} else {

--- a/controllers/precache.go
+++ b/controllers/precache.go
@@ -330,6 +330,7 @@ func (r *ClusterGroupUpgradeReconciler) getImageForVersionFromUpdateGraph(
 //      - CatalogSource: must be explicitly configured to be precached.
 //        All the clusters in the CGU must have same catalog source(s)
 // returns: precachingSpec, error
+// nolint:unparam
 func (r *ClusterGroupUpgradeReconciler) extractPrecachingSpecFromPolicies(
 	ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade,
 	policies []*unstructured.Unstructured) (ranv1alpha1.PrecachingSpec, error) {
@@ -597,6 +598,7 @@ func (r *ClusterGroupUpgradeReconciler) getPrecacheJobTemplateData(
 // getPrecacheSpecTemplateData: Converts precaching payload spec to template data
 // returns: templateData (softwareSpec)
 //          error
+//nolint:unparam
 func (r *ClusterGroupUpgradeReconciler) getPrecacheSpecTemplateData(
 	ctx context.Context,
 	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) *templateData {

--- a/controllers/precacheFsm.go
+++ b/controllers/precacheFsm.go
@@ -172,6 +172,7 @@ func (r *ClusterGroupUpgradeReconciler) precachingFsm(ctx context.Context,
 
 // handleNotStarted handles conditions in PrecacheStateNotStarted
 // returns: error
+//nolint:unparam
 func (r *ClusterGroupUpgradeReconciler) handleNotStarted(ctx context.Context,
 	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade,
 	cluster string) (string, error) {
@@ -200,11 +201,14 @@ func (r *ClusterGroupUpgradeReconciler) handleNotStarted(ctx context.Context,
 
 // handlePreparing handles conditions in PrecacheStatePreparingToStart
 // returns: error
+//nolint:unparam
 func (r *ClusterGroupUpgradeReconciler) handlePreparing(ctx context.Context,
 	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade,
 	cluster string) (string, error) {
 
+	//nolint:ineffassign
 	currentState, nextState := PrecacheStatePreparingToStart, PrecacheStatePreparingToStart
+	//nolint:ineffassign
 	var condition string
 	condition, err := r.getPreparingConditions(ctx, cluster)
 	if err != nil {

--- a/controllers/templates/backup-templates.go
+++ b/controllers/templates/backup-templates.go
@@ -2,7 +2,7 @@ package templates
 
 // Templates for backup job lifecycle
 
-//MngClusterActCreateBackupNS creates namespace
+// MngClusterActCreateBackupNS creates namespace
 const MngClusterActCreateBackupNS string = `
 {{ template "actionGVK"}}
 {{ template "metadata" . }}
@@ -17,7 +17,7 @@ spec:
         name: backup-agent
 `
 
-//MngClusterActCreateSA creates serviceaccount
+// MngClusterActCreateSA creates serviceaccount
 const MngClusterActCreateSA string = `
 {{ template "actionGVK"}}
 {{ template "metadata" . }}
@@ -33,7 +33,7 @@ spec:
         namespace: openshift-talo-backup
 `
 
-//MngClusterActCreateRB creates clusterrolebinding
+// MngClusterActCreateRB creates clusterrolebinding
 const MngClusterActCreateRB string = `
 {{ template "actionGVK"}}
 {{ template "metadata" . }}
@@ -56,7 +56,7 @@ spec:
           namespace: openshift-talo-backup
 `
 
-//MngClusterActCreateBackupJob creates k8s job
+// MngClusterActCreateBackupJob creates k8s job
 const MngClusterActCreateBackupJob string = `
 {{ template "actionGVK"}}
 {{ template "metadata" . }}
@@ -102,7 +102,7 @@ spec:
                 name: backup
 `
 
-//MngClusterActDeleteNS deletes namespace
+// MngClusterActDeleteNS deletes namespace
 const MngClusterActDeleteNS string = `
 {{ template "actionGVK"}}
 {{ template "metadata" . }}
@@ -113,7 +113,7 @@ spec:
     resource: namespace
 `
 
-//MngClusterViewBackupJob creates mcv to monitor k8s job
+// MngClusterViewBackupJob creates mcv to monitor k8s job
 const MngClusterViewBackupJob string = `
 {{ template "viewGVK"}}
 {{ template "metadata" . }}

--- a/controllers/templates/precache-templates.go
+++ b/controllers/templates/precache-templates.go
@@ -2,7 +2,7 @@ package templates
 
 // Templates for pre-caching lifecycle
 
-//CommonTemplates provides common template metadata
+// CommonTemplates provides common template metadata
 const CommonTemplates string = `
 {{ define "actionGVK" }}
 apiVersion: action.open-cluster-management.io/v1beta1
@@ -21,7 +21,7 @@ metadata:
 {{ end }}
 `
 
-//MngClusterActCreatePrecachingNS creates namespace
+// MngClusterActCreatePrecachingNS creates namespace
 const MngClusterActCreatePrecachingNS string = `
 {{ template "actionGVK"}}
 {{ template "metadata" . }}
@@ -38,7 +38,7 @@ spec:
           workload.openshift.io/allowed: management
 `
 
-//MngClusterActCreatePrecachingSpecCM creates precachingSpec configmap
+// MngClusterActCreatePrecachingSpecCM creates precachingSpec configmap
 const MngClusterActCreatePrecachingSpecCM string = `
 {{ template "actionGVK"}}
 {{ template "metadata" . }}
@@ -60,7 +60,7 @@ spec:
         namespace: openshift-talo-pre-cache
 `
 
-//MngClusterActCreateServiceAcct creates serviceaccount
+// MngClusterActCreateServiceAcct creates serviceaccount
 const MngClusterActCreateServiceAcct string = `
 {{ template "actionGVK"}}
 {{ template "metadata" . }}
@@ -76,7 +76,7 @@ spec:
         namespace: openshift-talo-pre-cache
 `
 
-//MngClusterActCreateClusterRoleBinding creates clusterrolebinding
+// MngClusterActCreateClusterRoleBinding creates clusterrolebinding
 const MngClusterActCreateClusterRoleBinding string = `
 {{ template "actionGVK"}}
 {{ template "metadata" . }}
@@ -99,7 +99,7 @@ spec:
           namespace: openshift-talo-pre-cache
 `
 
-//MngClusterActCreateJob creates precaching k8s job
+// MngClusterActCreateJob creates precaching k8s job
 const MngClusterActCreateJob string = `
 {{ template "actionGVK"}}
 {{ template "metadata" . }}
@@ -166,7 +166,7 @@ spec:
 
 `
 
-//MngClusterViewJob creates mcv to monitor precaching k8s job
+// MngClusterViewJob creates mcv to monitor precaching k8s job
 const MngClusterViewJob string = `
 {{ template "viewGVK"}}
 {{ template "metadata" . }}
@@ -178,7 +178,7 @@ spec:
     updateIntervalSeconds: {{ .ViewUpdateIntervalSec }}
 `
 
-//MngClusterViewConfigMap creates mcv to monitor configmap
+// MngClusterViewConfigMap creates mcv to monitor configmap
 const MngClusterViewConfigMap string = `
 {{ template "viewGVK"}}
 {{ template "metadata" . }}
@@ -190,7 +190,7 @@ spec:
     updateIntervalSeconds: {{ .ViewUpdateIntervalSec }}
 `
 
-//MngClusterViewServiceAcct creates mcv to monitor serviceaccount
+// MngClusterViewServiceAcct creates mcv to monitor serviceaccount
 const MngClusterViewServiceAcct string = `
 {{ template "viewGVK"}}
 {{ template "metadata" . }}
@@ -202,7 +202,7 @@ spec:
     updateIntervalSeconds: {{ .ViewUpdateIntervalSec }}
 `
 
-//MngClusterViewClusterRoleBinding creates mcv to monitor clusterrolebinding
+// MngClusterViewClusterRoleBinding creates mcv to monitor clusterrolebinding
 const MngClusterViewClusterRoleBinding string = `
 {{ template "viewGVK"}}
 {{ template "metadata" . }}
@@ -213,7 +213,7 @@ spec:
     updateIntervalSeconds: {{ .ViewUpdateIntervalSec }}
 `
 
-//MngClusterViewNamespace creates mcv to monitor namespace
+// MngClusterViewNamespace creates mcv to monitor namespace
 const MngClusterViewNamespace string = `
 {{ template "viewGVK"}}
 {{ template "metadata" . }}
@@ -224,7 +224,7 @@ spec:
     updateIntervalSeconds: {{ .ViewUpdateIntervalSec }}
 `
 
-//MngClusterActDeletePrecachingNS deletes prechaching namespace
+// MngClusterActDeletePrecachingNS deletes prechaching namespace
 const MngClusterActDeletePrecachingNS string = `
 {{ template "actionGVK"}}
 {{ template "metadata" . }}

--- a/controllers/utils/common.go
+++ b/controllers/utils/common.go
@@ -17,7 +17,7 @@ func GetManagedPolicyForUpgradeByIndex(
 }
 
 // GetMinOf3 return the minimum of 3 numbers.
-func GetMinOf3(number1 int, number2 int, number3 int) int {
+func GetMinOf3(number1, number2, number3 int) int {
 	if number1 <= number2 && number1 <= number3 {
 		return number1
 	} else if number2 <= number1 && number2 <= number3 {

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -91,3 +91,8 @@ const (
 const (
 	CleanupFinalizer = "ran.openshift.io/cleanup-finalizer"
 )
+
+// Upgrade status
+const (
+	CannotStart = "UpgradeCannotStart"
+)

--- a/controllers/utils/multicloud_util.go
+++ b/controllers/utils/multicloud_util.go
@@ -63,7 +63,7 @@ func ProcessSubscriptionManagedClusterView(
 	if conditionMCVforSub.Status == "True" && conditionMCVforSub.Reason == viewv1beta1.ReasonGetResource {
 		// Get the subscription content from the ManagedClusterView.
 		subscription := operatorsv1alpha1.Subscription{}
-		json.Unmarshal([]byte(mcv.Status.Result.Raw), &subscription)
+		json.Unmarshal(mcv.Status.Result.Raw, &subscription)
 
 		// If the subscription's status is "UpgradePending" approve the installPlan. For any other value of the state, continue.
 		if subscription.Status.State != SubscriptionStateUpgradePending {
@@ -123,7 +123,7 @@ var EnsureInstallPlanIsApproved = func(
 	if conditionMCVforInstallPlan.Status == "True" && conditionMCVforInstallPlan.Reason == viewv1beta1.ReasonGetResource {
 		// Get the InstallPlan content from the ManagedClusterView.
 		installPlan := operatorsv1alpha1.InstallPlan{}
-		json.Unmarshal([]byte(mcvForInstallPlan.Status.Result.Raw), &installPlan)
+		json.Unmarshal(mcvForInstallPlan.Status.Result.Raw, &installPlan)
 
 		// If the InstallPlan's approval is not manual, return. No action is taken for Automatic install plans.
 		if installPlan.Spec.Approval != operatorsv1alpha1.ApprovalManual {
@@ -263,7 +263,7 @@ func EnsureManagedClusterActionForInstallPlan(
 func NewManagedClusterActionForInstallPlanSpec(installPlan operatorsv1alpha1.InstallPlan) (*actionv1beta1.ActionSpec, error) {
 	installPlanClusterServiceVersionNames, err := json.Marshal(installPlan.Spec.ClusterServiceVersionNames)
 	if err != nil {
-		return nil, fmt.Errorf("Error trying to Marshal InstallPlan ClusterServiceVersionNames: %s", err.Error())
+		return nil, fmt.Errorf("error trying to Marshal InstallPlan ClusterServiceVersionNames: %s", err.Error())
 	}
 
 	templateContent := fmt.Sprintf(
@@ -315,6 +315,6 @@ func DeleteMultiCloudObjects(
 }
 
 // GetMultiCloudObjectName computes the name of a view or action
-func GetMultiCloudObjectName(clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, kind string, objectName string) string {
+func GetMultiCloudObjectName(clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, kind, objectName string) string {
 	return strings.ToLower(clusterGroupUpgrade.Name + "-" + clusterGroupUpgrade.Namespace + "-" + kind + "-" + objectName)
 }

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+which golangci-lint
+if [ $? -ne 0 ]; then
+    echo "Downloading golangci-lint tool"
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.2
+fi
+
+export GOCACHE=/tmp/
+export GOLANGCI_LINT_CACHE=/tmp/.cache
+golangci-lint run --verbose --print-resources-usage --modules-download-mode=vendor --timeout=5m0s

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+go mod vendor
+go mod tidy

--- a/recovery/cmd/launchBackup.go
+++ b/recovery/cmd/launchBackup.go
@@ -38,6 +38,7 @@ const recoveryScript string = "upgrade-recovery.sh"
 
 //RecoveryInProgress checks if a restore is in progress
 // returns:			bool
+//nolint:gocritic
 func RecoveryInProgress(BackupPath string) bool {
 	progressfile := filepath.Join(BackupPath, "progress")
 
@@ -49,6 +50,7 @@ func RecoveryInProgress(BackupPath string) bool {
 
 //ParseBackupPath parses the BackupPath
 // returns:			string
+//nolint:gocritic
 func ParseBackupPath(BackupPath string) string {
 	if check := strings.Contains(BackupPath[len(BackupPath)-1:], "/"); check {
 		BackupPath = BackupPath[:len(BackupPath)-1]
@@ -58,6 +60,7 @@ func ParseBackupPath(BackupPath string) string {
 
 //LaunchBackup triggers the backup procedure
 // returns:			error
+//nolint:gocritic
 func LaunchBackup(BackupPath string) error {
 
 	// check for slash in the BackupPath
@@ -153,8 +156,8 @@ func Cleanup(path string) error {
 	return nil
 }
 
-//ExecuteCmd execute shell commands
-//returns: 			error
+// ExecuteCmd execute shell commands
+// returns: 			error
 func ExecuteCmd(cmd string) error {
 
 	logger := log.StandardLogger()

--- a/recovery/cmd/root.go
+++ b/recovery/cmd/root.go
@@ -23,8 +23,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var cfgFile string
-
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "openshift-ai-image-backup",


### PR DESCRIPTION
This commit adds golangci-lint and fixes multiple violations. Some of
them have just been skipped by using nolint directives.

It also adds a new hack/update-deps script to update vendor
dependencies.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>
