### PR TITLE
Bump golangci-lint version to 1.46.1

### DIFF
--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -3,7 +3,7 @@
 which golangci-lint
 if [ $? -ne 0 ]; then
     echo "Downloading golangci-lint tool"
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.2
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.1
 fi
 
 export GOCACHE=/tmp/


### PR DESCRIPTION
Current version in incompatible with golang v1.18.0

Signed-off-by: Saeid Askari <saskari@redhat.com>