### PR TITLE
Set default backup value to false

### DIFF
--- a/api/v1alpha1/clustergroupupgrade_types.go
+++ b/api/v1alpha1/clustergroupupgrade_types.go
@@ -86,7 +86,7 @@ type ClusterGroupUpgradeSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// This field determines whether the cluster would be running a backup prior to the upgrade.
-	//+kubecuilder:default=true
+	//+kubebuilder:default=false
 	Backup bool `json:"backup,omitempty"`
 	// This field determines whether container image pre-caching will be done on all the clusters
 	// matching the selector.

--- a/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
+++ b/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
@@ -92,6 +92,7 @@ spec:
                     type: object
                 type: object
               backup:
+                default: false
                 description: This field determines whether the cluster would be running
                   a backup prior to the upgrade.
                 type: boolean


### PR DESCRIPTION
This commit sets the kubebuilder default value to false in the api.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>