### PR TITLE
Fix make deploy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG) && PRECACHE_IMG=$(PRECACHE_IMG) RECOVERY_IMG=$(RECOVERY_IMG) envsubst < related-images/in.yaml > related-images/patch.yaml 
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ following states:
 1. Run **make docker-build docker-push IMG=*your_repo_image***
 2. Run **make deploy IMG=*your_repo_image***
 
+Depending on how the ClusterGroupUpgrade CR is defined, the operator may create pre-caching and/or recovery workloads on the spoke clusters. To specify custom workload images, follow the examples below.
+### How to deploy with pre-caching
+1. Run **make docker-build docker-push IMG=*your_repo_image***
+1. Run **PRECACHE_IMG=*your_precache_repo_image* make docker-build-precache docker-push-precache**
+1. Run **make deploy IMG=*your_repo_image* PRECACHE_IMG=*your_precache_repo_image***
+
+### How to deploy with failed upgrade recovery
+1. Run **make docker-build docker-push IMG=*your_repo_image***
+1. Run **RECOVERY_IMG=*your_recovery_repo_image* make docker-build-recovery docker-push-recovery**
+1. Run **make deploy IMG=*your_repo_image* RECOVERY_IMG=*your_recovery_repo_image***
+
 ## How to test
 
 1. Export **KUBECONFIG** environment variable to point to your cluster running RHACM


### PR DESCRIPTION
Related images are now passed to the deployment
as environment variables created by environment substitution.
This commit fixes a bug when the substitution
wasn't done for the make deploy target.
In addition, "How to deploy" readme chapter was updated for the case
when pre-caching / recovery are required

Signed-off-by: Vitaly Grinberg <vgrinber@redhat.com>

/cc @irinamihai @danielmellado @donpenney @rcarrillocruz @sabbir-47 