### PR TITLE
Make image tags consistent with upstream builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.3
+VERSION ?= 4.11.0
 
 # You can use podman or docker as a container engine. Notice that there are some options that might be only valid for one of them.
 ENGINE ?= docker

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=cluster-group-upgrades-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.19.1
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.16.0-ocp
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -16,9 +16,9 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-v1.19.1
+    operators.operatorframework.io/builder: operator-sdk-v1.16.0-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: cluster-group-upgrades-operator.v0.0.3
+  name: cluster-group-upgrades-operator.v4.11.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -52,9 +52,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'This field holds a label common to multiple clusters that will
-          be updated. The expected format is as follows: clusterSelector: - label1Name=label1Value
-          - label2Name=label2Value If the value is empty, then the expected format
-          is: clusterSelector: - label1Name All the clusters matching the labels specified
+          be updated. The expected format is as follows: clusterSelector:   - label1Name=label1Value   -
+          label2Name=label2Value If the value is empty, then the expected format is:
+          clusterSelector:   - label1Name All the clusters matching the labels specified
           in clusterSelector will be included in the update plan.'
         displayName: Cluster Selector
         path: clusterSelector
@@ -266,9 +266,7 @@ spec:
           - create
         serviceAccountName: cluster-group-upgrades-controller-manager
       deployments:
-      - label:
-          control-plane: controller-manager
-        name: cluster-group-upgrades-controller-manager
+      - name: cluster-group-upgrades-controller-manager
         spec:
           replicas: 1
           selector:
@@ -300,10 +298,10 @@ spec:
                 - /manager
                 env:
                 - name: PRECACHE_IMG
-                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:0.0.3
+                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.11.0
                 - name: RECOVERY_IMG
-                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-recovery:0.0.3
-                image: quay.io/openshift-kni/cluster-group-upgrades-operator:0.0.3
+                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-recovery:4.11.0
+                image: quay.io/openshift-kni/cluster-group-upgrades-operator:4.11.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -379,4 +377,4 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 0.0.3
+  version: 4.11.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: cluster-group-upgrades-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.19.1
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.16.0-ocp
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,6 +13,6 @@ configMapGenerator:
 images:
 - name: controller
   newName: quay.io/openshift-kni/cluster-group-upgrades-operator
-  newTag: 0.0.3
+  newTag: 4.11.0
 patchesStrategicMerge:
 - related-images/patch.yaml

--- a/config/manifests/bases/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -38,9 +38,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'This field holds a label common to multiple clusters that will
-          be updated. The expected format is as follows: clusterSelector: - label1Name=label1Value
-          - label2Name=label2Value If the value is empty, then the expected format
-          is: clusterSelector: - label1Name All the clusters matching the labels specified
+          be updated. The expected format is as follows: clusterSelector:   - label1Name=label1Value   -
+          label2Name=label2Value If the value is empty, then the expected format is:
+          clusterSelector:   - label1Name All the clusters matching the labels specified
           in clusterSelector will be included in the update plan.'
         displayName: Cluster Selector
         path: clusterSelector


### PR DESCRIPTION
This makes image tags of the deployment and related images consistent
with the tags applied in quay to the images pushed by the upstream CI.
This is needed for installing the upstream built operator.
If this is not done, the operator installation will fail because of
image pull error.
In addition it reverts the operator-sdk version to the latest
one recommended by the OCP documentation (operator-sdk-v1.16.0-ocp).
The latter fixes 'make bundle' failures happening with operator-sdk 1.19.1