### PR TITLE
Align image-references and CSV for ART build

### DIFF
--- a/manifests/stable/image-references
+++ b/manifests/stable/image-references
@@ -13,4 +13,4 @@ spec:
   - name: kube-rbac-proxy
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-kube-rbac-proxy:4.10
+      name: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0


### PR DESCRIPTION
Fixed the kube-rbac-proxy image reference in the ART manifests CSV
file to align with the image-references file.

Signed-off-by: Don Penney <dpenney@redhat.com>

/cc @nishant-parekh 