### PR TITLE
Copy registries.conf in precache container for mirrored registry

### DIFF
--- a/pre-cache/copy-env.sh
+++ b/pre-cache/copy-env.sh
@@ -18,6 +18,7 @@ done
 
 # Copy containers policy and cacert of disconnected registries if present
 cp /host/etc/containers/policy.json /etc/containers/policy.json
+cp /host/etc/containers/registries.conf /etc/containers/registries.conf || true
 cp -a /host/etc/docker /etc/ || true
 cp -a /host/etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/source/ && update-ca-trust || true
 cp -a /host/etc/pki/ca-trust/extracted/pem /etc/pki/ca-trust/extracted/ || true


### PR DESCRIPTION
This PR copies the registries.conf from the node into the precache container image. Registries.conf contains the mirrored registry for releases and operators.

This is needed in the corner case when enabling preaching in a disconnected environment but the upgrade path is not pointing at the disconnected registry but the official one. 

Signed-off-by: Alberto Losada <alosadag@redhat.com>