### PR TITLE
Add pre-caching unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ lint: ## Run golint against code.
 	hack/lint.sh
 
 .PHONY: unittests
-unittests:
+unittests: pre-cache-unit-test
 	@echo "Running unittests"
 	go test -v ./controllers/...
 

--- a/controllers/managedClusterResources_test.go
+++ b/controllers/managedClusterResources_test.go
@@ -1,0 +1,472 @@
+package controllers
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/openshift-kni/cluster-group-upgrades-operator/controllers/templates"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestMCR_renderYamlTemplates(t *testing.T) {
+	testcases := []struct {
+		name         string
+		data         templateData
+		template     string
+		resourceName string
+		result       string
+	}{
+		{
+			name:         "create namespace",
+			resourceName: "test-ns",
+			data: templateData{
+				Cluster:      "test",
+				ResourceName: "test-view",
+			},
+			template: templates.MngClusterActCreatePrecachingNS,
+			result: `
+apiVersion: action.open-cluster-management.io/v1beta1
+kind: ManagedClusterAction
+metadata:
+  name: test-ns
+  namespace: test
+spec:
+  actionType: Create
+  kube:
+    resource: namespace
+    template:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-talo-pre-cache
+        annotations:
+          workload.openshift.io/allowed: management
+`,
+		},
+		{
+			name:         "create service account",
+			resourceName: "test-sa-create",
+			data: templateData{
+				Cluster:      "test",
+				ResourceName: "test-sa",
+			},
+			template: templates.MngClusterActCreateServiceAcct,
+			result: `
+apiVersion: action.open-cluster-management.io/v1beta1
+kind: ManagedClusterAction
+metadata:
+    name: test-sa-create
+    namespace: test
+spec:
+    actionType: Create
+    kube:
+        resource: serviceaccount
+        template:
+            apiVersion: v1
+            kind: ServiceAccount
+            metadata:
+                name: pre-cache-agent
+                namespace: openshift-talo-pre-cache
+`,
+		},
+		{
+			name:         "create cluster role binding",
+			resourceName: "test-crb-create",
+			data: templateData{
+				Cluster:      "test",
+				ResourceName: "test-crb",
+			},
+			template: templates.MngClusterActCreateClusterRoleBinding,
+			result: `
+apiVersion: action.open-cluster-management.io/v1beta1
+kind: ManagedClusterAction
+metadata:
+  name: test-crb-create
+  namespace: test
+spec:
+  actionType: Create
+  kube:
+    resource: clusterrolebinding
+    template:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: pre-cache-crb
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: cluster-admin
+      subjects:
+      - kind: ServiceAccount
+        name: pre-cache-agent
+        namespace: openshift-talo-pre-cache`,
+		},
+		{
+			name:         "create job",
+			resourceName: "test-job-create",
+			data: templateData{
+				Cluster:       "test",
+				ResourceName:  "test-crb",
+				WorkloadImage: "test-image",
+				JobTimeout:    12,
+			},
+			template: templates.MngClusterActCreateJob,
+			result: `
+      apiVersion: action.open-cluster-management.io/v1beta1
+      kind: ManagedClusterAction
+      metadata:
+        name: test-job-create
+        namespace: test
+      spec:
+        actionType: Create
+        kube:
+          resource: job
+          namespace: openshift-talo-pre-cache
+          template:
+            apiVersion: batch/v1
+            kind: Job
+            metadata:
+              name: pre-cache
+              namespace: openshift-talo-pre-cache
+              annotations:
+                target.workload.openshift.io/management: '{"effect":"PreferredDuringScheduling"}'
+            spec:
+              activeDeadlineSeconds: 12
+              backoffLimit: 0
+              template:
+                metadata:
+                  name: pre-cache
+                  annotations:
+                    target.workload.openshift.io/management: '{"effect":"PreferredDuringScheduling"}'
+                spec:
+                  containers:
+                  - args:
+                    - /opt/precache/precache.sh
+                    command:
+                    - /bin/bash
+                    - -c
+                    env:
+                    - name: config_volume_path
+                      value: /etc/config
+                    image: test-image
+                    name: pre-cache-container
+                    resources: {}
+                    securityContext:
+                      privileged: true
+                      runAsUser: 0
+                    terminationMessagePath: /dev/termination-log
+                    terminationMessagePolicy: File
+                    volumeMounts:
+                    - mountPath: /host
+                      name: host 
+                    - mountPath: /etc/config
+                      name: config-volume
+                      readOnly: true
+                  dnsPolicy: ClusterFirst
+                  restartPolicy: Never
+                  schedulerName: default-scheduler
+                  securityContext: {}
+                  serviceAccountName: pre-cache-agent
+                  priorityClassName: system-cluster-critical
+                  volumes:
+                  - configMap:
+                      defaultMode: 420
+                      name: pre-cache-spec
+                    name: config-volume
+                  - hostPath:
+                      path: /
+                      type: Directory
+                    name: host
+`,
+		},
+		{
+			name:         "create job view",
+			resourceName: "test-job-view",
+			data: templateData{
+				Cluster:               "test",
+				ResourceName:          "test-view",
+				ViewUpdateIntervalSec: 13,
+			},
+			template: templates.MngClusterViewJob,
+			result: `
+apiVersion: view.open-cluster-management.io/v1beta1
+kind: ManagedClusterView
+metadata:
+  name: test-job-view
+  namespace: test
+spec:
+  scope:
+    resource: jobs
+    name: pre-cache
+    namespace: openshift-talo-pre-cache
+    updateIntervalSeconds: 13      
+`,
+		},
+		{
+			name:         "create cm view",
+			resourceName: "test-cm-view",
+			data: templateData{
+				Cluster:               "test",
+				ResourceName:          "test-cm-view",
+				ViewUpdateIntervalSec: 134,
+			},
+			template: templates.MngClusterViewConfigMap,
+			result: `
+apiVersion: view.open-cluster-management.io/v1beta1
+kind: ManagedClusterView
+metadata:
+  name: test-cm-view
+  namespace: test
+spec:
+  scope:
+    resource: configmap
+    name: pre-cache-spec
+    namespace: openshift-talo-pre-cache
+    updateIntervalSeconds: 134`,
+		},
+		{
+			name:         "create sa view",
+			resourceName: "test-sa-view",
+			data: templateData{
+				Cluster:               "test",
+				ResourceName:          "test-sa-view",
+				ViewUpdateIntervalSec: 14,
+			},
+			template: templates.MngClusterViewServiceAcct,
+			result: `
+apiVersion: view.open-cluster-management.io/v1beta1
+kind: ManagedClusterView
+metadata:
+  name: test-sa-view
+  namespace: test
+spec:
+  scope:
+    resource: serviceaccounts
+    name: pre-cache-agent
+    namespace: openshift-talo-pre-cache
+    updateIntervalSeconds: 14`,
+		},
+		{
+			name:         "create crb view",
+			resourceName: "test-crb-view",
+			data: templateData{
+				Cluster:               "test",
+				ResourceName:          "test-crb-view",
+				ViewUpdateIntervalSec: 16,
+			},
+			template: templates.MngClusterViewClusterRoleBinding,
+			result: `
+apiVersion: view.open-cluster-management.io/v1beta1
+kind: ManagedClusterView
+metadata:
+  name: test-crb-view
+  namespace: test
+spec:
+  scope:
+    resource: clusterrolebinding
+    name: pre-cache-crb
+    updateIntervalSeconds: 16      
+`,
+		},
+		{
+			name:         "create ns view",
+			resourceName: "test-ns-view",
+			data: templateData{
+				Cluster:               "test",
+				ResourceName:          "test-ns-view",
+				ViewUpdateIntervalSec: 17,
+			},
+			template: templates.MngClusterViewNamespace,
+			result: `
+apiVersion: view.open-cluster-management.io/v1beta1
+kind: ManagedClusterView
+metadata:
+  name: test-ns-view
+  namespace: test
+spec:
+  scope:
+    resource: namespaces
+    name: openshift-talo-pre-cache
+    updateIntervalSeconds: 17
+`,
+		},
+		{
+			name:         "delete ns",
+			resourceName: "delete-ns-action",
+			data: templateData{
+				Cluster: "test",
+			},
+			template: templates.MngClusterActDeletePrecachingNS,
+			result: `
+apiVersion: action.open-cluster-management.io/v1beta1
+kind: ManagedClusterAction
+metadata:
+  name: delete-ns-action
+  namespace: test
+spec:
+  actionType: Delete
+  kube:
+    resource: namespace
+    name: openshift-talo-pre-cache
+`,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &ClusterGroupUpgradeReconciler{
+				Log: logr.Discard(),
+			}
+			obj := &unstructured.Unstructured{}
+			w, err := r.renderYamlTemplate(tc.resourceName, tc.template, tc.data)
+			if err != nil {
+				t.Errorf("error rendering yaml template: %v", err)
+			}
+			// decode YAML into unstructured.Unstructured
+			dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+			renderedObject, _, err := dec.Decode(w.Bytes(), nil, obj)
+			if err != nil {
+				t.Errorf("error serializing yaml template: %v", err)
+			}
+			obj1 := &unstructured.Unstructured{}
+			desiredObject, _, err := dec.Decode([]byte(tc.result), nil, obj1)
+			if err != nil {
+				t.Errorf("error serializing yaml string: %v", err)
+			}
+			assert.Equal(t, true, reflect.DeepEqual(renderedObject, desiredObject))
+		})
+	}
+}
+
+func TestMCR_getView(t *testing.T) {
+	testcases := []struct {
+		name         string
+		data         templateData
+		template     string
+		resourceName string
+
+		create bool
+	}{
+		{
+
+			name:         "Create and test view",
+			resourceName: "ns-view",
+			data: templateData{
+				Cluster: "test",
+			},
+			template: templates.MngClusterViewNamespace,
+			create:   true,
+		},
+		{
+			name:         "test non-existing view",
+			resourceName: "ns-view",
+			data: templateData{
+				Cluster: "test",
+			},
+			template: templates.MngClusterViewNamespace,
+			create:   false,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &ClusterGroupUpgradeReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects().Build(),
+				Log:    logr.Discard(),
+				Scheme: scheme.Scheme,
+			}
+
+			obj := &unstructured.Unstructured{}
+			w, err := r.renderYamlTemplate(tc.resourceName, tc.template, tc.data)
+			if err != nil {
+				t.Errorf("error rendering yaml template: %v", err)
+			}
+			dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+			_, _, err = dec.Decode(w.Bytes(), nil, obj)
+			if err != nil {
+				t.Errorf("error serializing yaml template: %v", err)
+			}
+			if tc.create {
+				if err := r.Create(context.TODO(), obj); err != nil {
+					t.Errorf("error creating a configmap: %v", err)
+				}
+			}
+			_, found, err := r.getView(context.TODO(), tc.resourceName, tc.data.Cluster)
+			if err != nil {
+				t.Errorf("error getting a view: %v", err)
+			}
+			assert.Equal(t, found, tc.create)
+		})
+	}
+}
+
+func TestMCR_createResourcesFromTemplates(t *testing.T) {
+	testcases := []struct {
+		name         string
+		data         templateData
+		templates    []resourceTemplate
+		resourceName string
+
+		create bool
+	}{
+		{
+
+			name: "Create objects from precacheDependenciesCreateTemplates",
+			data: templateData{
+				Cluster: "test",
+			},
+			templates: precacheDependenciesCreateTemplates,
+		},
+		{
+
+			name: "Create objects from precacheDependenciesViewTemplates",
+			data: templateData{
+				Cluster: "test",
+			},
+			templates: precacheDependenciesViewTemplates,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &ClusterGroupUpgradeReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects().Build(),
+				Log:    logr.Discard(),
+				Scheme: scheme.Scheme,
+			}
+
+			err := r.createResourcesFromTemplates(context.TODO(), &tc.data, tc.templates)
+			if err != nil {
+				t.Errorf("error returned from createResourcesFromTemplates: %v", err)
+			}
+			for _, item := range tc.templates {
+				var obj = &unstructured.Unstructured{}
+				var kind string
+				var group string
+				if strings.Contains(item.resourceName, "view") {
+					group = "view.open-cluster-management.io"
+					kind = "ManagedClusterView"
+				} else {
+					group = "action.open-cluster-management.io"
+					kind = "ManagedClusterAction"
+				}
+				obj.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   group,
+					Kind:    kind,
+					Version: "v1beta1",
+				})
+				err = r.Get(context.TODO(), types.NamespacedName{
+					Name:      item.resourceName,
+					Namespace: tc.data.Cluster,
+				}, obj)
+				assert.Equal(t, err, nil)
+			}
+		})
+	}
+}

--- a/controllers/overrides_test.go
+++ b/controllers/overrides_test.go
@@ -1,0 +1,87 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	ranv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/api/v1alpha1"
+	utils "github.com/openshift-kni/cluster-group-upgrades-operator/controllers/utils"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestOverrides_getOverrides(t *testing.T) {
+	testcases := []struct {
+		name     string
+		objectNs string
+		readNs   string
+		wrData   map[string]string
+		rdData   map[string]string
+	}{
+		{
+			name:     "Overrides exist",
+			objectNs: "test",
+			readNs:   "test",
+			wrData: map[string]string{
+				"precache.image":                "test-image:test-tag",
+				"platform.image":                "test-platform-image:test-tag",
+				"operators.indexes":             "registry.example.com:5000/test-index:v0.0",
+				"operators.packagesAndChannels": "local-storage-operator: stable\nperformance-addon-operator: 4.9\nptp-operator: stable\nsriov-network-operator: stable",
+			},
+			rdData: map[string]string{
+				"precache.image":                "test-image:test-tag",
+				"platform.image":                "test-platform-image:test-tag",
+				"operators.indexes":             "registry.example.com:5000/test-index:v0.0",
+				"operators.packagesAndChannels": "local-storage-operator: stable\nperformance-addon-operator: 4.9\nptp-operator: stable\nsriov-network-operator: stable",
+			},
+		},
+		{
+			name:     "Overrides don't exist",
+			objectNs: "dummy",
+			readNs:   "test",
+			wrData: map[string]string{
+				"precache.image":                "test-image:test_tag",
+				"platform.image":                "test-platform-image:test_tag",
+				"operators.indexes":             "registry.example.com:5000/test-index:v0.0",
+				"operators.packagesAndChannels": "local-storage-operator: stable\nperformance-addon-operator: 4.9\nptp-operator: stable\nsriov-network-operator: stable",
+			},
+			rdData: map[string]string{},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &ClusterGroupUpgradeReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects().Build(),
+				Log:    logr.Discard(),
+				Scheme: scheme.Scheme,
+			}
+
+			cm := &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      utils.OperatorConfigOverrides,
+					Namespace: tc.objectNs,
+				},
+				Data: tc.wrData,
+			}
+
+			if err := r.Create(context.TODO(), cm); err != nil {
+				t.Errorf("error creating a configmap: %v", err)
+			}
+			var cgu ranv1alpha1.ClusterGroupUpgrade
+			cgu.Namespace = tc.readNs
+			res, err := r.getOverrides(context.TODO(), &cgu)
+			if err != nil {
+				t.Errorf("error reading a configmap: %v", err)
+			}
+			assert.Equal(t, tc.rdData, res)
+		})
+	}
+}

--- a/controllers/precache.go
+++ b/controllers/precache.go
@@ -95,9 +95,8 @@ func (r *ClusterGroupUpgradeReconciler) getImageForVersionFromUpdateGraph(
 //      - CatalogSource: must be explicitly configured to be precached.
 //        All the clusters in the CGU must have same catalog source(s)
 // returns: precachingSpec, error
-// nolint:unparam
 func (r *ClusterGroupUpgradeReconciler) extractPrecachingSpecFromPolicies(
-	ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade,
+	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade,
 	policies []*unstructured.Unstructured) (ranv1alpha1.PrecachingSpec, error) {
 
 	var spec ranv1alpha1.PrecachingSpec
@@ -211,7 +210,7 @@ func (r *ClusterGroupUpgradeReconciler) deployDependencies(
 	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade,
 	cluster string) (bool, error) {
 
-	spec := r.getPrecacheSpecTemplateData(ctx, clusterGroupUpgrade)
+	spec := r.getPrecacheSpecTemplateData(clusterGroupUpgrade)
 	spec.Cluster = cluster
 	msg := fmt.Sprintf("%v", spec)
 	r.Log.Info("[deployDependencies]", "getPrecacheSpecTemplateData",
@@ -257,9 +256,7 @@ func (r *ClusterGroupUpgradeReconciler) getPrecacheimagePullSpec(
 // getPrecacheSpecTemplateData: Converts precaching payload spec to template data
 // returns: precacheTemplateData (softwareSpec)
 //          error
-//nolint:unparam
 func (r *ClusterGroupUpgradeReconciler) getPrecacheSpecTemplateData(
-	ctx context.Context,
 	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) *templateData {
 
 	rv := new(templateData)

--- a/controllers/precacheFsm.go
+++ b/controllers/precacheFsm.go
@@ -78,7 +78,7 @@ func (r *ClusterGroupUpgradeReconciler) precachingFsm(ctx context.Context,
 			return nil
 		}
 
-		spec, err := r.extractPrecachingSpecFromPolicies(ctx, clusterGroupUpgrade, managedPoliciesPresent)
+		spec, err := r.extractPrecachingSpecFromPolicies(clusterGroupUpgrade, managedPoliciesPresent)
 		if err != nil {
 			return err
 		}
@@ -130,7 +130,7 @@ func (r *ClusterGroupUpgradeReconciler) precachingFsm(ctx context.Context,
 		switch currentState {
 		// Initial State
 		case PrecacheStateNotStarted:
-			nextState, err = r.handleNotStarted(ctx, clusterGroupUpgrade, cluster)
+			nextState, err = r.handleNotStarted(ctx, cluster)
 			if err != nil {
 				return err
 			}
@@ -172,9 +172,7 @@ func (r *ClusterGroupUpgradeReconciler) precachingFsm(ctx context.Context,
 
 // handleNotStarted handles conditions in PrecacheStateNotStarted
 // returns: error
-//nolint:unparam
 func (r *ClusterGroupUpgradeReconciler) handleNotStarted(ctx context.Context,
-	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade,
 	cluster string) (string, error) {
 
 	currentState, nextState := PrecacheStateNotStarted, PrecacheStatePreparingToStart
@@ -201,13 +199,11 @@ func (r *ClusterGroupUpgradeReconciler) handleNotStarted(ctx context.Context,
 
 // handlePreparing handles conditions in PrecacheStatePreparingToStart
 // returns: error
-//nolint:unparam
 func (r *ClusterGroupUpgradeReconciler) handlePreparing(ctx context.Context,
 	cluster string) (string, error) {
 
-	//nolint:ineffassign
-	currentState, nextState := PrecacheStatePreparingToStart, PrecacheStatePreparingToStart
-	//nolint:ineffassign
+	currentState := PrecacheStatePreparingToStart
+	var nextState string
 	var condition string
 	condition, err := r.getPreparingConditions(ctx, cluster, precacheNSViewTemplates[0].resourceName)
 	if err != nil {

--- a/pre-cache/test.sh
+++ b/pre-cache/test.sh
@@ -49,24 +49,24 @@ echo "Testing common functions:"
 # shellcheck disable=SC2154
 result=$(pull_index "temp" $pull_secret_path)
 [[ $? -eq 0 ]] || fatal "pull_index unexpected exit code"
-[[ $result == "pull --quiet temp --root=/cache --authfile=$pull_secret_path" ]] || fatal "Index pull failure"
+[[ $result == "pull --quiet temp --authfile=$pull_secret_path" ]] || fatal "Index pull failure"
 echo " Index pull pass"
 
 result=$(mount_index test)
 [[ $? -eq 0 ]] || fatal "mount_index unexpected exit code"
-[[ $result == "--root=/cache image mount test" ]]  || fatal "Index image mount failure"
+[[ $result == "image mount test" ]]  || fatal "Index image mount failure"
 echo " Index image mount pass"
 
 result=$(unmount_index test)
 [[ $? -eq 0 ]] || fatal "mount_index_image unexpected exit code"
-[[ $result == "--root=/cache image unmount test" ]]  || fatal "Index image unmount failure"
+[[ $result == "image unmount test" ]]  || fatal "Index image unmount failure"
 echo " Index image unmount pass"
 
 # Test olm
 echo "Testing olm unit:"
 result=$(extract_packages)
 [[ $result == "package1,package2" ]]  || fatal "Package name extraction failure"
-echo " extract_packages - OK"
+echo " extract_packages - pass"
 
 # Test release
 echo "Testing release unit:"


### PR DESCRIPTION
Adds unit tests for `managedclusterresources` and `overrides`.
Replaces one usage instance of dynamic client by the builtin client.
Fixes bugs in pre-cache script unit test and adds it to the Makefile
`unittests` target.
Removes lint overrides and fixes lint errors.
This increases the unit test coverage from 5% to 7.5%.
The work will continue after the `failed upgrade recovery` changes merge in.
/cc @danielmellado  @irinamihai  @rcarrillocruz  @sabbir-47 
