### PR TITLE
Bug 2105992: Fix batch timeout calculation units (and add unit tests)

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -351,12 +351,12 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 					// Check if this batch has timed out
 					if !clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.IsZero() {
 
-						currentBatchTimeout := calculateBatchTimeout(
+						currentBatchTimeout := utils.CalculateBatchTimeout(
 							clusterGroupUpgrade.Spec.RemediationStrategy.Timeout,
-							clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.Time,
-							clusterGroupUpgrade.Status.Status.StartedAt.Time,
 							len(clusterGroupUpgrade.Status.RemediationPlan),
-							clusterGroupUpgrade.Status.Status.CurrentBatch)
+							clusterGroupUpgrade.Status.Status.CurrentBatch,
+							clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.Time,
+							clusterGroupUpgrade.Status.Status.StartedAt.Time)
 
 						if time.Since(clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.Time) > currentBatchTimeout {
 							// Check if this was a canary or not
@@ -433,22 +433,6 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 	// Update status
 	err = r.updateStatus(ctx, clusterGroupUpgrade)
 	return
-}
-
-func calculateBatchTimeout(timeoutMinutes int, currentBatchStartTime, cguStartTime time.Time, numBatches, currentBatch int) time.Duration {
-
-	// The remaining time will be the total timeout subtract the elapsed time spent on both the batch and cgu
-	// It is important to include the current batch here so that we don't let the entire timeout be consumed by a single batch that gets stuck
-	remainingTime := float64(timeoutMinutes)*float64(time.Minute) - float64(currentBatchStartTime.Sub(cguStartTime).Nanoseconds())
-
-	// The number of batches will always be at least 1, and currentBatch is indexed from 0, so there should never be a <1 result here
-	remainingBatches := numBatches - currentBatch
-
-	// The current batch's timeout shall be the remaining time divided by the number of batches remaining
-	// This is to ensure we are giving each batch as much time as possible within the remaining allotment
-	currentBatchTimeout := time.Duration(remainingTime / float64(remainingBatches))
-
-	return currentBatchTimeout
 }
 
 func (r *ClusterGroupUpgradeReconciler) initializeRemediationPolicyForBatch(

--- a/controllers/clustergroupupgrade_controller_test.go
+++ b/controllers/clustergroupupgrade_controller_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatchTimeout(t *testing.T) {
+
+	type (
+		BatchTimeoutTestInputs struct {
+			timeoutMinutes        int
+			currentBatchStartTime time.Time
+			cguStartTime          time.Time
+			numBatches            int
+			currentBatch          int
+		}
+	)
+
+	testcases := []struct {
+		inputs   BatchTimeoutTestInputs
+		expected time.Duration
+		name     string
+	}{
+		{
+			inputs: BatchTimeoutTestInputs{
+				timeoutMinutes:        100,
+				currentBatchStartTime: time.Unix(1657000000, 0),
+				cguStartTime:          time.Unix(1657000000, 0),
+				numBatches:            1,
+				currentBatch:          0,
+			},
+			expected: time.Duration(100 * time.Minute),
+			name:     "Base case 1",
+		},
+		{
+			inputs: BatchTimeoutTestInputs{
+				timeoutMinutes:        200,
+				currentBatchStartTime: time.Unix(1657000000, 0),
+				cguStartTime:          time.Unix(1657000000, 0),
+				numBatches:            2,
+				currentBatch:          0,
+			},
+			expected: time.Duration(100 * time.Minute),
+			name:     "Base case 2",
+		},
+		{
+			inputs: BatchTimeoutTestInputs{
+				timeoutMinutes:        200,
+				currentBatchStartTime: time.Unix(1657006000, 0),
+				cguStartTime:          time.Unix(1657000000, 0),
+				numBatches:            2,
+				currentBatch:          1,
+			},
+			expected: time.Duration(100 * time.Minute),
+			name:     "Base case 3",
+		},
+		{
+			inputs: BatchTimeoutTestInputs{
+				timeoutMinutes:        240,
+				currentBatchStartTime: time.Unix(1657000000, 0),
+				cguStartTime:          time.Unix(1657000000, 0),
+				numBatches:            5,
+				currentBatch:          0,
+			},
+			expected: time.Duration(48 * time.Minute),
+			name:     "Realistic case 1",
+		},
+		{
+			inputs: BatchTimeoutTestInputs{
+				timeoutMinutes:        240,
+				currentBatchStartTime: time.Unix(1657002400, 0),
+				cguStartTime:          time.Unix(1657000000, 0),
+				numBatches:            5,
+				currentBatch:          1,
+			},
+			expected: time.Duration(50 * time.Minute),
+			name:     "Realistic case 2",
+		},
+		{
+			inputs: BatchTimeoutTestInputs{
+				timeoutMinutes:        240,
+				currentBatchStartTime: time.Unix(1657006000, 0),
+				cguStartTime:          time.Unix(1657000000, 0),
+				numBatches:            5,
+				currentBatch:          4,
+			},
+			expected: time.Duration(140 * time.Minute),
+			name:     "Realistic case 3",
+		},
+		{
+			inputs: BatchTimeoutTestInputs{
+				timeoutMinutes:        100,
+				currentBatchStartTime: time.Unix(1657003000, 0),
+				cguStartTime:          time.Unix(1657000000, 0),
+				numBatches:            100,
+				currentBatch:          99,
+			},
+			expected: time.Duration(50 * time.Minute),
+			name:     "Edge case 1",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := calculateBatchTimeout(
+				tc.inputs.timeoutMinutes,
+				tc.inputs.currentBatchStartTime,
+				tc.inputs.cguStartTime,
+				tc.inputs.numBatches,
+				tc.inputs.currentBatch)
+			assert.Equal(t, tc.expected, actual, "The expected and actual timeout should be the same.")
+		})
+	}
+}

--- a/controllers/utils/batches.go
+++ b/controllers/utils/batches.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"time"
+)
+
+// CalculateBatchTimeout calculates the current batch timeout for the running cgu
+func CalculateBatchTimeout(timeoutMinutes, numBatches, currentBatch int, currentBatchStartTime, cguStartTime time.Time) time.Duration {
+
+	// The remaining time will be the total timeout subtract the elapsed time spent on both the batch and cgu
+	// It is important to include the current batch here so that we don't let the entire timeout be consumed by a single batch that gets stuck
+	remainingTime := float64(timeoutMinutes)*float64(time.Minute) - float64(currentBatchStartTime.Sub(cguStartTime).Nanoseconds())
+
+	// The number of batches will always be at least 1, and currentBatch is indexed from 0, so there should never be a <1 result here
+	remainingBatches := numBatches - currentBatch
+
+	// The current batch's timeout shall be the remaining time divided by the number of batches remaining
+	// This is to ensure we are giving each batch as much time as possible within the remaining allotment
+	currentBatchTimeout := time.Duration(remainingTime / float64(remainingBatches))
+
+	return currentBatchTimeout
+}

--- a/controllers/utils/batches_test.go
+++ b/controllers/utils/batches_test.go
@@ -1,20 +1,4 @@
-/*
-Copyright 2022.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-package controllers
+package utils
 
 import (
 	"testing"
@@ -121,12 +105,12 @@ func TestBatchTimeout(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := calculateBatchTimeout(
+			actual := CalculateBatchTimeout(
 				tc.inputs.timeoutMinutes,
-				tc.inputs.currentBatchStartTime,
-				tc.inputs.cguStartTime,
 				tc.inputs.numBatches,
-				tc.inputs.currentBatch)
+				tc.inputs.currentBatch,
+				tc.inputs.currentBatchStartTime,
+				tc.inputs.cguStartTime)
 			assert.Equal(t, tc.expected, actual, "The expected and actual timeout should be the same.")
 		})
 	}


### PR DESCRIPTION
The reference timeout units were incorrectly referred to as seconds instead of as minutes in the solution for CNF-5294. This fixes that, and also adds a number of unit tests that validate the new behaviour performs as intended.