### PR TITLE
Bug 2079838: Make image tag consistent with u/s build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.3
+VERSION ?= 4.10.0
 
 # You can use podman or docker as a container engine. Notice that there are some options that might be only valid for one of them.
 ENGINE ?= docker

--- a/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.10.1-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: cluster-group-upgrades-operator.v0.0.3
+  name: cluster-group-upgrades-operator.v4.10.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -290,8 +290,8 @@ spec:
                 - /manager
                 env:
                 - name: PRECACHE_IMG
-                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:0.0.3
-                image: quay.io/openshift-kni/cluster-group-upgrades-operator:0.0.3
+                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.10.0
+                image: quay.io/openshift-kni/cluster-group-upgrades-operator:4.10.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -367,4 +367,4 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 0.0.3
+  version: 4.10.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,6 +13,6 @@ configMapGenerator:
 images:
 - name: controller
   newName: quay.io/openshift-kni/cluster-group-upgrades-operator
-  newTag: 0.0.3
+  newTag: 4.10.0
 patchesStrategicMerge:
 - related-images/patch.yaml


### PR DESCRIPTION
This makes image tags of the deployment and related images consistent
with the tags applied in quay to the images pushed by the upstream CI.
This is needed for installing the upstream built operator.
If this is not done, the operator installation will fail because of
image pull error.

/cc @danielmellado @donpenney  @jc-rh  @nishant-parekh @rcarrillocruz @sabbir-47 