### PR TITLE
Improving precache duration by running simultaneous pull tasks

### DIFF
--- a/pre-cache/common
+++ b/pre-cache/common
@@ -4,6 +4,7 @@ container_tool="${container_tool:-podman}"
 pull_secret_path="${pull_secret_path:-/host/var/lib/kubelet/config.json}"
 pull_spec_file="${pull_spec_file:-/tmp/images.txt}"
 config_volume_path="${config_volume_path:-/etc/config}"
+max_pull_threads="${MAX_PULL_THREADS:-10}" #number of simultaneous pulls executed can be modified by setting MAX_PULL_THREADS environment variable
 
 log_debug() {
   echo "upgrades.pre-cache $(date -Iseconds) DEBUG $@"

--- a/pre-cache/pull
+++ b/pre-cache/pull
@@ -4,39 +4,82 @@ cwd="${cwd:-/tmp/precache}"
 . $cwd/common
 
 mirror_images() {
+
     if ! [[ -f $pull_spec_file ]]; then
         log_debug "no pull spec provided - misconfiguration error"
         return 1
     fi
+    # definition of vars once the config is provided
+    local max_bg=$max_pull_threads
+    declare -A pids # Hash that include the images pulled along with their pids to be monitored by wait command
+    local total_pulls=$(sort -u $pull_spec_file | wc -l)  # Required to keep track of the pull task vs total
+    local current_pull=1
+
     for line in $(sort -u $pull_spec_file) ; do
         # Strip double quotes
         img="${line%\"}"
         img="${img#\"}"
-
+        log_debug "Pulling ${img} [${current_pull}/${total_pulls}]"
+        # If image is on disk, then skip. This improves the global performance
         $container_tool image exists $img
         if [[ $? == 0 ]]; then
             log_debug "Skipping existing image $img"
+            current_pull=$((current_pull + 1))
             continue
         fi
-        success=0
-        iterations=10
-        until [[ $success -eq 1 ]] || [[ $iterations -eq 0 ]]
-        do
-            $container_tool  pull $img --authfile=/var/lib/kubelet/config.json
-            if [[ $? == 0 ]]; then
-                success=1
+        $container_tool pull $img --authfile=/var/lib/kubelet/config.json -q > /dev/null &
+        #$container_tool copy docker://${img} --authfile=/var/lib/kubelet/config.json containers-storage:${img} -q & # SKOPEO 
+        pids[${img}]=$! # Keeping track of the PID and container image in case the pull fails
+        max_bg=$((max_bg - 1)) # Batch size adapted 
+        current_pull=$((current_pull + 1)) 
+        if [[ $max_bg == 0 ]] # If the batch is done, then monitor the status of all pulls before moving to the next batch
+        then
+          for pid in ${!pids[@]}; do
+            wait ${pids[$pid]} # The way wait monitor for each background task (PID). If any error then copy the image in the failed array so it can be retried later
+            if [[ $? != 0 ]]; then
+              log_debug "Pull failed for container image: ${pid} . Retrying later... "
+              failed_pulls+=(${pid}) # Failed, then add the image to be retrieved later
             fi
-            iterations=$((iterations - 1))
-        done
-        if [[ $success == 0 ]]; then
-            log_debug "failed to pull ${img}"
+          done
+          # Once the batch is processed, reset the new batch size and clear the processes hash for the next one
+          max_bg=$max_pull_threads
+          pids=()
         fi
     done
-    log_debug "Image pre-cache done"
 }
 
+retry_images() {
+    local success
+    local iterations
+    local rv=0
+    for failed_pull in ${failed_pulls[@]}; do
+      success=0
+      iterations=10
+      until [[ $success -eq 1 ]] || [[ $iterations -eq 0 ]]
+      do
+        log_debug "Retrying failed image pull: ${failed_pull}"
+        $container_tool pull $failed_pull --authfile=/var/lib/kubelet/config.json
+        if [[ $? == 0 ]]; then
+          success=1
+        fi
+          iterations=$((iterations - 1))
+      done
+      if [[ $success == 0 ]]; then
+       log_debug "Limit number of retries reached. The image could not be pulled: ${failed_pull}"
+       rv=1
+      fi
+    done
+    log_debug "Image pre-cache done"
+    return $rv
+}
 
 if [[ "${BASH_SOURCE[0]}" = "${0}" ]]; then
+  failed_pulls=() # Array that will include all the images that failed to be pulled
   mirror_images
-  exit $?
+  retry_images # Return 1 if max.retries reached
+  if [[ $? -ne 0 ]]; then
+    log_debug "[FAIL] One or more images were not precached successfully"
+    exit 1
+  fi
+  exit 0
 fi


### PR DESCRIPTION
This PR tries to cover:

- Improving the time it takes to pull all the container images. Until now it has been done sequentially, this PR executes by default batches of 10 at the same time. That's the default, however, it can be parametrized using an env variable. 
- I wanted to keep the functionality of retrying images that were not pulled successfully. When running multiple tasks in parallel, the wait command only prints the status of the last job. That's why the code looks a little bit complicated since I had to keep track of the PIDs and container image names. 
- Solves the enhancement opened [Pre-cache UOCR: Suggest to include remaining time or no. of images to finish the pulling task](https://bugzilla.redhat.com/show_bug.cgi?id=2048467). It displays information on the number of the image being pulled out of the total images to be downloaded, so you have an idea where the process is at any moment.

```
upgrades.pre-cache 2022-03-11T13:41:52+00:00 DEBUG Release index image processing done
09d925e015e1f09b6a2b5a7212c46fe2fce4dc711e5c9e7bc39892aa9e790143
upgrades.pre-cache 2022-03-11T13:41:53+00:00 DEBUG Operators index is not specified. Operators won't be pre-cached
upgrades.pre-cache 2022-03-11T13:41:53+00:00 DEBUG Pulling quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:023fba035f3807a225d262ef0f32e726cbdf6aadc3959fe82283778fecb33954 [1/140]
upgrades.pre-cache 2022-03-11T13:41:53+00:00 DEBUG Pulling quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:026925f8171263b54070c6611a255882b736922d611b39997e7daa1d82232dba [2/140]
```
[Here](https://docs.google.com/spreadsheets/d/1BuNrvuzo8NoPprlmnz5alv3SH8M0GCgt5zfW1W4Jfa0/edit#gid=0) you have a spreadsheet where I calculate the improvement running different batches (10 vs 20) at the same time and comparing podman vs skopeo. 


Signed-off-by: Alberto Losada <alosadag@redhat.com>