### PR TITLE
Enable disconnected features

### DIFF
--- a/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -16,6 +16,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.16.0-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: cluster-group-upgrades-operator.v4.11.0
@@ -117,6 +118,8 @@ spec:
         path: precaching
       - displayName: Remediation Plan
         path: remediationPlan
+      - displayName: Safe Resource Names
+        path: safeResourceNames
       - displayName: Status
         path: status
       version: v1alpha1

--- a/bundle/manifests/ran.openshift.io_clustergroupupgrades.yaml
+++ b/bundle/manifests/ran.openshift.io_clustergroupupgrades.yaml
@@ -317,6 +317,10 @@ spec:
                     type: string
                   type: array
                 type: array
+              safeResourceNames:
+                additionalProperties:
+                  type: string
+                type: object
               status:
                 description: UpgradeStatus defines the observed state of the upgrade
                 properties:

--- a/config/manifests/bases/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
   name: cluster-group-upgrades-operator.v0.0.0
   namespace: placeholder
 spec:
@@ -103,6 +104,8 @@ spec:
         path: precaching
       - displayName: Remediation Plan
         path: remediationPlan
+      - displayName: Safe Resource Names
+        path: safeResourceNames
       - displayName: Status
         path: status
       version: v1alpha1


### PR DESCRIPTION
Enable image referencing by digest instead of tags when making bundle
Add annotation for disconnected OLM capability as recommended by docs
Fix "make catalog-build" target

This only enables bundle to be built with digests, but does not change the default from tags (the latter can be changed after ensuring no harm is done to downstream digest mapping).
To build bundle with digests run "USE_IMAGE_DIGESTS=true make bundle".
This will make bundle references container images and related images by digests, but environment variables for pre-caching and recovery will still use tags.

Please note, this can't be backported without bumping the operator-sdk version

/cc @nishant-parekh @donpenney @jc-rh @danielmellado @rcarrillocruz @sabbir-47 

