### PR TITLE
Enhancement CNF-5013: Make CGU resource cleanup more consistent

### DIFF
--- a/controllers/actions.go
+++ b/controllers/actions.go
@@ -162,6 +162,11 @@ func (r *ClusterGroupUpgradeReconciler) deleteResources(
 	}
 	clusterGroupUpgrade.Status.CopiedPolicies = nil
 
+	err = r.precachingCleanup(ctx, clusterGroupUpgrade)
+	if err != nil {
+		return fmt.Errorf("failed to delete precaching objects for CGU %s: %v", clusterGroupUpgrade.Name, err)
+	}
+
 	clusters, err := r.getAllClustersForUpgrade(ctx, clusterGroupUpgrade)
 	if err != nil {
 		return fmt.Errorf("Cannot obtain all the details about the clusters in the CR: %s", err)

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -321,11 +321,6 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 			}
 
 			if isUpgradeComplete {
-				err = r.precachingCleanup(ctx, clusterGroupUpgrade)
-				if err != nil {
-					msg := fmt.Sprint("Precaching cleanup failed with error:", err)
-					r.Recorder.Event(clusterGroupUpgrade, corev1.EventTypeWarning, "PrecachingCleanupFailed", msg)
-				}
 				meta.SetStatusCondition(&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
 					Type:    "Ready",
 					Status:  metav1.ConditionTrue,


### PR DESCRIPTION
* This is effectively a port of enhancement [CNF-5013](https://issues.redhat.com//browse/CNF-5013) which was merged in https://github.com/openshift-kni/cluster-group-upgrades-operator/pull/227wq