### PR TITLE
new templates folder for pre-cache and backup job templates

### DIFF
--- a/controllers/precache.go
+++ b/controllers/precache.go
@@ -584,13 +584,13 @@ func (r *ClusterGroupUpgradeReconciler) getPrecacheJobTemplateData(
 	rv := new(templateData)
 
 	rv.Cluster = clusterName
-	rv.PrecachingJobTimeout = uint64(
+	rv.JobTimeout = uint64(
 		clusterGroupUpgrade.Spec.RemediationStrategy.Timeout) * 60
 	image, err := r.getPrecacheimagePullSpec(ctx, clusterGroupUpgrade)
 	if err != nil {
 		return rv, err
 	}
-	rv.PrecachingWorkloadImage = image
+	rv.WorkloadImage = image
 	return rv, nil
 }
 

--- a/controllers/templates/backup-templates.go
+++ b/controllers/templates/backup-templates.go
@@ -1,0 +1,125 @@
+package templates
+
+// Templates for backup job lifecycle
+
+//MngClusterActCreateBackupNS creates namespace
+const MngClusterActCreateBackupNS string = `
+{{ template "actionGVK"}}
+{{ template "metadata" . }}
+spec: 
+  actionType: Create
+  kube: 
+    resource: namespace
+    template: 
+      apiVersion: v1
+      kind: Namespace
+      metadata: 
+        name: backup-agent
+`
+
+//MngClusterActCreateSA creates serviceaccount
+const MngClusterActCreateSA string = `
+{{ template "actionGVK"}}
+{{ template "metadata" . }}
+spec:
+  actionType: Create
+  kube:
+    resource: serviceaccount
+    template:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: backup-agent
+        namespace: openshift-talo-backup
+`
+
+//MngClusterActCreateRB creates clusterrolebinding
+const MngClusterActCreateRB string = `
+{{ template "actionGVK"}}
+{{ template "metadata" . }}
+spec:
+  actionType: Create
+  kube:
+    resource: clusterrolebinding
+    template:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: backup-agent
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: cluster-admin
+      subjects:
+        - kind: ServiceAccount
+          name: backup-agent
+          namespace: openshift-talo-backup
+`
+
+//MngClusterActCreateBackupJob creates k8s job
+const MngClusterActCreateBackupJob string = `
+{{ template "actionGVK"}}
+{{ template "metadata" . }}
+spec:
+  actionType: Create
+  kube:
+    namespace: openshift-talo-backup
+    resource: job
+    template:
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: backup-agent
+      spec:
+	    activeDeadlineSeconds: {{ .JobTimeout }}
+        backoffLimit: 0
+        template:
+          spec:
+            containers:
+              -
+                args:
+                  - launchBackup
+                  - "--BackupPath"
+                  - /var/recovery
+                image: {{ .WorkloadImage }}
+                name: container-image
+                securityContext:
+                  privileged: true
+                  runAsUser: 0
+                tty: true
+                volumeMounts:
+                  -
+                    mountPath: /host
+                    name: backup
+            restartPolicy: Never
+            hostNetwork: true
+            serviceAccountname: backup-agent
+            volumes:
+              -
+                hostPath:
+                  path: /
+                  type: Directory
+                name: backup
+`
+
+//MngClusterActDeleteNS deletes namespace
+const MngClusterActDeleteNS string = `
+{{ template "actionGVK"}}
+{{ template "metadata" . }}
+spec: 
+  actionType: Delete
+  kube: 
+    name: backup-agent
+    resource: namespace
+`
+
+//MngClusterViewBackupJob creates mcv to monitor k8s job
+const MngClusterViewBackupJob string = `
+{{ template "viewGVK"}}
+{{ template "metadata" . }}
+spec:
+  scope:
+    resource: jobs
+    name: backup-agent
+    namespace: openshift-talo-backup
+`

--- a/controllers/templates/precache-templates.go
+++ b/controllers/templates/precache-templates.go
@@ -1,0 +1,236 @@
+package templates
+
+// Templates for pre-caching lifecycle
+
+//CommonTemplates provides common template metadata
+const CommonTemplates string = `
+{{ define "actionGVK" }}
+apiVersion: action.open-cluster-management.io/v1beta1
+kind: ManagedClusterAction
+{{ end }}
+
+{{ define "viewGVK" }}
+apiVersion: view.open-cluster-management.io/v1beta1
+kind: ManagedClusterView
+{{ end }}
+
+{{ define "metadata"}}
+metadata:
+  name: {{ .ResourceName }}
+  namespace: {{ .Cluster }}
+{{ end }}
+`
+
+//MngClusterActCreatePrecachingNS creates namespace
+const MngClusterActCreatePrecachingNS string = `
+{{ template "actionGVK"}}
+{{ template "metadata" . }}
+spec:
+  actionType: Create
+  kube:
+    resource: namespace
+    template:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-talo-pre-cache
+        annotations:
+          workload.openshift.io/allowed: management
+`
+
+//MngClusterActCreatePrecachingSpecCM creates precachingSpec configmap
+const MngClusterActCreatePrecachingSpecCM string = `
+{{ template "actionGVK"}}
+{{ template "metadata" . }}
+spec:
+  actionType: Create
+  kube:
+    resource: configmap
+    template:
+      apiVersion: v1
+      data:
+        operators.indexes: |{{ range .Operators.Indexes }}
+          {{ . }} {{ end }}
+        operators.packagesAndChannels: |{{ range .Operators.PackagesAndChannels }} 
+          {{ . }} {{ end }}
+        platform.image: {{ .PlatformImage }}
+      kind: ConfigMap
+      metadata:
+        name: pre-cache-spec
+        namespace: openshift-talo-pre-cache
+`
+
+//MngClusterActCreateServiceAcct creates serviceaccount
+const MngClusterActCreateServiceAcct string = `
+{{ template "actionGVK"}}
+{{ template "metadata" . }}
+spec:
+  actionType: Create
+  kube:
+    resource: serviceaccount
+    template:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: pre-cache-agent
+        namespace: openshift-talo-pre-cache
+`
+
+//MngClusterActCreateClusterRoleBinding creates clusterrolebinding
+const MngClusterActCreateClusterRoleBinding string = `
+{{ template "actionGVK"}}
+{{ template "metadata" . }}
+spec:
+  actionType: Create
+  kube:
+    resource: clusterrolebinding
+    template:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: pre-cache-crb
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: cluster-admin
+      subjects:
+        - kind: ServiceAccount
+          name: pre-cache-agent
+          namespace: openshift-talo-pre-cache
+`
+
+//MngClusterActCreateJob creates precaching k8s job
+const MngClusterActCreateJob string = `
+{{ template "actionGVK"}}
+{{ template "metadata" . }}
+spec:
+  actionType: Create
+  kube:
+    resource: job
+    namespace: openshift-talo-pre-cache
+    template:
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: pre-cache
+        namespace: openshift-talo-pre-cache
+        annotations:
+          target.workload.openshift.io/management: '{"effect":"PreferredDuringScheduling"}'
+      spec:
+        activeDeadlineSeconds: {{ .JobTimeout }}
+        backoffLimit: 0
+        template:
+          metadata:
+            name: pre-cache
+            annotations:
+              target.workload.openshift.io/management: '{"effect":"PreferredDuringScheduling"}'
+          spec:
+            containers:
+            - args:
+              - /opt/precache/precache.sh
+              command:
+              - /bin/bash
+              - -c
+              env:
+              - name: config_volume_path
+                value: /etc/config
+              image: {{ .WorkloadImage }}
+              name: pre-cache-container
+              resources: {}
+              securityContext:
+                privileged: true
+                runAsUser: 0
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              volumeMounts:
+              - mountPath: /host
+                name: host 
+              - mountPath: /etc/config
+                name: config-volume
+                readOnly: true
+            dnsPolicy: ClusterFirst
+            restartPolicy: Never
+            schedulerName: default-scheduler
+            securityContext: {}
+            serviceAccountName: pre-cache-agent
+            priorityClassName: system-cluster-critical
+            volumes:
+            - configMap:
+                defaultMode: 420
+                name: pre-cache-spec
+              name: config-volume
+            - hostPath:
+                path: /
+                type: Directory
+              name: host
+
+`
+
+//MngClusterViewJob creates mcv to monitor precaching k8s job
+const MngClusterViewJob string = `
+{{ template "viewGVK"}}
+{{ template "metadata" . }}
+spec:
+  scope:
+    resource: jobs
+    name: pre-cache
+    namespace: openshift-talo-pre-cache
+    updateIntervalSeconds: {{ .ViewUpdateIntervalSec }}
+`
+
+//MngClusterViewConfigMap creates mcv to monitor configmap
+const MngClusterViewConfigMap string = `
+{{ template "viewGVK"}}
+{{ template "metadata" . }}
+spec:
+  scope:
+    resource: configmap
+    name: pre-cache-spec
+    namespace: openshift-talo-pre-cache
+    updateIntervalSeconds: {{ .ViewUpdateIntervalSec }}
+`
+
+//MngClusterViewServiceAcct creates mcv to monitor serviceaccount
+const MngClusterViewServiceAcct string = `
+{{ template "viewGVK"}}
+{{ template "metadata" . }}
+spec:
+  scope:
+    resource: serviceaccounts
+    name: pre-cache-agent
+    namespace: openshift-talo-pre-cache
+    updateIntervalSeconds: {{ .ViewUpdateIntervalSec }}
+`
+
+//MngClusterViewClusterRoleBinding creates mcv to monitor clusterrolebinding
+const MngClusterViewClusterRoleBinding string = `
+{{ template "viewGVK"}}
+{{ template "metadata" . }}
+spec:
+  scope:
+    resource: clusterrolebinding
+    name: pre-cache-crb
+    updateIntervalSeconds: {{ .ViewUpdateIntervalSec }}
+`
+
+//MngClusterViewNamespace creates mcv to monitor namespace
+const MngClusterViewNamespace string = `
+{{ template "viewGVK"}}
+{{ template "metadata" . }}
+spec:
+  scope:
+    resource: namespaces
+    name: openshift-talo-pre-cache
+    updateIntervalSeconds: {{ .ViewUpdateIntervalSec }}
+`
+
+//MngClusterActDeletePrecachingNS deletes prechaching namespace
+const MngClusterActDeletePrecachingNS string = `
+{{ template "actionGVK"}}
+{{ template "metadata" . }}
+spec:
+  actionType: Delete
+  kube:
+    resource: namespace
+    name: openshift-talo-pre-cache
+`


### PR DESCRIPTION
For [CNF-4055](https://issues.redhat.com/browse/CNF-4055) story, it aims to refactor and reorganize codes around pre-caching to be reused by backup implementation.
This pull requests of sub-task 4257 reorganizes templates to a template folder and adds backup templates to be used by backup trigger implementation.