### PR TITLE
 Bug 2083631 Reset batch start time on batch timeout

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -339,6 +339,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 							})
 						} else {
 							r.Log.Info("Batch upgrade timed out")
+							clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt = metav1.Time{}
 							if clusterGroupUpgrade.Status.Status.CurrentBatch < len(clusterGroupUpgrade.Status.RemediationPlan) {
 								clusterGroupUpgrade.Status.Status.CurrentBatch++
 							}


### PR DESCRIPTION
It's getting reset in the batch complete case only right now. This PR added the missing line for the timeout case.