### PR TITLE
Enable shellcheck for all .sh scripts

### DIFF
--- a/deploy/upgrades/operator-upgrade/cleanup.sh
+++ b/deploy/upgrades/operator-upgrade/cleanup.sh
@@ -5,6 +5,8 @@ spokes=( "spoke1" "spoke2" "spoke5" )
 for spoke in "${spokes[@]}";
 do
     echo "$spoke"
-    mcv=( $(oc get managedclusterview -n "$spoke" | tail -n +2 | awk '{print $1}') ); for (( i=0; i<${#mcv[@]}; i++)); do echo "${mcv[$i]}"; oc delete managedclusterview -n "$spoke" "${mcv[$i]}"; done;
-    mca=( $(oc get managedclusteraction -n "$spoke" | tail -n +2 | awk '{print $1}') ); for (( i=0; i<${#mca[@]}; i++)); do oc delete managedclusteraction -n "$spoke" "${mca[$i]}"; done;
+    mapfile -t mcv < <(oc get managedclusterview -n "$spoke" | tail -n +2 | awk '{print $1}')
+    for (( i=0; i<${#mcv[@]}; i++)); do echo "${mcv[$i]}"; oc delete managedclusterview -n "$spoke" "${mcv[$i]}"; done;
+    mapfile -t mca < <(oc get managedclusteraction -n "$spoke" | tail -n +2 | awk '{print $1}')
+    for (( i=0; i<${#mca[@]}; i++)); do oc delete managedclusteraction -n "$spoke" "${mca[$i]}"; done;
 done

--- a/hack/install-integration-tests-deps.sh
+++ b/hack/install-integration-tests-deps.sh
@@ -7,7 +7,6 @@ _GOARCH=$(go env GOARCH)
 _ARCH=$(arch)
 
 KIND_ENV="kind"
-NON_KIND_ENV="non-kind"
 mkdir -p ./bin
 
 
@@ -30,7 +29,7 @@ fi
 
 # Install kind if needed.
 if [ "$env" == "$KIND_ENV" ] && ! [ -x "$(command -v kind)" ]; then
-    echo "Installing kind... https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-$(uname)-$GOARCH"
+    echo "Installing kind... https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-$(uname)-$_GOARCH"
     curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-$(uname)-$_GOARCH
     mv ./kind ./bin/
     chmod 755 ./bin/kind

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -9,6 +9,5 @@ if [ ! -f ${shellcheck} ]; then
 fi
 
 # Skip specific folders for now, until shellcheck warnings are addressed
-find . -name '*.sh' -not -path './vendor/*' -not -path './git/*' \
-    -not -path './pre-cache/*' -not -path './hack/*' -not -path './deploy/*' -print0 \
-    | xargs -0 --no-run-if-empty ${shellcheck}
+find . -name '*.sh' -not -path './vendor/*' -not -path './git/*' -print0 \
+    | xargs -0 --no-run-if-empty ${shellcheck} -x

--- a/pre-cache/copy-env.sh
+++ b/pre-cache/copy-env.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 cwd="${cwd:-/opt/precache}"
-. $cwd/common
+# shellcheck source=pre-cache/common
+source $cwd/common
 
 # Copy podman dependencies to the container. Podman itself runs off the host in the
 # container by adding /host/usr/bin to the path
@@ -23,6 +24,7 @@ done
 cp /host/etc/containers/policy.json /etc/containers/policy.json
 cp /host/etc/containers/registries.conf /etc/containers/registries.conf || true
 cp -a /host/etc/docker /etc/ || true
+# shellcheck disable=SC2015
 cp -a /host/etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/source/ && update-ca-trust || true
 cp -a /host/etc/pki/ca-trust/extracted/pem /etc/pki/ca-trust/extracted/ || true
 [ ! -d "$podman_pull_path" ] && mkdir -p "$podman_pull_path"

--- a/pre-cache/test.sh
+++ b/pre-cache/test.sh
@@ -3,13 +3,14 @@
 set -e
 
 fatal() {
-  echo "FATAL: $@"
+  echo "FATAL: $*"
   exit 1
 }
 
 for f in common olm release pull
 do
     echo "Testing import of $f"
+    # shellcheck disable=1090,2154
     . $cwd/$f
     rc=$?
     [[ $rc -eq 0 ]] || fatal "Could not import $f"
@@ -32,14 +33,18 @@ printf '{
       }]
   }
 }' > /tmp/release-manifests/image-references
+# shellcheck disable=SC2154
 (rm $pull_spec_file || true) &> /dev/null
 
+# shellcheck disable=SC2034
 container_tool=/usr/bin/echo
+# shellcheck disable=SC2034
 config_volume_path=/tmp
 
 # Test common
 echo "Testing common functions:"
 
+# shellcheck disable=SC2154
 result=$(pull_index "temp" $pull_secret_path)
 [[ $? -eq 0 ]] || fatal "pull_index unexpected exit code"
 [[ $result == "pull --quiet temp --root=/cache --authfile=$pull_secret_path" ]] || fatal "Index pull failure"


### PR DESCRIPTION
Dropped the hack folder from the shellcheck exclusions and cleaned up
existing warnings. This ensures that future updates to scripts in the
hack folder will have to pass the shellcheck linter test.

Signed-off-by: Don Penney <dpenney@redhat.com>