### PR TITLE
Ignore bin and testbin dirs for bash linters

### DIFF
--- a/hack/bashate.sh
+++ b/hack/bashate.sh
@@ -22,7 +22,6 @@ source ${VENVDIR}/bin/activate || fatal "Could not activate virtualenv"
 
 pip install bashate==2.1.0 || fatal "Installation of bashate failed"
 
-find . -name '*.sh' -not -path './vendor/*' -not -path './git/*' -print0 \
+find . -name '*.sh' -not -path './vendor/*' -not -path './git/*' \
+    -not -path './bin/*' -not -path './testbin/*' -print0 \
     | xargs -0 --no-run-if-empty bashate -v -e 'E*' -i E006
-
-#    | xargs -0 --no-run-if-empty bashate -v -e 'E*' -i E006,E001,E002,E003,E010,E011

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -8,5 +8,6 @@ if [ ! -f ${shellcheck} ]; then
         | tar -xJ -C $(go env GOPATH)/bin --strip=1 shellcheck-${scversion}/shellcheck
 fi
 
-find . -name '*.sh' -not -path './vendor/*' -not -path './git/*' -print0 \
+find . -name '*.sh' -not -path './vendor/*' -not -path './git/*' \
+    -not -path './bin/*' -not -path './testbin/*' -print0 \
     | xargs -0 --no-run-if-empty ${shellcheck} -x


### PR DESCRIPTION
Updated the bash linter scripts, shellcheck and bashate, to ignore the
bin and testbin directories.

Signed-off-by: Don Penney <dpenney@redhat.com>