### PR TITLE
Fix crashing on policies with no annotations

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -877,6 +877,9 @@ func (r *ClusterGroupUpgradeReconciler) copyManagedInformPolicy(
 
 	// Set new policy annotations - copy them from the managed policy.
 	annotations := managedPolicy.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
 	annotations[utils.DesiredResourceName] = name
 	newPolicy.SetAnnotations(annotations)
 


### PR DESCRIPTION
Now make an empty map for annotations during `copyManagedInformPolicy`
if the policy has no annotations.

Signed-off-by: Saeid Askari <saskari@redhat.com>