### PR TITLE
Remove serviceaccount file from manifests/stable

### DIFF
--- a/manifests/stable/cluster-group-upgrades-controller-manager_v1_serviceaccount.yaml
+++ b/manifests/stable/cluster-group-upgrades-controller-manager_v1_serviceaccount.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  name: cluster-group-upgrades-controller-manager


### PR DESCRIPTION
Removed serviceaccount file from manifests/stable, which was missed
when the corresponding file was removed from bundle/manifests

Signed-off-by: Don Penney <dpenney@redhat.com>