### PR TITLE
Add retry to golangci-lint installation

### DIFF
--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -3,7 +3,16 @@
 which golangci-lint
 if [ $? -ne 0 ]; then
     echo "Downloading golangci-lint tool"
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.1
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -d -b $(go env GOPATH)/bin v1.46.1
+
+    if [ $? -ne 0 ]; then
+        echo "Install from script failed. Trying go install"
+        go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.1
+        if [ $? -ne 0 ]; then
+            echo "Install of golangci-lint failed"
+            exit 1
+        fi
+    fi
 fi
 
 export GOCACHE=/tmp/


### PR DESCRIPTION
The installation of golangci-lint has been seen to fail occasionally
due to github rate limiting. Added a retry to the golangci-lint.sh to
install golangci-lint via "go install" method if standard installation
script method fails.

Signed-off-by: Don Penney <dpenney@redhat.com>

/cc @jc-rh 