### PR TITLE
Enhancement CNF-5294: Improve batch timeout calculation to use the remaining time for calculating the remaining timeout

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -328,7 +328,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 					}
 
 					// Check for batch timeout.
-					remainingTime := float64(clusterGroupUpgrade.Spec.RemediationStrategy.Timeout) - time.Since(clusterGroupUpgrade.Status.Status.StartedAt.Time).Seconds()
+					remainingTime := float64(clusterGroupUpgrade.Spec.RemediationStrategy.Timeout) - time.Since(clusterGroupUpgrade.Status.Status.StartedAt.Time).Seconds() - time.Since(clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.Time).Seconds()
 					// Because the length of the plan will include the current batch but the status index starts at 0 we need to add one to the remaining batches
 					remainingBatches := len(clusterGroupUpgrade.Status.RemediationPlan) - clusterGroupUpgrade.Status.Status.CurrentBatch + 1
 

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -327,7 +327,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 						nextReconcile = ctrl.Result{RequeueAfter: requeueAfter}
 					}
 
-					// The remaining time will be the total timeout subtract the elasped time spent on both the batch and cgu
+					// The remaining time will be the total timeout subtract the elapsed time spent on both the batch and cgu
 					// It is important to include the current batch here so that we don't let the entire timeout be consumed by a single batch that gets stuck
 					remainingTime := float64(clusterGroupUpgrade.Spec.RemediationStrategy.Timeout) - clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.Time.Sub(clusterGroupUpgrade.Status.Status.StartedAt.Time).Seconds()
 					// Because the length of the plan will include the current batch but the status index starts at 0 we need to add one to the remaining batches

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -340,7 +340,8 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 					currentBatchTimeout := time.Duration(remainingTime / float64(remainingBatches) * float64(time.Second))
 
 					// Check if this batch has timed out
-					if time.Since(clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.Time) > currentBatchTimeout {
+					if !clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.IsZero() &&
+						time.Since(clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.Time) > currentBatchTimeout {
 
 						// Check if this was a canary or not
 						if len(clusterGroupUpgrade.Spec.RemediationStrategy.Canaries) != 0 &&

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -330,43 +330,34 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 					// The remaining time will be the total timeout subtract the elapsed time spent on both the batch and cgu
 					// It is important to include the current batch here so that we don't let the entire timeout be consumed by a single batch that gets stuck
 					remainingTime := float64(clusterGroupUpgrade.Spec.RemediationStrategy.Timeout) - clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.Time.Sub(clusterGroupUpgrade.Status.Status.StartedAt.Time).Seconds()
+
 					// Because the length of the plan will include the current batch but the status index starts at 0 we need to add one to the remaining batches
+					// This also means its not possible for this to be zero so no worries about a division by zero later
 					remainingBatches := len(clusterGroupUpgrade.Status.RemediationPlan) - clusterGroupUpgrade.Status.Status.CurrentBatch + 1
 
-					// Must avoid a division by 0 here in case this is the last batch
-					if remainingBatches > 0 {
+					// The current batch's timeout shall be the remaining time divided by the number of batches remaining
+					// This is to ensure we are giving each batch as much time as possible within the remaining allotment
+					currentBatchTimeout := time.Duration(remainingTime / float64(remainingBatches) * float64(time.Second))
 
-						// The current batch's timeout shall be the remaining time divided by the number of batches remaining
-						// This is to ensure we are giving each batch as much time as possible within the remaining allotment
-						currentBatchTimeout := time.Duration(remainingTime / float64(remainingBatches) * float64(time.Second))
+					// Check if this batch has timed out
+					if time.Since(clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.Time) > currentBatchTimeout {
 
-						// Check if this batch has timed out
-						if time.Since(clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.Time) > currentBatchTimeout {
-
-							// Check if this was a canary or not
-							if len(clusterGroupUpgrade.Spec.RemediationStrategy.Canaries) != 0 &&
-								clusterGroupUpgrade.Status.Status.CurrentBatch <= len(clusterGroupUpgrade.Spec.RemediationStrategy.Canaries) {
-								r.Log.Info("Canaries batch timed out")
-								meta.SetStatusCondition(&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
-									Type:    "Ready",
-									Status:  metav1.ConditionFalse,
-									Reason:  "UpgradeTimedOut",
-									Message: "The ClusterGroupUpgrade CR policies are taking too long to complete",
-								})
-							} else {
-								// This was not a canary but we already know we timed out
-								// Setting the remaining time to be negative here will trigger the default case below
-								remainingTime = -1
+						// Check if this was a canary or not
+						if len(clusterGroupUpgrade.Spec.RemediationStrategy.Canaries) != 0 &&
+							clusterGroupUpgrade.Status.Status.CurrentBatch <= len(clusterGroupUpgrade.Spec.RemediationStrategy.Canaries) {
+							r.Log.Info("Canaries batch timed out")
+							meta.SetStatusCondition(&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
+								Type:    "Ready",
+								Status:  metav1.ConditionFalse,
+								Reason:  "UpgradeTimedOut",
+								Message: "The ClusterGroupUpgrade CR policies are taking too long to complete",
+							})
+						} else {
+							r.Log.Info("Batch upgrade timed out")
+							clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt = metav1.Time{}
+							if clusterGroupUpgrade.Status.Status.CurrentBatch < len(clusterGroupUpgrade.Status.RemediationPlan) {
+								clusterGroupUpgrade.Status.Status.CurrentBatch++
 							}
-						}
-					}
-
-					// If there is zero or negative time remaining then we have timed out
-					if remainingTime <= 0 {
-						r.Log.Info("Batch upgrade timed out")
-						clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt = metav1.Time{}
-						if clusterGroupUpgrade.Status.Status.CurrentBatch < len(clusterGroupUpgrade.Status.RemediationPlan) {
-							clusterGroupUpgrade.Status.Status.CurrentBatch++
 						}
 					}
 				}


### PR DESCRIPTION
For each batch the timeout will be calculated using the remaining time and the remaining number of batches. This will cause the timeout to continuously adjust itself for batches that complete quickly or slowly early on by giving the remaining batches more or less time respectively.