### PR TITLE
Add verify-bindata and shellcheck to ci-job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ common-deps-update:	controller-gen kustomize
 	go mod tidy
 
 .PHONY: ci-job
-ci-job: common-deps-update fmt vet lint golangci-lint unittests
+ci-job: common-deps-update fmt vet lint golangci-lint unittests verify-bindata shellcheck
 
 .PHONY: shellcheck
 shellcheck: ## Run shellcheck

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
-ENGINE=${ENGINE:-docker}
+shellcheck=$(go env GOPATH)/bin/shellcheck
+if [ ! -f ${shellcheck} ]; then
+    echo "Downloading shellcheck tool"
+    scversion=v0.7.2
+    wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion}/shellcheck-${scversion}.linux.x86_64.tar.xz" \
+        | tar -xJ -C $(go env GOPATH)/bin --strip=1 shellcheck-${scversion}/shellcheck
+fi
 
 # Skip specific folders for now, until shellcheck warnings are addressed
 find . -name '*.sh' -not -path './vendor/*' -not -path './git/*' \
     -not -path './pre-cache/*' -not -path './hack/*' -not -path './deploy/*' -print0 \
-    | xargs -0 --no-run-if-empty ${ENGINE} run --rm -v "${PWD}:/mnt" docker.io/koalaman/shellcheck:v0.7.2
+    | xargs -0 --no-run-if-empty ${shellcheck}


### PR DESCRIPTION
This update adds the verify-bindata and shellcheck tests to ci-job in
the Makefile, which is run as part of the CI integration test. This
will protect against the introduction of changes to bindata that has
not been reflected in the generated golang source, as well as new
shellcheck warnings in bash scripts.

Signed-off-by: Don Penney <dpenney@redhat.com>