### PR TITLE
Update generated files for version change

### DIFF
--- a/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -19,7 +19,7 @@ metadata:
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.16.0-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: cluster-group-upgrades-operator.v4.11.0
+  name: cluster-group-upgrades-operator.v4.12.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -308,10 +308,10 @@ spec:
                 - /manager
                 env:
                 - name: PRECACHE_IMG
-                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.11.0
+                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.12.0
                 - name: RECOVERY_IMG
-                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-recovery:4.11.0
-                image: quay.io/openshift-kni/cluster-group-upgrades-operator:4.11.0
+                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-recovery:4.12.0
+                image: quay.io/openshift-kni/cluster-group-upgrades-operator:4.12.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -387,4 +387,4 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 4.11.0
+  version: 4.12.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,6 +13,6 @@ configMapGenerator:
 images:
 - name: controller
   newName: quay.io/openshift-kni/cluster-group-upgrades-operator
-  newTag: 4.11.0
+  newTag: 4.12.0
 patchesStrategicMerge:
 - related-images/patch.yaml


### PR DESCRIPTION
Release version was updated to 4.12.0, but this change was not
reflected in the files generated by running "make bundle".

Signed-off-by: Don Penney <dpenney@redhat.com>