### PR TITLE
cleanup backup view and job if upgrade succeeds

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -338,10 +338,10 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 				}
 
 				if isUpgradeComplete {
-					err = r.precachingCleanup(ctx, clusterGroupUpgrade)
+					err = r.jobAndViewCleanup(ctx, clusterGroupUpgrade)
 					if err != nil {
-						msg := fmt.Sprint("Precaching cleanup failed with error:", err)
-						r.Recorder.Event(clusterGroupUpgrade, corev1.EventTypeWarning, "PrecachingCleanupFailed", msg)
+						msg := fmt.Sprint("Job and managedclusterview cleanup failed with error:", err)
+						r.Recorder.Event(clusterGroupUpgrade, corev1.EventTypeWarning, "JobAndViewCleanupFailed", msg)
 					}
 					meta.SetStatusCondition(&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
 						Type:    "Ready",


### PR DESCRIPTION
- Refactored  precachingCleanup function to jobAndViewCleanup
- When upgrade succeeds jobAndViewCleanup function removes
both view and stale job for backup and precaching

/cc @vitus133 @rcarrillocruz @donpenney @danielmellado 
Signed-off-by: Sabbir Hasan <sahasan@redhat.com>