### PR TITLE
Bug 2084962: Remove hard limit of 100 concurrent cluster upgrades

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -1805,18 +1805,12 @@ func (r *ClusterGroupUpgradeReconciler) validateCR(ctx context.Context, clusterG
 	}
 
 	var newMaxConcurrency int
-	// Automatically adjust maxConcurrency to the min of maxConcurrency, number of clusters, 100 or
-	// to the min of number of clusters, 100 if maxConcurrency is set to 0.
-	if clusterGroupUpgrade.Spec.RemediationStrategy.MaxConcurrency > 0 {
-		newMaxConcurrency = utils.GetMinOf3(
-			clusterGroupUpgrade.Spec.RemediationStrategy.MaxConcurrency,
-			len(clusters),
-			utils.MaxNumberOfClustersForUpgrade)
+	// Automatically adjust maxConcurrency to the min of maxConcurrency and the number of clusters.
+	if clusterGroupUpgrade.Spec.RemediationStrategy.MaxConcurrency > 0 &&
+		clusterGroupUpgrade.Spec.RemediationStrategy.MaxConcurrency < len(clusters) {
+		newMaxConcurrency = clusterGroupUpgrade.Spec.RemediationStrategy.MaxConcurrency
 	} else {
 		newMaxConcurrency = len(clusters)
-		if utils.MaxNumberOfClustersForUpgrade < len(clusters) {
-			newMaxConcurrency = utils.MaxNumberOfClustersForUpgrade
-		}
 	}
 
 	if newMaxConcurrency != clusterGroupUpgrade.Status.ComputedMaxConcurrency {

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -90,11 +90,6 @@ const (
 	TestManagedClusterActionFailedMessage  = "ManagedClusterAction failed"
 )
 
-// Upgrade specific constants.
-const (
-	MaxNumberOfClustersForUpgrade = 100
-)
-
 // Reconciling instructions.
 const (
 	ReconcileNow    = 0


### PR DESCRIPTION
- Removed the hard limit of upgrading 100 clusters concurrently
