### PR TITLE
[release-4.10] Bug 2106114: Fix batch timeout calculation units (and add unit tests)

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -329,17 +329,12 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 				// Check if this batch has timed out
 				if !clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.IsZero() {
 
-					// The remaining time will be the total timeout subtract the elapsed time spent on both the batch and cgu
-					// It is important to include the current batch here so that we don't let the entire timeout be consumed by a single batch that gets stuck
-					remainingTime := float64(clusterGroupUpgrade.Spec.RemediationStrategy.Timeout) - clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.Time.Sub(clusterGroupUpgrade.Status.Status.StartedAt.Time).Seconds()
-
-					// Because the length of the plan will include the current batch but the status index starts at 0 we need to add one to the remaining batches
-					// This also means its not possible for this to be zero so no worries about a division by zero later
-					remainingBatches := len(clusterGroupUpgrade.Status.RemediationPlan) - clusterGroupUpgrade.Status.Status.CurrentBatch + 1
-
-					// The current batch's timeout shall be the remaining time divided by the number of batches remaining
-					// This is to ensure we are giving each batch as much time as possible within the remaining allotment
-					currentBatchTimeout := time.Duration(remainingTime / float64(remainingBatches) * float64(time.Second))
+					currentBatchTimeout := utils.CalculateBatchTimeout(
+						clusterGroupUpgrade.Spec.RemediationStrategy.Timeout,
+						len(clusterGroupUpgrade.Status.RemediationPlan),
+						clusterGroupUpgrade.Status.Status.CurrentBatch,
+						clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.Time,
+						clusterGroupUpgrade.Status.Status.StartedAt.Time)
 
 					if time.Since(clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.Time) > currentBatchTimeout {
 						// Check if this was a canary or not

--- a/controllers/utils/batches.go
+++ b/controllers/utils/batches.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"time"
+)
+
+// CalculateBatchTimeout calculates the current batch timeout for the running cgu
+func CalculateBatchTimeout(timeoutMinutes, numBatches, currentBatch int, currentBatchStartTime, cguStartTime time.Time) time.Duration {
+
+	// The remaining time will be the total timeout subtract the elapsed time spent on both the batch and cgu
+	// It is important to include the current batch here so that we don't let the entire timeout be consumed by a single batch that gets stuck
+	remainingTime := float64(timeoutMinutes)*float64(time.Minute) - float64(currentBatchStartTime.Sub(cguStartTime).Nanoseconds())
+
+	// The number of batches will always be at least 1, and currentBatch is indexed from 0, so there should never be a <1 result here
+	remainingBatches := numBatches - currentBatch
+
+	// The current batch's timeout shall be the remaining time divided by the number of batches remaining
+	// This is to ensure we are giving each batch as much time as possible within the remaining allotment
+	currentBatchTimeout := time.Duration(remainingTime / float64(remainingBatches))
+
+	return currentBatchTimeout
+}

--- a/controllers/utils/batches_test.go
+++ b/controllers/utils/batches_test.go
@@ -1,0 +1,117 @@
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatchTimeout(t *testing.T) {
+
+	type (
+		BatchTimeoutTestInputs struct {
+			timeoutMinutes        int
+			currentBatchStartTime time.Time
+			cguStartTime          time.Time
+			numBatches            int
+			currentBatch          int
+		}
+	)
+
+	testcases := []struct {
+		inputs   BatchTimeoutTestInputs
+		expected time.Duration
+		name     string
+	}{
+		{
+			inputs: BatchTimeoutTestInputs{
+				timeoutMinutes:        100,
+				currentBatchStartTime: time.Unix(1657000000, 0),
+				cguStartTime:          time.Unix(1657000000, 0),
+				numBatches:            1,
+				currentBatch:          0,
+			},
+			expected: time.Duration(100 * time.Minute),
+			name:     "Base case 1",
+		},
+		{
+			inputs: BatchTimeoutTestInputs{
+				timeoutMinutes:        200,
+				currentBatchStartTime: time.Unix(1657000000, 0),
+				cguStartTime:          time.Unix(1657000000, 0),
+				numBatches:            2,
+				currentBatch:          0,
+			},
+			expected: time.Duration(100 * time.Minute),
+			name:     "Base case 2",
+		},
+		{
+			inputs: BatchTimeoutTestInputs{
+				timeoutMinutes:        200,
+				currentBatchStartTime: time.Unix(1657006000, 0),
+				cguStartTime:          time.Unix(1657000000, 0),
+				numBatches:            2,
+				currentBatch:          1,
+			},
+			expected: time.Duration(100 * time.Minute),
+			name:     "Base case 3",
+		},
+		{
+			inputs: BatchTimeoutTestInputs{
+				timeoutMinutes:        240,
+				currentBatchStartTime: time.Unix(1657000000, 0),
+				cguStartTime:          time.Unix(1657000000, 0),
+				numBatches:            5,
+				currentBatch:          0,
+			},
+			expected: time.Duration(48 * time.Minute),
+			name:     "Realistic case 1",
+		},
+		{
+			inputs: BatchTimeoutTestInputs{
+				timeoutMinutes:        240,
+				currentBatchStartTime: time.Unix(1657002400, 0),
+				cguStartTime:          time.Unix(1657000000, 0),
+				numBatches:            5,
+				currentBatch:          1,
+			},
+			expected: time.Duration(50 * time.Minute),
+			name:     "Realistic case 2",
+		},
+		{
+			inputs: BatchTimeoutTestInputs{
+				timeoutMinutes:        240,
+				currentBatchStartTime: time.Unix(1657006000, 0),
+				cguStartTime:          time.Unix(1657000000, 0),
+				numBatches:            5,
+				currentBatch:          4,
+			},
+			expected: time.Duration(140 * time.Minute),
+			name:     "Realistic case 3",
+		},
+		{
+			inputs: BatchTimeoutTestInputs{
+				timeoutMinutes:        100,
+				currentBatchStartTime: time.Unix(1657003000, 0),
+				cguStartTime:          time.Unix(1657000000, 0),
+				numBatches:            100,
+				currentBatch:          99,
+			},
+			expected: time.Duration(50 * time.Minute),
+			name:     "Edge case 1",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := CalculateBatchTimeout(
+				tc.inputs.timeoutMinutes,
+				tc.inputs.numBatches,
+				tc.inputs.currentBatch,
+				tc.inputs.currentBatchStartTime,
+				tc.inputs.cguStartTime)
+			assert.Equal(t, tc.expected, actual, "The expected and actual timeout should be the same.")
+		})
+	}
+}


### PR DESCRIPTION
This was originally submitted under Bug 2105992 however due to the differences
in the code between 4.10 and main could not be cherry picked automatically.