### PR TITLE
Bug 2091113: Query child resources only when new ones are being created 

### DIFF
--- a/controllers/actions.go
+++ b/controllers/actions.go
@@ -150,14 +150,19 @@ func (r *ClusterGroupUpgradeReconciler) deleteResources(
 	if err != nil {
 		return fmt.Errorf("failed to delete PlacementRules for CGU %s: %v", clusterGroupUpgrade.Name, err)
 	}
+	clusterGroupUpgrade.Status.PlacementRules = nil
+
 	err = utils.DeletePlacementBindings(ctx, r.Client, clusterGroupUpgrade.Namespace, labels)
 	if err != nil {
 		return fmt.Errorf("failed to delete PlacementBindings for CGU %s: %v", clusterGroupUpgrade.Name, err)
 	}
+	clusterGroupUpgrade.Status.PlacementBindings = nil
+
 	err = utils.DeletePolicies(ctx, r.Client, clusterGroupUpgrade.Namespace, labels)
 	if err != nil {
 		return fmt.Errorf("failed to delete Policies for CGU %s: %v", clusterGroupUpgrade.Name, err)
 	}
+	clusterGroupUpgrade.Status.CopiedPolicies = nil
 
 	clusters, err := r.getAllClustersForUpgrade(ctx, clusterGroupUpgrade)
 	if err != nil {

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -1646,31 +1646,31 @@ func (r *ClusterGroupUpgradeReconciler) getAllClustersForUpgrade(ctx context.Con
 	return clusterNames, nil
 }
 
-/* checkDuplicateChildResources looks up the name and desired name of the new resource u in the list of resource names and the safe name map, before
+/* checkDuplicateChildResources looks up the name and desired name of the new resource in the list of resource names and the safe name map, before
    adding the names to them. If duplicate (with same desired name annotation value) resource is found, it gets deleted, i.e. the new one takes precedence.
 
    returns: the updated childResourceNameList
 */
-func (r *ClusterGroupUpgradeReconciler) checkDuplicateChildResources(ctx context.Context, safeNameMap map[string]string, childResourceNames []string, u *unstructured.Unstructured) ([]string, error) {
-	if desiredName, ok := u.GetAnnotations()[utils.DesiredResourceName]; ok {
+func (r *ClusterGroupUpgradeReconciler) checkDuplicateChildResources(ctx context.Context, safeNameMap map[string]string, childResourceNames []string, newResource *unstructured.Unstructured) ([]string, error) {
+	if desiredName, ok := newResource.GetAnnotations()[utils.DesiredResourceName]; ok {
 		if safeName, ok := safeNameMap[desiredName]; ok {
-			if u.GetName() != safeName {
+			if newResource.GetName() != safeName {
 				// Found an object with the same object name in annotation but different from our records in the names map
 				// This could happen when reconcile calls work on a stale version of CGU right after a status update from a previous reconcile
 				// Or the controller pod fails to update the status after creating objects, e.g. node failure
 				// Remove it as we have created a new one and updated the map
-				r.Log.Info("[checkDuplicateChildResources] clean up stale child resource", "name", u.GetName(), "kind", u.GetKind())
-				err := r.Client.Delete(ctx, u)
+				r.Log.Info("[checkDuplicateChildResources] clean up stale child resource", "name", newResource.GetName(), "kind", newResource.GetKind())
+				err := r.Client.Delete(ctx, newResource)
 				if err != nil {
 					return childResourceNames, err
 				}
 				return childResourceNames, nil
 			}
 		} else {
-			safeNameMap[desiredName] = u.GetName()
+			safeNameMap[desiredName] = newResource.GetName()
 		}
 	}
-	childResourceNames = append(childResourceNames, u.GetName())
+	childResourceNames = append(childResourceNames, newResource.GetName())
 	return childResourceNames, nil
 }
 


### PR DESCRIPTION
During ZTP scale test, it was discovered that the list operations could be too slow when the number of objects in the namespace get higher than a few hundreds, even though the number of objects matching the label selector is fairly small. This change minimizes the use of the list operation so that TALO can sustain higher rate of SNO deployment scenario. It was tested in the scale lab and achieved 100% du profile applied at 50 clusters per 10 minutes (1.5 times the highest rate achieved without this change)