### PR TITLE
Add check of bundle generated files to ci-job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ bashate: ## Run bashate
 	hack/bashate.sh
 
 .PHONY: ci-job
-ci-job: common-deps-update fmt vet lint golangci-lint unittests verify-bindata shellcheck bashate
+ci-job: common-deps-update fmt vet lint golangci-lint unittests verify-bindata shellcheck bashate bundle-check
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
@@ -263,6 +263,10 @@ bundle-build: ## Build the bundle image.
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
 	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
+
+.PHONY: bundle-check
+bundle-check: bundle
+	hack/check-git-tree.sh
 
 .PHONY: opm
 OPM = ./bin/opm

--- a/hack/check-git-tree.sh
+++ b/hack/check-git-tree.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+RC=0
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Unstaged or untracked changes exist:"
+    git status --porcelain
+    git diff
+    RC=1
+else
+    echo "git tree is clean"
+fi
+
+exit ${RC}


### PR DESCRIPTION
Added hack/check-git-tree.sh utility to check git tree for unstaged or
untracked files, and updated the ci-job target to run this check after
generating bundle files. This will ensure generated file changes will
not be missed by commits.

Signed-off-by: Don Penney <dpenney@redhat.com>