### PR TITLE
recovery: Restore /var/lib/kubelet after reboot

### DIFF
--- a/recovery/bindata/upgrade-recovery.sh
+++ b/recovery/bindata/upgrade-recovery.sh
@@ -319,16 +319,6 @@ function restore_files {
     log_info "Completed restoring /usr/local content"
 
     #
-    # Restore /var/lib/kubelet content
-    #
-    log_info "Restoring /var/lib/kubelet content"
-    time with_retries 3 1 rsync -avc --delete --no-t ${BACKUP_DIR}/kubelet/ /var/lib/kubelet/
-    if [ $? -ne 0 ]; then
-        fatal "Failed to restore /var/lib/kubelet content"
-    fi
-    log_info "Completed restoring /var/lib/kubelet content"
-
-    #
     # Restore /etc content
     #
     log_info "Restoring /etc content"
@@ -364,6 +354,16 @@ function restore_files {
 }
 
 function restore_cluster {
+    #
+    # Restore /var/lib/kubelet content
+    #
+    log_info "Restoring /var/lib/kubelet content"
+    time with_retries 3 1 rsync -avc --delete --no-t ${BACKUP_DIR}/kubelet/ /var/lib/kubelet/
+    if [ $? -ne 0 ]; then
+        fatal "Failed to restore /var/lib/kubelet content"
+    fi
+    log_info "Completed restoring /var/lib/kubelet content"
+
     #
     # Start crio, if needed
     #

--- a/recovery/generated/zz_generated.bindata.go
+++ b/recovery/generated/zz_generated.bindata.go
@@ -375,16 +375,6 @@ function restore_files {
     log_info "Completed restoring /usr/local content"
 
     #
-    # Restore /var/lib/kubelet content
-    #
-    log_info "Restoring /var/lib/kubelet content"
-    time with_retries 3 1 rsync -avc --delete --no-t ${BACKUP_DIR}/kubelet/ /var/lib/kubelet/
-    if [ $? -ne 0 ]; then
-        fatal "Failed to restore /var/lib/kubelet content"
-    fi
-    log_info "Completed restoring /var/lib/kubelet content"
-
-    #
     # Restore /etc content
     #
     log_info "Restoring /etc content"
@@ -420,6 +410,16 @@ function restore_files {
 }
 
 function restore_cluster {
+    #
+    # Restore /var/lib/kubelet content
+    #
+    log_info "Restoring /var/lib/kubelet content"
+    time with_retries 3 1 rsync -avc --delete --no-t ${BACKUP_DIR}/kubelet/ /var/lib/kubelet/
+    if [ $? -ne 0 ]; then
+        fatal "Failed to restore /var/lib/kubelet content"
+    fi
+    log_info "Completed restoring /var/lib/kubelet content"
+
     #
     # Start crio, if needed
     #


### PR DESCRIPTION
Moved the restore of /var/lib/kubelet from the first stage of recovery
to the start of the second stage, after the reboot. As kubelet.service
is shutdown and disabled during the first stage to prevent it coming
up after the reboot until launched by the recovery utility, this will
ensure there are no open references to these files that would cause
the restore rsync to fail.

Signed-off-by: Don Penney <dpenney@redhat.com>