### PR TITLE
ART-4052: Add requirements for ART bundle creation

### DIFF
--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -1,0 +1,13 @@
+updates:
+  - file: "stable/cluster-group-upgrades-operator.clusterserviceversion.yaml" # relative to this file
+    update_list:
+    - search: "cluster-group-upgrades-operator.v{MAJOR}.{MINOR}.0"
+      replace: "cluster-group-upgrades-operator.{FULL_VER}"
+    - search: "version: {MAJOR}.{MINOR}.0"
+      replace: "version: {FULL_VER}"
+    - search: 'olm.skipRange: ">=4.6.0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.6.0 <{FULL_VER}"'
+  - file: "cluster-group-upgrades-operator.package.yaml"
+    update_list:
+    - search: "currentCSV: cluster-group-upgrades-operator.v{MAJOR}.{MINOR}.0"
+      replace: "currentCSV: cluster-group-upgrades-operator.{FULL_VER}"

--- a/manifests/cluster-group-upgrades-operator.package.yaml
+++ b/manifests/cluster-group-upgrades-operator.package.yaml
@@ -1,0 +1,5 @@
+packageName: cluster-group-upgrades-operator
+channels:
+- name: stable
+  currentCSV: cluster-group-upgrades-operator.v4.10.0
+defaultChannel: stable

--- a/manifests/stable/cluster-group-upgrades-controller-manager-metrics-service_v1_service.yaml
+++ b/manifests/stable/cluster-group-upgrades-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    control-plane: controller-manager
+  name: cluster-group-upgrades-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/manifests/stable/cluster-group-upgrades-controller-manager_v1_serviceaccount.yaml
+++ b/manifests/stable/cluster-group-upgrades-controller-manager_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: cluster-group-upgrades-controller-manager

--- a/manifests/stable/cluster-group-upgrades-manager-config_v1_configmap.yaml
+++ b/manifests/stable/cluster-group-upgrades-manager-config_v1_configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: 9a2365a3.openshift.io
+kind: ConfigMap
+metadata:
+  name: cluster-group-upgrades-manager-config

--- a/manifests/stable/cluster-group-upgrades-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/manifests/stable/cluster-group-upgrades-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: cluster-group-upgrades-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/manifests/stable/cluster-group-upgrades-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/manifests/stable/cluster-group-upgrades-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    control-plane: controller-manager
+  name: cluster-group-upgrades-operator-controller-manager-metrics-svc
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/manifests/stable/cluster-group-upgrades-operator-controller-manager_v1_serviceaccount.yaml
+++ b/manifests/stable/cluster-group-upgrades-operator-controller-manager_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: cluster-group-upgrades-operator-controller-manager

--- a/manifests/stable/cluster-group-upgrades-operator-manager-config_v1_configmap.yaml
+++ b/manifests/stable/cluster-group-upgrades-operator-manager-config_v1_configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: 9a2365a3.openshift.io
+kind: ConfigMap
+metadata:
+  name: cluster-group-upgrades-operator-manager-config

--- a/manifests/stable/cluster-group-upgrades-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/manifests/stable/cluster-group-upgrades-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: cluster-group-upgrades-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/manifests/stable/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/manifests/stable/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -1,0 +1,370 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "ran.openshift.io/v1alpha1",
+          "kind": "ClusterGroupUpgrade",
+          "metadata": {
+            "name": "ClusterGroupUpgrade-sample"
+          },
+          "spec": {
+            "preCaching": true
+          }
+        }
+      ]
+    capabilities: Basic Install
+    operators.operatorframework.io/builder: operator-sdk-v1.10.1-ocp
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+  name: cluster-group-upgrades-operator.v4.10.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: ClusterGroupUpgrade is the Schema for the ClusterGroupUpgrades
+        API
+      displayName: Cluster Group Upgrade
+      kind: ClusterGroupUpgrade
+      name: clustergroupupgrades.ran.openshift.io
+      resources:
+      - kind: Deployment
+        name: ""
+        version: apps/v1
+      - kind: Namespace
+        name: ""
+        version: v1
+      specDescriptors:
+      - displayName: Actions
+        path: actions
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Blocking CRs
+        path: blockingCRs
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'This field holds a label common to multiple clusters that will
+          be updated. The expected format is as follows: clusterSelector:   - label1Name=label1Value   -
+          label2Name=label2Value If the value is empty, then the expected format is:
+          clusterSelector:   - label1Name All the clusters matching the labels specified
+          in clusterSelector will be included in the update plan.'
+        displayName: Cluster Selector
+        path: clusterSelector
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Clusters
+        path: clusters
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: This field determines when the upgrade starts. While false, the
+          upgrade doesn't start. The policies, placement rules and placement bindings
+          are created, but clusters are not added to the placement rule. Once set
+          to true, the clusters start being upgraded, one batch at a time.
+        displayName: Enable
+        path: enable
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:bool
+      - displayName: Managed Policies
+        path: managedPolicies
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: This field determines whether container image pre-caching will
+          be done on all the clusters matching the selector. If required, the pre-caching
+          process starts immediately on all clusters irrespectively of the value of
+          the "enable" flag
+        displayName: PreCaching
+        path: preCaching
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:bool
+      - displayName: Remediation Strategy
+        path: remediationStrategy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - displayName: Computed Maximum Concurrency
+        path: computedMaxConcurrency
+      - displayName: Conditions
+        path: conditions
+      - displayName: Copied Policies
+        path: copiedPolicies
+      - displayName: Managed Policies Compliant Before Upgrade
+        path: managedPoliciesCompliantBeforeUpgrade
+      - displayName: Managed Policies Content
+        path: managedPoliciesContent
+      - description: Contains the managed policies (and the namespaces) that have
+          NonCompliant clusters that require updating.
+        displayName: Managed Policies For Upgrade
+        path: managedPoliciesForUpgrade
+      - displayName: Managed Policies Namespace
+        path: managedPoliciesNs
+      - description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+          Important: Run "make" to regenerate code after modifying this file'
+        displayName: Placement Bindings
+        path: placementBindings
+      - displayName: Placement Rules
+        path: placementRules
+      - displayName: Precaching
+        path: precaching
+      - displayName: Remediation Plan
+        path: remediationPlan
+      - displayName: Status
+        path: status
+      version: v1alpha1
+  description: cluster-group-upgrades-operator is an operator that facilitates platform
+    upgrades of group of clusters
+  displayName: cluster-group-upgrades-operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAZAAAAGQCAIAAAAP3aGbAAAbp0lEQVR4Xu3dfWhc15nH8StpJGtkOdcSQxSaOhrDkkJpkcIugdJQjcu+saGVloTd/rHF44a+wMJaLoQ2fxTLFJou6RJ5octm2zRjtvtHlwSPU7LsltCMS0IgUCI1YVmXgEdxHaIwtWZkSaOX0cweza0nyrEkz8t9Oc+93w/ByOcG4lia332ec885t6tWq1kAIEG3PgAApiKwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGAQWADEILABiEFgAxCCwAIhBYAEQg8ACIAaBBUAMAguAGF21Wk0fA5pWzecrudx2Pt8Y6Ukmu5PJWCrVGAHcQmChTSqnyjMzlcuX9Qu39IyN9YyP96ZSKrxUhOmXgdYRWGhZrVhcTae3Ll3SL+yve3RUxZYKr96pqa6jR/XLQHMILNNtz82pgFC/VotF61bDpSqXoD726k9yM5WqlUr6haapyutQOq2Si7ILrSKwDLWZyWxms6rt2i8anJqlb2pKffL1a55Rf6q16en9/kitUv8L6g+vwkvlr34N2AuBZZyN2dn12dnqwoJ+YR9dtq0+9vGZGa8LFpVWq6dO6aNuILnQJALLIKrbWk2nt+fn9QvNiU1MqNjy6PGcd2m1m5Nc/dPTXocvhCKwTOFWt+VFbKkY3bxwQR/1kjPP1ZdOBzVVBzMRWEZwvX5RH3hVp6gPvH6hRbViUcWoz2m1W+/kZN/UVOf/IwgHAit4rqdVg+qwVLXV9qe9ms+vTE213aK6yJmnUxHMJFfEEVgBq+RyN0+c0EddpWJLZZbqsFqaGNqYnS3PzHTeorqLVjHiCKwgqRJmeXzct1Bw2quD152rHnArm1VR1fxjykD0nTypksvdqTqYj8AK0s1U6oCtLd5x1nDt7Pi7tQBV5VRlbm57bq6l9euBU/8jzlQdBVdEEFiBUT3X2pkz+ijaQsEVEQRWMFRFU0omfWsGI8J5Nsp2xRDjPKxgGDifHQLb8/Orp06pO8Ha9HR114k3CA0qrACoz1Lp+HF9FG6jTwwfKqwAqPJKH4IHNi9cuHnixPL4+GYmo1+DTFRYfqO8CgTPE8OBCstvG9ztg1BdWFg7c6aUTO7MHtZPFoNEVFh+Kx49ynR7sLps+9D0dKtL/2ECKixfbWYypFXg1Ldg/dw51ZivptM8TJSFwPIV/aBRNi9cULFFkygILaF/mG43ltMk9k9PMyVvOCos/2xls/oQzPCHJrE+Ja9fg0mosPyzPD5uwtlSOFiHh4jBUwSWT7bn5pYfeEAfhaliExMDs7OcF2gaWkKfMN0uS+XyZXWD2Tlln/l4k1Bh+aSUTBp+JB72pDrEw5kMGxINQYXlh533NpNWMqlv3M0TJyi1DEFg+WF9dlYfgigb58/fTKXUjUe/AH/REvqB7Tjh0GXbqj3snZrSL8AvVFie28pmSatwUN/Hlb/+aw6rCRCB5blN1ouGy+qpU2RWUGgJvcXZ7WF1+LnnWFzqPyosb9EPhpWqs9hr5T8Cy1v0gyHG6TT+oyX0kOoHi0ND+ihCJDYxcSSX00fhGSosD9EyhF7l8mUm4P1EheUhjmeIgu7RUZvG0C9UWF6p5vOkVRRUFxYosnxDYHmFfjA62HrlGwLLK5wnEx2qlGaboT8ILE+oH1/6wUjh/uQPAssT/PhGDTMA/uApoSc4ri+C7KtXeTOr16iw3MdxfdFEkeUDAst9PDOKpi2WvHuPltB9HNcXTV22fZRjlD1GheUyjmeILPV9Z3GD1wgsl3E8Q5QRWF4jsFzGzGuUMY3lNQLLTZuZDP1glFUILI8RWG6iH4y46sICry/0FIHlGvWTunXpkj6KiKHI8hSB5Rpmr2AxjeUxAss19IOweFDoMRaOuoPj29EwxGfKM1RY7uDMSTQwjeUdAssdnCeDBqaxvENguYDj27Eb01jeIbBcwPNB7EZL6B0CywX0g9iNXdDeIbA6RT+I2xFYHiGwOkV5hdsx7+4R1mF1iuPbcTteB+0RKqyOcHw79sQuaI8QWB2hH8R+eFboBQKrI7/neAbso8K8uwcIrPblcrlB5imwDyosLxBY7cvQD2J/lcuX9SF0jKeEbSoWi8mhoav6MPChI6+8Ekul9FF0gAqrTaq84vB2HIzlo64jsNo0W3+98wpnYGF/LB91HYHVjlwut1BffvVGX59+DbiFeXfXEVjtcMor5dzi4kevAB+qlUpVniO7isBqWT6fv3Rr+dVblvXOyMhHrwMfoshyF4HVMm01wzcpsrA/prHcRWC1TAusVy3rlxRZ2AcPCt1FYLUmm8060+27Pba4uNnfrw0Cyvb8PLugXURgtWbP1e0ly3p0fV0fBeqYxnIRgdWC3dPtGtUYvpBI6KMAu6BdRWC1YM/yquGrhcIVMgu3ocJyEXsJP+T8YNWKxcYtcXturjEBob5+qrv7e0tLt/71PdiW9XoicU+hoF9AtPEuaLdELrBUAO0cE5rPb+fz1cY/t82j7+l4fbrqYJ+2rJfj8d5yWb+ACGMXtFtCHlhOPG3lck4wdXLix2vHjn3h2jV9dC9kFjQDTz99aHpaH0XrQhhYKqFUc6dCyt0D179sWS/pY/sis7Bb7+TkIG/bdUNIAktVT1vZrAopFVW10h37tnY00w/u9rBl/bs+hojqsu2jrMZyg+zAUjXURiajosrFSmpPhZGR+1vfgqMy6yfUWaizr17tTib1UbRI5LIGVU+tTU+XksnlBx7YOH/e67RSXo/F9KEmqBbyT8vlrXhcv4DoYXGDK4QF1mYmczOVKh0/7k9ONVxZW9OHmvMWmYU6dkG7QkxgqahSJdXqqVOdPOlr268OXH51MCezlm1bv4AoYRe0KwQEViOq/Cyp3KUya6xUem94WL+AyGAXtCuMDizV9i+Pj5sQVa/qAy0rWdZnb9x4g707EcY0VucMDSx1L1qbnr554oS6L+nXxFKZ9ZeFAnukI4td0J0zMbCcwmrj/Hn9Qih8tVB4PB6vDAzoFxB2VFidM24d1sbs7NqZM/po0FpdNXpHn7asn9v2Xd6scYWx2AXdIbMqrNV02sC0sur54i5nGp4praihyOqQKYFVKxZVWm1euKBfMIMXSxKcKa1nWO4QJSxu6JApgWVyWikPj47qQy55olSasCxWaUUEy0c7ZERgqbTa2ufoYUN8plLRh9xDexgdVFgdCj6wyjMzJtdWjtHr1z0tgZz2kKeHoVddWCj+5jf6KJoWcGBVcrn1c+f0USM9pA+479ly+U/W1jgYPtz+78c/1ofQtCADy5lo10dN9a1jx/QhD7yr2s9C4bv9/ZRaYVV79119CE0LMrBUMxj4npvmferaNU+7wt2eXl+n1AqropyfeQMFFljVfF7cWvZv+/gszym1Ho/Head0yHx8aanILuh2BRZYqrzSh4z3lc1N/xKr7tly+RPr678cGdEvQLIcixvaFUxgqfLK/CeDt+stl/0sshwly3p0cfGLlvU+HWJYEFhtCyaw1mdn9SEh/C+yHK9a1ifrk/EcXhoCBFbbggmsLbGvPFJF1g+Cq3SeXl+/v1ymQxStWK3Oh+jQJJ8FEFjuvi7Qf48UCq7vhW6e0yFOWNY7xJZMb3fvfOgostoTQGBtZDL6kDQ/C67IcrxlWQ/WJ7bYhCjO75aXLQKrXQEEVghO2LinUHjSgKR41bKSpdLj8TixJYjzQhMCqz0BHOC31NWlD8k0Ua90DPFYPP6dvj5OBDRf4zBI/z96IeB3hRWC8qpBNYbmFDbPlstjpdIzts1jRJO9n0g0bikUWW3wO7Cq+bw+JJZqDJ8x6c1dpfrpWveXyyq2VoaG9MswwE+3txtfz3HUTOv8DqztEAWW8uc3bpwxbOuME1v3LS0xt2Wgn+56Iy8VVhv8Dqzw+c76+qNGnqygmkRnSp4l8oZ4Z2Rk90EN6y+/vLP/P1y3cK/5HVhhmsNq+GGtFuDKrIOp2PpkofBF1m0Z4JuLi7t/+97q6vq5c6Xjx1fTaWKrSX4HVij1lssvx+PGZpZVXwDx4OLiuGX9cmSEWflAvJFIaO8Pbzxi3rxwgdhqEoHlDpVZRj003NO79VXy95fLPxgaYnrLT5WBga8VCvqoZS3ce2/ja2KrGQSWa+4pFF4bHjY/BkqW9b2lpWSppPrE13w5RhVP1Gq7Z68aXo/FtBFi62AElps+duOGiMxyqA7lC9euHbcsCi5P/WJ4+NlyWR+te2mfTbVObK1NT9c46u+j/A6s7mRSHwoXWZll7Sq4Jpjh8oBKqy/duKGP3nLwTomN8+dLyeSG2LOYvEBguU9cZjneqs9wjZTLX7ast2kV3XBwWln1WcWD7xC1UmntzJnl8fFQPl5vg++BdfSoPhRGKrOu9Peb/NzwAC9Z1ufqreLj8TjJ1bY7ppXjvSY2S2zPz988cWI1naZD9DuwesbH9aGQ6ltfN3ytw8FK9TVcJFcbKgMD6m+smbSy9pp338/OxFYyKffwS1f4fVqDukUUo7TNTf3sPlGr7TfnKs7DlvWNY8fGVlYGd20xwW7vJxJ/WygcPDm122Px+FMt/nj0Tk4ezmS6otGsaPwOLEXdJUSfONqG7/b3P72+ro9KpirHr4yMpGKx0evX9WtRtRWPf79Wa/Ubrf4mL+tjd9Zl24PZbCyV0i+EXQCBpVpxia/M6dAvhoe/fuNG+E6rsi3rIcv6m3vv/Uylkvjo1pPoUFH1k76+75faPI2sqdZxL4dOnx6I2DPEAAJrM5NZPXVKH42A94aH/+rGjT0XEIbDffV6IVLhtTI09B/VattR5fjtyEjbf109Y2Oq1IrCw3dHAIFVzedLx4/ro9GgbsWPlMvanrJQsuvh9Ui9bfzYjRu9LU7TmO/tY8f+8dq1l/ThdvxmdPTjHUySqPbwcCbTOzWlXwijAAJLWR4f347wm46ese0nOroly+MUXw+PjqriS25+qfvNlUTiQqHwfLns4vfv58eOffbaNX20Rf1nz8YFvk29VcEE1sbs7NqZM/polFypP0sKcXt4MKf++tzQ0CcGBh6IxUY++MDYCFMhpXr5XKXywuKiR6Xxv4yOfqmDCquh7+TJgdnZcD89DCawotwVNqhPwt93dT2/tqZfiKqH6kGmqrDDlYpKsf719bZndjqxMjT0+4GB12OxX3/wwRvlcvMLFNrmVmBZ9SmtI7lciDMrmMBSVqamti5d0kejJ6xPD1306XqQOVnmjKi+sufWess2qjN1q1i8+271xXal4qzbVNl0pd7l+RBPt3OlJWzoHh0dzGbDukI7sMCq5HI3T5zQRyNp2bb/rlTyqN2A+TqcdL9dl22rOiuUmeX31pyGWCrVfeuGGXF3lUovWtaPjD//D1LUSqWbqdR2GN/KE1hgKVF4qNG8RwqFedt+SB9G+LlbXjnCmlmBtYSOCG7TuaM36g8QmdWKiPssy7tQCV9vGGSFZVFk7eXBQuG38bhprzuER/7swPOwOhS+OivgCsuiyNrf+4nE1woFJuPDzd1HhHsKU50VcIWlHM5k9CHU3VMovGhZz4+MMBkfYg/u9TYdd6k6a2VqKhyH/wUfWLFUqndyUh/FLZ9fXFQd4pM2b4kIoYfrL4jTRz2gmhjVG4Ygs4IPLGVnPwGfx/2pn+mvl0rztv2Yl/Md8N+3fDzHdXt+fm16Wh+VxojA6k4mmX2/o7tKpafK5TxLH8LiPsv6lMezV5rNCxekv4Mn+En3hogf4dCSd0ZGvunZXlz44/mRkc8HsVnyyCuvyD2q1KDAqubzKrNqETt3pRPEllyqTH5RH/NJl23b+bzQDdJGtIQOGsNW/dHiovqhf2NkhCZRnH9LJPQhv6iaYDWd1keFMKjCcnCKQ3tUtfXM8nJoXs8Tbk/a9teD7iQGL16UeEipcYFVKxZVY8hS0vYs2/Z3NzeJLZMF2AzuJrQxNKgldKi/wcFovyqyE86TxEXWbZnqPst6wYy1KUIbQ+MCy6q/Hfrwc8/po2ias27rav05lNxXT4ePuoX81/CwPytFm7F16VIll9NHzWZcS9gQzdcXeuH9ROKfVlfpE4Ol0uq14eGPNff+et90j46qxlAfNZi5gaXcTKUql9t4LS72sBWPv3j48D+38hZ1uMXMtHKobqZPTm9odGDVisWdwzFYTeoqp+By90VVOIDqyn+WSNzj/Sbn9sgqsowOLKueWaVkktWkXnjt2LF/delVoNjPowMDP6zVzJm32pOgIsv0wFK25+Z2NpqTWd6gVfTOjxKJR0wtrHYTVGQJCCyLzPLFytDQ//T0kFyuMLwNvJ2UIktGYFlklo9Ucr0yMPCf16/TLbbBtqwfCCmsdotNTByRsMRBTGBZvMrQd6pbfCORyBYKzNA36Unb/srmpuEzVvu56803zT9G2cSFo/uJpVIsKPWT+uB99tq1p8rlq5b1v4nE0yxD3d9j8Xi+vkNQaFopGxIOK5dUYTlUnbVzQDW9YUBU2XUlkfjvlZWfLy0x26UawG9Lrqp2EzH1Li+wLOazjBHl8HrYsr7h/QtvfGZ+VygysCwyyzwqvN4bHn49FntpYeFVywrrN0Y1xf+QSPzF9vbg0pJ+Tb5Dp08PmH2GstTAssgss60MDeUHB3+9ufnC4uK7lvWufl0Su34mjKqnxlZWQplTDT1jY3eZ/dZVwYFl1U9VXpmaYu+O+VT9tXj33W9WKlfW1n5V7x8Nv8/Y9WLqkZGRVCw2ev26fjm8ji4tmXxIluzAsthvKNnvRkeL1erb3d2/W15WKaYiLMCJsPvq/6iE+uO+vmTYK6kDGP6KCvGBZdUza216mrNoQkMFmfp1oVq91r2z7OalhQWnHHMl0Zzz71UB9XD9v/KZSuVwpZII4u01Zuo/e9bkVyuEIbAcKrM2zp/XRxFeTpupj+7l45y43bTeyUmTj/wNT2Apm5nM6qlT+iiAphm+RydUgWXx6BDo2JDBmSBpa04zesbH7Xy+Z2xMvwBAvrAFltJ19Ohdc3N9J0/qFwA0oVYs6kPGCGFgOQ5nMoefe66Ll10BLdo2eO1oaANL6Uunj+Ry3fWn1wBCIMyBZdWntFR72Ds5qV8AIFDIA8uqT2kNZrO0h0AIhG1ZwwFUZ76aTrOJBziYydsJw19hNTjt4aHTp/ULAHYxNq2sSFVYDZVcTpVaVbZrAHth4ahZYqkUM/HAngx/qh7FwLJuzcQPXrzITDywW3cyqQ+ZJKKB5eidmrLzeUotoIHAMhqlFrAbgSWAU2rxABGI8dYcQXiAiIizr141uciiwvqIWCqlSq3+s2f1C0AEdNm2yWllEVh7is/MqPtMbGJCvwCEmsmvn3AQWHtT95kjudzgxYuGL0sBXNRrfGAxh3UHtWJxfXZ2/dw5/QIQOoZPYFkEVpOq+fza9PTWpUv6BSAsVDNh5/P6qGFoCZuibjuD2eyRV17htHiEVe/UlD5kHiqslm1mMqra4sU8CJm73nyzx+xFWBaB1R5nYmtjdpbYQjiI6ActWsL2dB09Gp+Z4d08CI3+6Wl9yEhUWJ1iPh7Sddm2Kq9MPrevgQqrU435eBaaQqjeqSkRaWVRYbmrksuVZ2Yqly/rFwCDmb/8qoEKy02xVOpILke1BUH6Tp6UklYWFZZ3qLYggqDyyqLC8g7VFszXf/asoLSyqLD8QbUFAwl6ONhAheWHRrXFui2Y43AmIyutLCos/1XzeVVtbV64oF8AfNQ7OTmYzeqjxiOwgqFiayOTYXMPAiGxGXQQWEGqFYtb2awquDhFHn7aeRZk/Fl9e2IOK0jqFteXTqt73eDFizxMhD/6z54VmlYWFZZRtufm1mdnmd6Cd4ROXTUQWMZRfeJmJqOSiz4R7uoZGzuSy0mcumogsMy1lc1uZDKcAwFXyJ1o343AMp3zPFHVXBRcaJtKK1VbmX+g6B0RWGJQcKE9oUkri8ASh4ILLQlTWlkEllyVXG6n4MpmWXqK/YRgll1DYMnmLD3dzGZpFaGJTUwMZrNhSiuLwAoN1So6k1zb8/P6NUTPodOnB2Zn9VH5CKywUcm1PjurwotJrmjqsm0VVX3ptH4hFAis0Nqem3MmuUiu6OgZG1NtoKwz+VpCYIUfyRUR/WfPxmdm9NFwIbAiRCXXzvR8Nss8V8jEJiZUGxiatQsHILCiyJmhV+HFqc3Sddm2qqoOCXlvc+cIrEhzVkVs5XKs55Lo0OnTKq1CtnDhYAQW/qCSy+3UXLkcDaP5+k6eVFEV4sn1/RBY0KmGUcUWZZeZIhtVDgILB9mem/tDeLGSPlBdtt2XTvdPT0c2qhwEFprlJJf6lal6P3WPjqqcUmkVqbmq/RBYaMfOVNfcnJNftI1eUCVV79TUoXRa7vnrXiCw0CmVXE547XzBhH3Heicn+6amwrq3pkMEFtxUKxY/DK+5OdbWN8mpp3pTKfUrrd8BCCx4iPw6WM/YmOr4VD1F39ckAgu+cia/tvN5J8IiOP8Vm5joGR9XxZQKKYqpVhFYCJJTgu0UX8Xizvy9+m3oZsFUGaUSKjY+vvMrlVRnCCwYp5rPV+slWLUeZ06oSanFVAGl6iYnobqTyShsSPYTgQUxnCBT+VWZm2v81qo/pvQ5zlTRpFLJCSb1W5VNzte0eF4jsBAeTi3W+O1WLvfhtVu0f6dBVUN7LiLv3dXEEUmBI7AAiNGtDwCAqQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiEFgARCDwAIgBoEFQAwCC4AYBBYAMQgsAGIQWADEILAAiPH/MiKT6dBv5iYAAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - action.open-cluster-management.io
+          resources:
+          - managedclusteractions
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps.open-cluster-management.io
+          resources:
+          - placementrules
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cluster.open-cluster-management.io
+          resources:
+          - managedclusters
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cluster.open-cluster-management.io
+          resources:
+          - managedclusters/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - policy.open-cluster-management.io
+          resources:
+          - placementbindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - policy.open-cluster-management.io
+          resources:
+          - policies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ran.openshift.io
+          resources:
+          - clustergroupupgrades
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ran.openshift.io
+          resources:
+          - clustergroupupgrades/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ran.openshift.io
+          resources:
+          - clustergroupupgrades/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - view.open-cluster-management.io
+          resources:
+          - managedclusterviews
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: cluster-group-upgrades-controller-manager
+      deployments:
+      - name: cluster-group-upgrades-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=10
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                resources: {}
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                command:
+                - /manager
+                env:
+                - name: PRECACHE_IMG
+                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.10.0
+                image: quay.io/openshift-kni/cluster-group-upgrades-operator:4.10.0
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 20Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: cluster-group-upgrades-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: cluster-group-upgrades-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - acm lifecyclemanagement upgrades cluster
+  links:
+  - name: Cluster Group Upgrades Operator
+    url: https://cluster-group-upgrades-operator.domain
+  maturity: alpha
+  provider:
+    name: Red Hat
+  version: 4.10.0

--- a/manifests/stable/image-references
+++ b/manifests/stable/image-references
@@ -6,7 +6,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.10.0
-  - name: topology-aware-lifecycle-manager-rhel8-operator
+  - name: topology-aware-lifecycle-rhel8-operator
     from:
       kind: DockerImage
       name: quay.io/openshift-kni/cluster-group-upgrades-operator:4.10.0

--- a/manifests/stable/ran.openshift.io_clustergroupupgrades.yaml
+++ b/manifests/stable/ran.openshift.io_clustergroupupgrades.yaml
@@ -1,0 +1,333 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: clustergroupupgrades.ran.openshift.io
+spec:
+  group: ran.openshift.io
+  names:
+    kind: ClusterGroupUpgrade
+    listKind: ClusterGroupUpgradeList
+    plural: clustergroupupgrades
+    shortNames:
+    - cgu
+    singular: clustergroupupgrade
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterGroupUpgrade is the Schema for the ClusterGroupUpgrades
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterGroupUpgradeSpec defines the desired state of ClusterGroupUpgrade
+            properties:
+              actions:
+                description: Actions defines the actions to be done either before
+                  or after the managedPolicies are remediated
+                properties:
+                  afterCompletion:
+                    description: AfterCompletion defines the actions to be done after
+                      upgrade is completed
+                    properties:
+                      addClusterLabels:
+                        additionalProperties:
+                          type: string
+                        description: This field defines a map of key/value pairs that
+                          identify the cluster labels to be added to the specified
+                          clusters. Labels applied to the clusters either defined
+                          in spec.clusters or selected by spec.clusterSelector.
+                        type: object
+                      deleteClusterLabels:
+                        additionalProperties:
+                          type: string
+                        description: This field defines a map of key/value pairs that
+                          identify the cluster labels to be deleted for the specified
+                          clusters. Labels applied to the clusters either defined
+                          in spec.clusters or selected by spec.clusterSelector.
+                        type: object
+                      deleteObjects:
+                        default: true
+                        description: This field defines whether clean up the resources
+                          created for upgrade
+                        type: boolean
+                    type: object
+                  beforeEnable:
+                    description: BeforeEnable defines the actions to be done before
+                      starting upgrade
+                    properties:
+                      addClusterLabels:
+                        additionalProperties:
+                          type: string
+                        description: This field defines a map of key/value pairs that
+                          identify the cluster labels to be added to the specified
+                          clusters. Labels applied to the clusters either defined
+                          in spec.clusters or selected by spec.clusterSelector.
+                        type: object
+                      deleteClusterLabels:
+                        additionalProperties:
+                          type: string
+                        description: This field defines a map of key/value pairs that
+                          identify the cluster labels to be deleted for the specified
+                          clusters. Labels applied to the clusters either defined
+                          in spec.clusters or selected by spec.clusterSelector.
+                        type: object
+                    type: object
+                type: object
+              blockingCRs:
+                items:
+                  description: BlockingCR defines the Upgrade CRs that block the current
+                    CR from running if not completed
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+                type: array
+              clusterSelector:
+                description: 'This field holds a label common to multiple clusters
+                  that will be updated. The expected format is as follows: clusterSelector:   -
+                  label1Name=label1Value   - label2Name=label2Value If the value is
+                  empty, then the expected format is: clusterSelector:   - label1Name
+                  All the clusters matching the labels specified in clusterSelector
+                  will be included in the update plan.'
+                items:
+                  type: string
+                type: array
+              clusters:
+                items:
+                  type: string
+                type: array
+              enable:
+                default: true
+                description: This field determines when the upgrade starts. While
+                  false, the upgrade doesn't start. The policies, placement rules
+                  and placement bindings are created, but clusters are not added to
+                  the placement rule. Once set to true, the clusters start being upgraded,
+                  one batch at a time.
+                type: boolean
+              managedPolicies:
+                items:
+                  type: string
+                type: array
+              preCaching:
+                default: false
+                description: This field determines whether container image pre-caching
+                  will be done on all the clusters matching the selector. If required,
+                  the pre-caching process starts immediately on all clusters irrespectively
+                  of the value of the "enable" flag
+                type: boolean
+              remediationStrategy:
+                description: RemediationStrategySpec defines the remediation policy
+                properties:
+                  canaries:
+                    description: Canaries defines the list of managed clusters that
+                      should be remediated first when remediateAction is set to enforce
+                    items:
+                      type: string
+                    type: array
+                  maxConcurrency:
+                    type: integer
+                  timeout:
+                    default: 240
+                    type: integer
+                required:
+                - maxConcurrency
+                type: object
+            required:
+            - remediationStrategy
+            type: object
+          status:
+            description: ClusterGroupUpgradeStatus defines the observed state of ClusterGroupUpgrade
+            properties:
+              computedMaxConcurrency:
+                type: integer
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              copiedPolicies:
+                items:
+                  type: string
+                type: array
+              managedPoliciesCompliantBeforeUpgrade:
+                items:
+                  type: string
+                type: array
+              managedPoliciesContent:
+                additionalProperties:
+                  type: string
+                type: object
+              managedPoliciesForUpgrade:
+                description: Contains the managed policies (and the namespaces) that
+                  have NonCompliant clusters that require updating.
+                items:
+                  description: ManagedPolicyForUpgrade defines the observed state
+                    of a Policy
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+                type: array
+              managedPoliciesNs:
+                additionalProperties:
+                  type: string
+                type: object
+              placementBindings:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                items:
+                  type: string
+                type: array
+              placementRules:
+                items:
+                  type: string
+                type: array
+              precaching:
+                description: PrecachingStatus defines the observed pre-caching status
+                properties:
+                  clusters:
+                    items:
+                      type: string
+                    type: array
+                  spec:
+                    description: PrecachingSpec defines the pre-caching software spec
+                      derived from policies
+                    properties:
+                      operatorsIndexes:
+                        items:
+                          type: string
+                        type: array
+                      operatorsPackagesAndChannels:
+                        items:
+                          type: string
+                        type: array
+                      platformImage:
+                        type: string
+                    type: object
+                  status:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              remediationPlan:
+                items:
+                  items:
+                    type: string
+                  type: array
+                type: array
+              status:
+                description: UpgradeStatus defines the observed state of the upgrade
+                properties:
+                  completedAt:
+                    format: date-time
+                    type: string
+                  currentBatch:
+                    type: integer
+                  currentBatchStartedAt:
+                    format: date-time
+                    type: string
+                  remediationPlanForBatch:
+                    additionalProperties:
+                      type: integer
+                    type: object
+                  startedAt:
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
since the presence of `image-references` in the bundle dir was messing up with CI, I suggest we just create a copy in `manifests/` with the structure that makes ART's automation happy, while keeping `bundle/` untouched.