### PR TITLE
Bug:2102743 RBAC permissions are not granted for ServiceMonitor CR ...

### DIFF
--- a/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -19,7 +19,7 @@ metadata:
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.16.0-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: cluster-group-upgrades-operator.v4.11.0
+  name: cluster-group-upgrades-operator.v4.12.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -201,6 +201,30 @@ spec:
           verbs:
           - update
         - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - policy.open-cluster-management.io
           resources:
           - placementbindings
@@ -308,10 +332,10 @@ spec:
                 - /manager
                 env:
                 - name: PRECACHE_IMG
-                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.11.0
+                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.12.0
                 - name: RECOVERY_IMG
-                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-recovery:4.11.0
-                image: quay.io/openshift-kni/cluster-group-upgrades-operator:4.11.0
+                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-recovery:4.12.0
+                image: quay.io/openshift-kni/cluster-group-upgrades-operator:4.12.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -387,4 +411,4 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 4.11.0
+  version: 4.12.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,6 +13,6 @@ configMapGenerator:
 images:
 - name: controller
   newName: quay.io/openshift-kni/cluster-group-upgrades-operator
-  newTag: 4.11.0
+  newTag: 4.12.0
 patchesStrategicMerge:
 - related-images/patch.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -74,6 +74,30 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - policy.open-cluster-management.io
   resources:
   - placementbindings

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -92,6 +92,8 @@ func requeueWithCustomInterval(interval time.Duration) ctrl.Result {
 //+kubebuilder:rbac:groups=view.open-cluster-management.io,resources=managedclusterviews,verbs=create;update;delete;get;list;watch;patch
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
Permissions for metrics are granted on `role.yaml` using automatic configuration generation on introducing the
corresponding` //+kubebuilder:rbac` tag on `clustergroupupgrade_controller.go`