### PR TITLE
Bug 2109961: Run before enable actions even if all clusters are already compliant with cgu policy

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -264,13 +264,13 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 								statusReason = "UpgradeCompleted"
 								statusMessage = "The ClusterGroupUpgrade CR has all clusters already compliant with the specified managed policies"
 								nextReconcile = requeueImmediately()
+							} else {
+								// Start the upgrade.
+								statusReason = "UpgradeNotCompleted"
+								statusMessage = "The ClusterGroupUpgrade CR has upgrade policies that are still non compliant"
+								clusterGroupUpgrade.Status.Status.StartedAt = metav1.Now()
+								nextReconcile = requeueImmediately()
 							}
-
-							// Start the upgrade.
-							statusReason = "UpgradeNotCompleted"
-							statusMessage = "The ClusterGroupUpgrade CR has upgrade policies that are still non compliant"
-							clusterGroupUpgrade.Status.Status.StartedAt = metav1.Now()
-							nextReconcile = requeueImmediately()
 						}
 					} else {
 						statusReason = "UpgradeNotStarted"

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -214,67 +214,71 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 				}
 
 				if allManagedPoliciesExist {
-					// Trigger the before enable actions now since they should run even if all the clusters are already compliant.
-					err = r.takeActionsBeforeEnable(ctx, clusterGroupUpgrade)
-					if err != nil {
-						return
-					}
-
-					// Build the upgrade batches.
-					err = r.buildRemediationPlan(ctx, clusterGroupUpgrade, managedPoliciesPresent)
-					if err != nil {
-						return
-					}
 
 					// Set default values for status reason and message.
 					var statusReason, statusMessage string
-					var statusCondition metav1.ConditionStatus = metav1.ConditionFalse
-					// If the remediation plan is empty, update the status.
-					if clusterGroupUpgrade.Status.RemediationPlan == nil {
-						statusReason = "UpgradeCompleted"
-						statusMessage = "The ClusterGroupUpgrade CR has all clusters already compliant with the specified managed policies"
-						statusCondition = metav1.ConditionTrue
+					statusCondition := metav1.ConditionFalse
+
+					// Check if the cgu is even enabled
+					if *clusterGroupUpgrade.Spec.Enable {
+						// There are no blocking CRs, so start the upgrade.
+						statusReason = "UpgradeNotCompleted"
+						statusMessage = "The ClusterGroupUpgrade CR has upgrade policies that are still non compliant"
+						clusterGroupUpgrade.Status.Status.StartedAt = metav1.Now()
 						nextReconcile = requeueImmediately()
 					} else {
-						// Create the needed resources for starting the upgrade.
-						err = r.reconcileResources(ctx, clusterGroupUpgrade, managedPoliciesPresent)
-						if err != nil {
-							return
-						}
-						err = r.processManagedPolicyForUpgradeContent(ctx, clusterGroupUpgrade, managedPoliciesPresent)
+						statusReason = "UpgradeNotStarted"
+						statusMessage = "The ClusterGroupUpgrade CR is not enabled"
+						nextReconcile = requeueWithLongInterval()
+					}
+
+					// Check if there are any CRs that are blocking the start of the current one and are not yet completed.
+					var blockingCRsNotCompleted, blockingCRsMissing []string
+					blockingCRsNotCompleted, blockingCRsMissing, err = r.blockingCRsNotCompleted(ctx, clusterGroupUpgrade)
+					if err != nil {
+						return
+					}
+
+					if len(blockingCRsMissing) > 0 {
+						// If there are blocking CRs missing, update the message to show which those are.
+						statusReason = utils.CannotStart
+						statusMessage = fmt.Sprintf("The ClusterGroupUpgrade CR has blocking CRs that are missing: %s", blockingCRsMissing)
+						nextReconcile = requeueWithMediumInterval()
+					} else if len(blockingCRsNotCompleted) > 0 {
+						// If there are blocking CRs that are not completed, then the upgrade can't start.
+						statusReason = utils.CannotStart
+						statusMessage = fmt.Sprintf("The ClusterGroupUpgrade CR is blocked by other CRs that have not yet completed: %s", blockingCRsNotCompleted)
+						nextReconcile = requeueWithMediumInterval()
+					} else {
+
+						// Trigger the before enable actions now since we're about to start the execution
+						err = r.takeActionsBeforeEnable(ctx, clusterGroupUpgrade)
 						if err != nil {
 							return
 						}
 
-						if *clusterGroupUpgrade.Spec.Enable {
-							// Check if there are any CRs that are blocking the start of the current one and are not yet completed.
-							var blockingCRsNotCompleted, blockingCRsMissing []string
-							blockingCRsNotCompleted, blockingCRsMissing, err = r.blockingCRsNotCompleted(ctx, clusterGroupUpgrade)
+						// Build the upgrade batches.
+						err = r.buildRemediationPlan(ctx, clusterGroupUpgrade, managedPoliciesPresent)
+						if err != nil {
+							return
+						}
+
+						// If the remediation plan is empty, update the status.
+						if clusterGroupUpgrade.Status.RemediationPlan == nil {
+							statusReason = "UpgradeCompleted"
+							statusMessage = "The ClusterGroupUpgrade CR has all clusters already compliant with the specified managed policies"
+							statusCondition = metav1.ConditionTrue
+							nextReconcile = requeueImmediately()
+						} else {
+							// Create the needed resources for starting the upgrade.
+							err = r.reconcileResources(ctx, clusterGroupUpgrade, managedPoliciesPresent)
 							if err != nil {
 								return
 							}
-
-							if len(blockingCRsMissing) > 0 {
-								// If there are blocking CRs missing, update the message to show which those are.
-								statusReason = utils.CannotStart
-								statusMessage = fmt.Sprintf("The ClusterGroupUpgrade CR has blocking CRs that are missing: %s", blockingCRsMissing)
-								nextReconcile = requeueWithMediumInterval()
-							} else if len(blockingCRsNotCompleted) > 0 {
-								// If there are blocking CRs that are not completed, then the upgrade can't start.
-								statusReason = utils.CannotStart
-								statusMessage = fmt.Sprintf("The ClusterGroupUpgrade CR is blocked by other CRs that have not yet completed: %s", blockingCRsNotCompleted)
-								nextReconcile = requeueWithMediumInterval()
-							} else {
-								// There are no blocking CRs, so start the upgrade.
-								statusReason = "UpgradeNotCompleted"
-								statusMessage = "The ClusterGroupUpgrade CR has upgrade policies that are still non compliant"
-								clusterGroupUpgrade.Status.Status.StartedAt = metav1.Now()
-								nextReconcile = requeueImmediately()
+							err = r.processManagedPolicyForUpgradeContent(ctx, clusterGroupUpgrade, managedPoliciesPresent)
+							if err != nil {
+								return
 							}
-						} else {
-							statusReason = "UpgradeNotStarted"
-							statusMessage = "The ClusterGroupUpgrade CR is not enabled"
-							nextReconcile = requeueWithLongInterval()
 						}
 					}
 
@@ -428,7 +432,6 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 				}
 				// Set completion time only after post actions are executed with no errors
 				clusterGroupUpgrade.Status.Status.CompletedAt = metav1.Now()
-				nextReconcile = doNotRequeue()
 			}
 		}
 	}

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -222,6 +222,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 
 					// Set default values for status reason and message.
 					var statusReason, statusMessage string
+					statusCondition := metav1.ConditionFalse
 
 					// Create the needed resources for starting the upgrade.
 					err = r.reconcileResources(ctx, clusterGroupUpgrade, managedPoliciesPresent)
@@ -261,6 +262,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 
 							// If the remediation plan is empty, update the status.
 							if clusterGroupUpgrade.Status.RemediationPlan == nil {
+								statusCondition = metav1.ConditionTrue
 								statusReason = "UpgradeCompleted"
 								statusMessage = "The ClusterGroupUpgrade CR has all clusters already compliant with the specified managed policies"
 								nextReconcile = requeueImmediately()
@@ -280,7 +282,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 
 					meta.SetStatusCondition(&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
 						Type:    "Ready",
-						Status:  metav1.ConditionFalse,
+						Status:  statusCondition,
 						Reason:  statusReason,
 						Message: statusMessage,
 					})

--- a/deploy/upgrades/upgrade-starts-complete/cgu-upgrade-starts-complete.yaml
+++ b/deploy/upgrades/upgrade-starts-complete/cgu-upgrade-starts-complete.yaml
@@ -9,7 +9,7 @@ spec:
   managedPolicies:
     - policy1-common-cluster-version-policy
     - policy2-common-pao-sub-policy
-  enable: false
+  enable: true
   clusters:
   - spoke1
   remediationStrategy:

--- a/tests/kuttl/tests/upgrade-starts-complete/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-starts-complete/00-assert.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusters:
   - spoke1
-  enable: false
+  enable: true
   managedPolicies:
   - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy

--- a/tests/kuttl/tests/upgrade-starts-complete/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-starts-complete/00-assert.yaml
@@ -18,7 +18,7 @@ status:
   - message: The ClusterGroupUpgrade CR has all clusters already compliant with the
       specified managed policies
     reason: UpgradeCompleted
-    status: "False"
+    status: "True"
     type: Ready
   managedPoliciesCompliantBeforeUpgrade:
   - policy1-common-cluster-version-policy


### PR DESCRIPTION
    * Ensure that the before enable actions are run even if all clusters are already compliant
    * Update status for all clusters already being compliant so that the cgu will finalize and run after completion actions
    * Do not requeue after the cgu is completed
