### PR TITLE
Enhancement CNF-5302: Do not apply any changes after timeout has elapsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In order to model the various phases of an upgrade, the ClusterGroupUpgrade CR c
     * If the **ClusterGroupUpgrade** has the first batch as canaries and the policies for this first batch are not compliant within the batch timeout
     * If the policies for the upgrade have not turned to compliant within the *timeout* value specified in the *remediationStrategy*
 * **UpgradeTimedOut**
-  * In this state, the controller will periodically check if all the policies for the **ClusterGroupUpgrade** are compliant, and in that case it will transition to **UpgradeCompleted**. This is to give a chance for upgrades to catch up, as they could be taking long to complete due to network, CPU or other issues but they are not really stuck and they can indeed complete
+  * In this state, the controller will remove all the *managedPolicies* created for the **ClusterGroupUpgrade**. This is to ensure that changes are not made after the **ClusterGroupUpgrade** has passed its specified timeout. The user may re-run the **ClusterGroupUpgrade** again (perhaps with a longer timeout) if they still need to enforce changes on the clusters.
 * **UpgradeCompleted**
   * In this state, the upgrades of the clusters are complete
   * If the *action.afterCompletion.deleteObjects* field is set to **true** (which is the default value), the controller will delete the underlying RHACM objects (policies, placement bindings, placement rules, managed cluster views) once the upgrade completes. This is to avoid having RHACM Hub to continously check for compliance since the upgrade has been successful.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In order to model the various phases of an upgrade, the ClusterGroupUpgrade CR c
     * If the **ClusterGroupUpgrade** has the first batch as canaries and the policies for this first batch are not compliant within the batch timeout
     * If the policies for the upgrade have not turned to compliant within the *timeout* value specified in the *remediationStrategy*
 * **UpgradeTimedOut**
-  * In this state, the controller will remove all the *managedPolicies* created for the **ClusterGroupUpgrade**. This is to ensure that changes are not made after the **ClusterGroupUpgrade** has passed its specified timeout. The user may re-run the **ClusterGroupUpgrade** again (perhaps with a longer timeout) if they still need to enforce changes on the clusters.
+  * In this state, the controller will remove all the *managedPolicies* copies created for the **ClusterGroupUpgrade**. This is to ensure that changes are not made after the **ClusterGroupUpgrade** has passed its specified timeout. The user may re-run the **ClusterGroupUpgrade** again (perhaps with a longer timeout) if they still need to enforce changes on the clusters.
 * **UpgradeCompleted**
   * In this state, the upgrades of the clusters are complete
   * If the *action.afterCompletion.deleteObjects* field is set to **true** (which is the default value), the controller will delete the underlying RHACM objects (policies, placement bindings, placement rules, managed cluster views) once the upgrade completes. This is to avoid having RHACM Hub to continously check for compliance since the upgrade has been successful.

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -320,7 +320,17 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 					clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt = metav1.Now()
 				}
 
-				if clusterGroupUpgrade.Status.Status.CurrentBatch < len(clusterGroupUpgrade.Status.RemediationPlan) {
+				// Check whether we have time left on the cgu timeout
+				if time.Since(clusterGroupUpgrade.Status.Status.StartedAt.Time) > time.Duration(clusterGroupUpgrade.Spec.RemediationStrategy.Timeout)*time.Minute {
+					// We are completely out of time
+					meta.SetStatusCondition(&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
+						Type:    "Ready",
+						Status:  metav1.ConditionFalse,
+						Reason:  "UpgradeTimedOut",
+						Message: "The ClusterGroupUpgrade CR policies are taking too long to complete",
+					})
+					nextReconcile = requeueImmediately()
+				} else if clusterGroupUpgrade.Status.Status.CurrentBatch < len(clusterGroupUpgrade.Status.RemediationPlan) {
 					// Check if current policies have become compliant and if new policies have to be applied.
 					var isBatchComplete bool
 					isBatchComplete, err = r.getNextRemediationPoliciesForBatch(ctx, clusterGroupUpgrade)
@@ -389,13 +399,6 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 							Message: "The ClusterGroupUpgrade CR has all clusters compliant with all the managed policies",
 						})
 						nextReconcile = requeueImmediately()
-					} else if !clusterGroupUpgrade.Status.Status.StartedAt.IsZero() && time.Since(clusterGroupUpgrade.Status.Status.StartedAt.Time) > time.Duration(clusterGroupUpgrade.Spec.RemediationStrategy.Timeout)*time.Minute {
-						meta.SetStatusCondition(&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
-							Type:    "Ready",
-							Status:  metav1.ConditionFalse,
-							Reason:  "UpgradeTimedOut",
-							Message: "The ClusterGroupUpgrade CR policies are taking too long to complete",
-						})
 					} else {
 						err = r.remediateCurrentBatch(ctx, clusterGroupUpgrade, &nextReconcile)
 						if err != nil {
@@ -421,28 +424,32 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 					})
 					nextReconcile = requeueImmediately()
 				} else {
-					nextReconcile = requeueWithCustomInterval(60 * time.Minute)
+					r.Log.Info("CGU has timed out")
+					r.finalizeCguCompletion(ctx, clusterGroupUpgrade)
 				}
 			}
 		} else {
 			r.Log.Info("Upgrade is completed")
-			if clusterGroupUpgrade.Status.Status.CompletedAt.IsZero() {
-				// Take actions after upgrade is completed
-				clusterGroupUpgrade.Status.Status.CurrentBatch = 0
-				clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt = metav1.Time{}
-				if err = r.takeActionsAfterCompletion(ctx, clusterGroupUpgrade); err != nil {
-					return
-				}
-				// Set completion time only after post actions are executed with no errors
-				clusterGroupUpgrade.Status.Status.CompletedAt = metav1.Now()
-			}
+			r.finalizeCguCompletion(ctx, clusterGroupUpgrade)
 		}
-
 	}
-
 	// Update status
 	err = r.updateStatus(ctx, clusterGroupUpgrade)
 	return
+}
+
+func (r *ClusterGroupUpgradeReconciler) finalizeCguCompletion(ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) error {
+	if clusterGroupUpgrade.Status.Status.CompletedAt.IsZero() {
+		// Take actions after upgrade is completed
+		clusterGroupUpgrade.Status.Status.CurrentBatch = 0
+		clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt = metav1.Time{}
+		if err := r.takeActionsAfterCompletion(ctx, clusterGroupUpgrade); err != nil {
+			return err
+		}
+		// Set completion time only after post actions are executed with no errors
+		clusterGroupUpgrade.Status.Status.CompletedAt = metav1.Now()
+	}
+	return nil
 }
 
 func (r *ClusterGroupUpgradeReconciler) initializeRemediationPolicyForBatch(
@@ -1242,6 +1249,7 @@ func (r *ClusterGroupUpgradeReconciler) isUpgradeComplete(ctx context.Context, c
 
 	if isBatchComplete {
 		// Check previous batches
+		r.Log.Info("[isUpgradeComplete]", "RemediationProgress", clusterGroupUpgrade.Status.Status.CurrentBatchRemediationProgress)
 		for i := 0; i < len(clusterGroupUpgrade.Status.RemediationPlan)-1; i++ {
 			for _, batchClusterName := range clusterGroupUpgrade.Status.RemediationPlan[i] {
 				// Start with policy index 0 as we don't keep progress info from previous batches

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -1231,7 +1231,6 @@ func (r *ClusterGroupUpgradeReconciler) isUpgradeComplete(ctx context.Context, c
 
 	if isBatchComplete {
 		// Check previous batches
-		r.Log.Info("[isUpgradeComplete]", "RemediationProgress", clusterGroupUpgrade.Status.Status.CurrentBatchRemediationProgress)
 		for i := 0; i < len(clusterGroupUpgrade.Status.RemediationPlan)-1; i++ {
 			for _, batchClusterName := range clusterGroupUpgrade.Status.RemediationPlan[i] {
 				// Start with policy index 0 as we don't keep progress info from previous batches


### PR DESCRIPTION
* Delete any policies created by the CGU if the CGU times out
* This will prevent a policy that was created but did not reconcile in time from applying at some indeterminate time later