### PR TITLE
[release-4.10] Bug 2116401: Cherry pick Run before enable actions even if all clusters are already compliant with cgu policy

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -193,64 +193,67 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 
 				// Set default values for status reason and message.
 				var statusReason, statusMessage string
+				statusCondition := metav1.ConditionFalse
 
-				// If the remediation plan is empty, update the status.
-				if clusterGroupUpgrade.Status.RemediationPlan == nil {
-					statusReason = "UpgradeCompleted"
-					statusMessage = "The ClusterGroupUpgrade CR has all clusters already compliant with the specified managed policies"
-					nextReconcile = requeueImmediately()
-				} else {
-					// Create the needed resources for starting the upgrade.
-					err = r.reconcileResources(ctx, clusterGroupUpgrade, managedPoliciesPresent)
+				// Create the needed resources for starting the upgrade.
+				err = r.reconcileResources(ctx, clusterGroupUpgrade, managedPoliciesPresent)
+				if err != nil {
+					return
+				}
+				err = r.processManagedPolicyForUpgradeContent(ctx, clusterGroupUpgrade, managedPoliciesPresent)
+				if err != nil {
+					return
+				}
+
+				if *clusterGroupUpgrade.Spec.Enable {
+					// Check if there are any CRs that are blocking the start of the current one and are not yet completed.
+					var blockingCRsNotCompleted, blockingCRsMissing []string
+					blockingCRsNotCompleted, blockingCRsMissing, err = r.blockingCRsNotCompleted(ctx, clusterGroupUpgrade)
 					if err != nil {
 						return
 					}
-					err = r.processManagedPolicyForUpgradeContent(ctx, clusterGroupUpgrade, managedPoliciesPresent)
-					if err != nil {
-						return
-					}
 
-					if *clusterGroupUpgrade.Spec.Enable {
-						// Check if there are any CRs that are blocking the start of the current one and are not yet completed.
-						var blockingCRsNotCompleted, blockingCRsMissing []string
-						blockingCRsNotCompleted, blockingCRsMissing, err = r.blockingCRsNotCompleted(ctx, clusterGroupUpgrade)
+					if len(blockingCRsMissing) > 0 {
+						// If there are blocking CRs missing, update the message to show which those are.
+						statusReason = "UpgradeCannotStart"
+						statusMessage = fmt.Sprintf("The ClusterGroupUpgrade CR has blocking CRs that are missing: %s", blockingCRsMissing)
+						nextReconcile = requeueWithMediumInterval()
+					} else if len(blockingCRsNotCompleted) > 0 {
+						// If there are blocking CRs that are not completed, then the upgrade can't start.
+						statusReason = "UpgradeCannotStart"
+						statusMessage = fmt.Sprintf("The ClusterGroupUpgrade CR is blocked by other CRs that have not yet completed: %s", blockingCRsNotCompleted)
+						nextReconcile = requeueWithMediumInterval()
+					} else {
+						// There are no blocking CRs, continue with the upgrade process.
+						// Take actions before starting upgrade.
+						err = r.takeActionsBeforeEnable(ctx, clusterGroupUpgrade)
 						if err != nil {
 							return
 						}
 
-						if len(blockingCRsMissing) > 0 {
-							// If there are blocking CRs missing, update the message to show which those are.
-							statusReason = "UpgradeCannotStart"
-							statusMessage = fmt.Sprintf("The ClusterGroupUpgrade CR has blocking CRs that are missing: %s", blockingCRsMissing)
-							nextReconcile = requeueWithMediumInterval()
-						} else if len(blockingCRsNotCompleted) > 0 {
-							// If there are blocking CRs that are not completed, then the upgrade can't start.
-							statusReason = "UpgradeCannotStart"
-							statusMessage = fmt.Sprintf("The ClusterGroupUpgrade CR is blocked by other CRs that have not yet completed: %s", blockingCRsNotCompleted)
-							nextReconcile = requeueWithMediumInterval()
+						// If the remediation plan is empty, update the status.
+						if clusterGroupUpgrade.Status.RemediationPlan == nil {
+							statusCondition = metav1.ConditionTrue
+							statusReason = "UpgradeCompleted"
+							statusMessage = "The ClusterGroupUpgrade CR has all clusters already compliant with the specified managed policies"
+							nextReconcile = requeueImmediately()
 						} else {
-							// There are no blocking CRs, continue with the upgrade process.
-							// Take actions before starting upgrade.
-							err = r.takeActionsBeforeEnable(ctx, clusterGroupUpgrade)
-							if err != nil {
-								return
-							}
 							// Start the upgrade.
 							statusReason = "UpgradeNotCompleted"
 							statusMessage = "The ClusterGroupUpgrade CR has upgrade policies that are still non compliant"
 							clusterGroupUpgrade.Status.Status.StartedAt = metav1.Now()
 							nextReconcile = requeueImmediately()
 						}
-					} else {
-						statusReason = "UpgradeNotStarted"
-						statusMessage = "The ClusterGroupUpgrade CR is not enabled"
-						nextReconcile = requeueWithLongInterval()
 					}
+				} else {
+					statusReason = "UpgradeNotStarted"
+					statusMessage = "The ClusterGroupUpgrade CR is not enabled"
+					nextReconcile = requeueWithLongInterval()
 				}
 
 				meta.SetStatusCondition(&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
 					Type:    "Ready",
-					Status:  metav1.ConditionFalse,
+					Status:  statusCondition,
 					Reason:  statusReason,
 					Message: statusMessage,
 				})

--- a/deploy/upgrades/upgrade-starts-complete/cgu-upgrade-starts-complete.yaml
+++ b/deploy/upgrades/upgrade-starts-complete/cgu-upgrade-starts-complete.yaml
@@ -9,7 +9,7 @@ spec:
   managedPolicies:
     - policy1-common-cluster-version-policy
     - policy2-common-pao-sub-policy
-  enable: false
+  enable: true
   clusters:
   - spoke1
   remediationStrategy:

--- a/tests/kuttl/tests/upgrade-starts-complete/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-starts-complete/00-assert.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusters:
   - spoke1
-  enable: false
+  enable: true
   managedPolicies:
   - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
@@ -18,7 +18,7 @@ status:
   - message: The ClusterGroupUpgrade CR has all clusters already compliant with the
       specified managed policies
     reason: UpgradeCompleted
-    status: "False"
+    status: "True"
     type: Ready
   managedPoliciesCompliantBeforeUpgrade:
   - policy1-common-cluster-version-policy


### PR DESCRIPTION
Had to cherry pick manually due to changes since 4.10 was split