### PR TITLE
Ignore policies that have remediationAction enforce

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -649,8 +649,16 @@ func (r *ClusterGroupUpgradeReconciler) doManagedPoliciesExist(
 	// A child policy name has the name format parent_policy_namespace.parent_policy_name
 	// The policy map we are creating will be of format {"policy_name": "policy_namespace"}
 	policyMap := make(map[string]string)
+	policyEnforce := make(map[string]bool)
 	for _, childPolicy := range childPoliciesList {
 		policyNameArr := strings.SplitN(childPolicy.Name, ".", 2)
+
+		// Identify policies with remediationAction enforce to ignore
+		if strings.EqualFold(string(childPolicy.Spec.RemediationAction), "enforce") {
+			policyEnforce[policyNameArr[1]] = true
+			continue
+		}
+
 		policyMap[policyNameArr[1]] = policyNameArr[0]
 	}
 	r.Log.Info("[doManagedPoliciesExist]", "policyMap", policyMap)
@@ -665,6 +673,11 @@ func (r *ClusterGroupUpgradeReconciler) doManagedPoliciesExist(
 	clusterGroupUpgrade.Status.ManagedPoliciesContent = make(map[string]string)
 
 	for _, managedPolicyName := range clusterGroupUpgrade.Spec.ManagedPolicies {
+		if policyEnforce[managedPolicyName] {
+			r.Log.Info("Ignoring policy " + managedPolicyName + " with remediationAction enforce")
+			continue
+		}
+
 		if managedPolicyNamespace, ok := policyMap[managedPolicyName]; ok {
 			// Make sure the parent policy exists and nothing happened between querying the child policies above and now.
 			foundPolicy, err := r.getPolicyByName(ctx, managedPolicyName, managedPolicyNamespace)

--- a/controllers/managedclusterForCGU_controller.go
+++ b/controllers/managedclusterForCGU_controller.go
@@ -175,6 +175,12 @@ func (r *ManagedClusterForCguReconciler) newClusterGroupUpgrade(
 	// The list of policies is ordered from the lowest value to the highest.
 	// Policy without a wave is not managed.
 	for _, policy := range policies {
+		// Ignore policies with remediationAction enforce
+		if strings.EqualFold(string(policy.Spec.RemediationAction), "enforce") {
+			r.Log.Info("Ignoring policy " + policy.Name + " with remediationAction enforce")
+			continue
+		}
+
 		deployWave, found := policy.GetAnnotations()[ztpDeployWaveAnnotation]
 		if found {
 			deployWaveInt, err := strconv.Atoi(deployWave)


### PR DESCRIPTION
Ignore policies with remediation Action enforce from being processed by CGU controller

Signed-off-by: melserngawy <melserng@redhat.com>