### PR TITLE
Bug 2079502: Exclude generated policy from cluster-backup-operator

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -906,6 +906,7 @@ func (r *ClusterGroupUpgradeReconciler) copyManagedInformPolicy(
 	labels["app"] = "openshift-cluster-group-upgrades"
 	labels["openshift-cluster-group-upgrades/clusterGroupUpgrade"] = clusterGroupUpgrade.Name
 	labels["openshift-cluster-group-upgrades/parentPolicyName"] = managedPolicy.GetName()
+	labels[utils.ExcludeFromClusterBackup] = "true"
 	newPolicy.SetLabels(labels)
 
 	// Set new policy annotations - copy them from the managed policy.
@@ -1160,6 +1161,7 @@ func (r *ClusterGroupUpgradeReconciler) newBatchPlacementRule(clusterGroupUpgrad
 				"app": "openshift-cluster-group-upgrades",
 				"openshift-cluster-group-upgrades/clusterGroupUpgrade": clusterGroupUpgrade.Name,
 				"openshift-cluster-group-upgrades/forPolicy":           policyName,
+				utils.ExcludeFromClusterBackup:                         "true",
 			},
 			"annotations": map[string]interface{}{
 				utils.DesiredResourceName: desiredName,
@@ -1321,6 +1323,7 @@ func (r *ClusterGroupUpgradeReconciler) newBatchPlacementBinding(clusterGroupUpg
 			"labels": map[string]interface{}{
 				"app": "openshift-cluster-group-upgrades",
 				"openshift-cluster-group-upgrades/clusterGroupUpgrade": clusterGroupUpgrade.Name,
+				utils.ExcludeFromClusterBackup:                         "true",
 			},
 			"annotations": map[string]interface{}{
 				utils.DesiredResourceName: desiredName,

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -100,3 +100,7 @@ const (
 const (
 	CannotStart = "UpgradeCannotStart"
 )
+
+// ExcludeFromClusterBackup is a label to exclude object from cluster-backup-operator
+// https://github.com/stolostron/cluster-backup-operator#steps-to-identify-backup-data
+const ExcludeFromClusterBackup = "velero.io/exclude-from-backup"


### PR DESCRIPTION
Add labels to Policy, PlacementRule, PlacementBinding to exclude them from cluster-backup-oprator
https://github.com/stolostron/cluster-backup-operator#steps-to-identify-backup-data

Signed-off-by: Saeid Askari <saskari@redhat.com>