### PR TITLE
Fix OLM index extraction

### DIFF
--- a/pre-cache/common
+++ b/pre-cache/common
@@ -4,6 +4,10 @@ container_tool="${container_tool:-podman}"
 pull_secret_path="${pull_secret_path:-/host/var/lib/kubelet/config.json}"
 pull_spec_file="${pull_spec_file:-/tmp/images.txt}"
 config_volume_path="${config_volume_path:-/etc/config}"
+podman_pull_path="${podman_pull_path:-/run/containers/0}"
+docker_pull_path="${docker_pull_path:-/root/.docker}"
+rendered_index_path="${rendered_index_path:-/tmp/index.json}"
+
 
 log_debug() {
   echo "upgrades.pre-cache $(date -Iseconds) DEBUG $@"

--- a/pre-cache/copy-env.sh
+++ b/pre-cache/copy-env.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+cwd="${cwd:-/opt/precache}"
+. $cwd/common
+
 # Copy podman dependencies to the container. Podman itself runs off the host in the
 # container by adding /host/usr/bin to the path
 # This is a work around for podman not passing LD_LIBRARY_PATH environment
@@ -22,3 +25,8 @@ cp /host/etc/containers/registries.conf /etc/containers/registries.conf || true
 cp -a /host/etc/docker /etc/ || true
 cp -a /host/etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/source/ && update-ca-trust || true
 cp -a /host/etc/pki/ca-trust/extracted/pem /etc/pki/ca-trust/extracted/ || true
+[ ! -d "$podman_pull_path" ] && mkdir -p "$podman_pull_path"
+cp $pull_secret_path "$podman_pull_path/auth.json"
+[ ! -d "$docker_pull_path" ] && mkdir -p "$docker_pull_path"
+cp $pull_secret_path "$docker_pull_path/config.json"
+

--- a/pre-cache/olm
+++ b/pre-cache/olm
@@ -3,10 +3,6 @@
 cwd="${cwd:-/opt/precache}"
 . $cwd/common
 
-podman_pull_path="${podman_pull_path:-/run/containers/0}"
-rendered_index_path="${rendered_index_path:-/tmp/index.json}"
-
-
 extract_pull_spec(){
     rendered_index=$1
     operators_spec_file=$2
@@ -17,13 +13,9 @@ extract_pull_spec(){
 
 render_index(){
     index=$1
-    pull_secret_path=$2
-    packages=$3
-    image_mount=$4
+    packages=$2
+    image_mount=$3
     
-    # copy pull secret to the default runtime dir - opm doesn't accept authfile as an arg
-    [ ! -d "$podman_pull_path" ] && mkdir -p "$podman_pull_path"
-    cp $pull_secret_path "$podman_pull_path/auth.json"
     capath="/host/etc/docker/certs.d/${index%/*}/ca.crt"
     # opm doesn't accept cacert as an arg
     if [[ -f "$capath" ]]; then
@@ -79,7 +71,7 @@ olm_main(){
           log_debug "operators index is set, but no packages provided - inconsistent configuration"
           return 1
         fi
-        render_index $index $pull_secret_path $packages $image_mount
+        render_index $index $packages $image_mount
         if [[ $? -ne 0 ]]; then
           log_debug "render_index failed: OLM index render failed for index $index, package(s) $packages"
           return 1


### PR DESCRIPTION
This fixes a bug in sqlite OLM catalog extraction, causing
operator bundle to be identified incorrectly. The bug was
percieved as a failure to pull one or more images.
The problem is fixed by cherry-picking this commit from the
main branch:

Commit d019df2490ac8b0753b953abd8a15a09e86f6ed8
    This fixes an authorization problem occurring when
    trying to render an OLM index container with opm.
    There are two tools used in the precaching workload
    from inside the container, podman and opm.
    Podman is using auth.json from /run/containers/0
    when run as root. Opm is using ~/.docker/config.json.
    This change adds missing pull secret copy to the
    latter for the opm use, and also puts all the relevant
    copy operations to the "copy_env.sh" script

Signed-off-by: Vitaly Grinberg <vgrinber@redhat.com>
/cc @irinamihai @rcarrillocruz @danielmellado 