### PR TITLE
Bug 2075585: Support for hub cluster template function fromConfigMap

### DIFF
--- a/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -158,8 +158,12 @@ spec:
           resources:
           - configmaps
           verbs:
+          - create
+          - delete
           - get
           - list
+          - patch
+          - update
           - watch
         - apiGroups:
           - ""

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,8 +11,12 @@ rules:
   resources:
   - configmaps
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -843,7 +843,7 @@ func (r *ClusterGroupUpgradeReconciler) doManagedPoliciesExist(
 
 			// If the parent policy is not valid due to missing field, add its name to the list of invalid policies.
 			policyErr := utils.VerifyPolicyObjects(foundPolicy)
-			if policyErr != nil || policyInvalidHubTmpl[managedPolicyName] {
+			if policyErr != nil {
 				r.Log.Error(policyErr, "Policy is invalid")
 				managedPoliciesInfo.invalidPolicies = append(managedPoliciesInfo.invalidPolicies, managedPolicyName)
 				continue

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -56,6 +56,12 @@ type ClusterGroupUpgradeReconciler struct {
 	Recorder record.EventRecorder
 }
 
+type policiesInfo struct {
+	invalidPolicies []string
+	missingPolicies []string
+	presentPolicies []*unstructured.Unstructured
+}
+
 const statusUpdateWaitInMilliSeconds = 100
 
 func doNotRequeue() ctrl.Result {
@@ -91,7 +97,7 @@ func requeueWithCustomInterval(interval time.Duration) ctrl.Result {
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=action.open-cluster-management.io,resources=managedclusteractions,verbs=create;update;delete;get;list;watch;patch
 //+kubebuilder:rbac:groups=view.open-cluster-management.io,resources=managedclusterviews,verbs=create;update;delete;get;list;watch;patch
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;watch;create;update;patch;delete
@@ -206,9 +212,8 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 			} else if readyCondition.Reason == "UpgradeNotStarted" || readyCondition.Reason == utils.CannotStart {
 				// Before starting the upgrade check that all the managed policies exist.
 				var allManagedPoliciesExist bool
-				var managedPoliciesMissing []string
-				var managedPoliciesPresent []*unstructured.Unstructured
-				allManagedPoliciesExist, managedPoliciesMissing, managedPoliciesPresent, err =
+				var managedPoliciesInfo policiesInfo
+				allManagedPoliciesExist, managedPoliciesInfo, err =
 					r.doManagedPoliciesExist(ctx, clusterGroupUpgrade, true)
 				if err != nil {
 					return
@@ -216,7 +221,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 
 				if allManagedPoliciesExist {
 					// Build the upgrade batches.
-					err = r.buildRemediationPlan(ctx, clusterGroupUpgrade, managedPoliciesPresent)
+					err = r.buildRemediationPlan(ctx, clusterGroupUpgrade, managedPoliciesInfo.presentPolicies)
 					if err != nil {
 						return
 					}
@@ -226,11 +231,16 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 					statusCondition := metav1.ConditionFalse
 
 					// Create the needed resources for starting the upgrade.
-					err = r.reconcileResources(ctx, clusterGroupUpgrade, managedPoliciesPresent)
+					var isPolicyErr bool
+					isPolicyErr, err = r.reconcileResources(ctx, clusterGroupUpgrade, managedPoliciesInfo.presentPolicies)
 					if err != nil {
 						return
+					} else if isPolicyErr {
+						nextReconcile = requeueWithMediumInterval()
+						return nextReconcile, nil
 					}
-					err = r.processManagedPolicyForUpgradeContent(ctx, clusterGroupUpgrade, managedPoliciesPresent)
+
+					err = r.processManagedPolicyForUpgradeContent(ctx, clusterGroupUpgrade, managedPoliciesInfo.presentPolicies)
 					if err != nil {
 						return
 					}
@@ -288,8 +298,16 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 						Message: statusMessage,
 					})
 				} else {
-					// If not all managedPolicies exist, update the Status accordingly.
-					statusMessage := fmt.Sprintf("The ClusterGroupUpgrade CR has managed policies that are missing: %s", managedPoliciesMissing)
+					// If not all managedPolicies exist or invalid, update the Status accordingly.
+					var statusMessage string = "The ClusterGroupUpgrade CR has: "
+					if len(managedPoliciesInfo.missingPolicies) != 0 {
+						statusMessage += fmt.Sprintf("missing managed policies: %s ", managedPoliciesInfo.missingPolicies)
+					}
+
+					if len(managedPoliciesInfo.invalidPolicies) != 0 {
+						statusMessage += fmt.Sprintf("invalid managed policies: %s ", managedPoliciesInfo.invalidPolicies)
+					}
+
 					meta.SetStatusCondition(&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
 						Type:    "Ready",
 						Status:  metav1.ConditionFalse,
@@ -738,22 +756,22 @@ func (r *ClusterGroupUpgradeReconciler) getPolicyByName(ctx context.Context, pol
 
 /* doManagedPoliciesExist checks that all the managedPolicies specified in the CR exist.
    returns: true/false                   if all the policies exist or not
-            []string                     with the missing managed policy names
-			[]*unstructured.Unstructured a list of the managedPolicies present on the system
+			policiesInfo                 managed policies info including the missing policy names,
+			                             the invalid policy names and the policies present on the system
 			error
 */
 func (r *ClusterGroupUpgradeReconciler) doManagedPoliciesExist(
 	ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade,
-	filterNonCompliantPolicies bool) (bool, []string, []*unstructured.Unstructured, error) {
+	filterNonCompliantPolicies bool) (bool, policiesInfo, error) {
 
 	clusters, err := r.getSuccessfulClustersList(ctx, clusterGroupUpgrade, "upgrade")
 	r.Log.Info("[doManagedPoliciesExist]", "clusterList:", clusters)
 	if err != nil {
-		return false, nil, nil, err
+		return false, policiesInfo{}, err
 	}
 	childPoliciesList, err := utils.GetChildPolicies(ctx, r.Client, clusters)
 	if err != nil {
-		return false, nil, nil, err
+		return false, policiesInfo{}, err
 	}
 
 	// Go through all the child policies and split the namespace from the policy name.
@@ -761,6 +779,7 @@ func (r *ClusterGroupUpgradeReconciler) doManagedPoliciesExist(
 	// The policy map we are creating will be of format {"policy_name": "policy_namespace"}
 	policyMap := make(map[string]string)
 	policyEnforce := make(map[string]bool)
+	policyInvalidHubTmpl := make(map[string]bool)
 	for _, childPolicy := range childPoliciesList {
 		policyNameArr := utils.GetParentPolicyNameAndNamespace(childPolicy.Name)
 
@@ -770,14 +789,25 @@ func (r *ClusterGroupUpgradeReconciler) doManagedPoliciesExist(
 			continue
 		}
 
+		for _, policyT := range childPolicy.Spec.PolicyTemplates {
+			configPolicy := &unstructured.Unstructured{}
+			json.Unmarshal(policyT.ObjectDefinition.Raw, configPolicy)
+
+			configPlcTAnnotations := configPolicy.GetAnnotations()
+			// Identify policies have invalid hub templates
+			_, ok := configPlcTAnnotations["policy.open-cluster-management.io/hub-templates-error"]
+			if ok || strings.Contains(string(policyT.ObjectDefinition.Raw), "{{hub") {
+				policyInvalidHubTmpl[policyNameArr[1]] = true
+			}
+		}
+
 		policyMap[policyNameArr[1]] = policyNameArr[0]
 	}
 	r.Log.Info("[doManagedPoliciesExist]", "policyMap", policyMap)
 
 	// Go through the managedPolicies in the CR, make sure they exist and save them to the upgrade's status together with
 	// their namespace.
-	var managedPoliciesMissing []string
-	var managedPoliciesPresent []*unstructured.Unstructured
+	var managedPoliciesInfo policiesInfo
 	var managedPoliciesForUpgrade []ranv1alpha1.ManagedPolicyForUpgrade
 	var managedPoliciesCompliantBeforeUpgrade []string
 	clusterGroupUpgrade.Status.ManagedPoliciesNs = make(map[string]string)
@@ -796,12 +826,27 @@ func (r *ClusterGroupUpgradeReconciler) doManagedPoliciesExist(
 			if err != nil {
 				// If the parent policy was not found, add its name to the list of missing policies.
 				if errors.IsNotFound(err) {
-					managedPoliciesMissing = append(managedPoliciesMissing, managedPolicyName)
+					managedPoliciesInfo.missingPolicies = append(managedPoliciesInfo.missingPolicies, managedPolicyName)
 					continue
 				} else {
 					// If another error happened, return it.
-					return false, nil, nil, err
+					return false, managedPoliciesInfo, err
 				}
+			}
+
+			// If the parent policy has invalid hub template, add its name to the list of invalid policies.
+			if policyInvalidHubTmpl[managedPolicyName] {
+				r.Log.Error(&utils.PolicyErr{ObjName: managedPolicyName, ErrMsg: utils.PlcHasHubTmplErr}, "Policy is invalid")
+				managedPoliciesInfo.invalidPolicies = append(managedPoliciesInfo.invalidPolicies, managedPolicyName)
+				continue
+			}
+
+			// If the parent policy is not valid due to missing field, add its name to the list of invalid policies.
+			policyErr := utils.VerifyPolicyObjects(foundPolicy)
+			if policyErr != nil || policyInvalidHubTmpl[managedPolicyName] {
+				r.Log.Error(policyErr, "Policy is invalid")
+				managedPoliciesInfo.invalidPolicies = append(managedPoliciesInfo.invalidPolicies, managedPolicyName)
+				continue
 			}
 
 			if filterNonCompliantPolicies {
@@ -809,7 +854,7 @@ func (r *ClusterGroupUpgradeReconciler) doManagedPoliciesExist(
 				clustersNonCompliantWithPolicy, err := r.getClustersNonCompliantWithPolicy(
 					ctx, clusterGroupUpgrade, foundPolicy)
 				if err != nil {
-					return false, nil, nil, err
+					return false, managedPoliciesInfo, err
 				}
 
 				if len(clustersNonCompliantWithPolicy) == 0 {
@@ -822,10 +867,10 @@ func (r *ClusterGroupUpgradeReconciler) doManagedPoliciesExist(
 				managedPoliciesForUpgrade = append(managedPoliciesForUpgrade, newPolicyInfo)
 			}
 			// Add the policy to the list of present policies and update the status with the policy's namespace.
-			managedPoliciesPresent = append(managedPoliciesPresent, foundPolicy)
+			managedPoliciesInfo.presentPolicies = append(managedPoliciesInfo.presentPolicies, foundPolicy)
 			clusterGroupUpgrade.Status.ManagedPoliciesNs[managedPolicyName] = managedPolicyNamespace
 		} else {
-			managedPoliciesMissing = append(managedPoliciesMissing, managedPolicyName)
+			managedPoliciesInfo.missingPolicies = append(managedPoliciesInfo.missingPolicies, managedPolicyName)
 		}
 	}
 
@@ -837,11 +882,11 @@ func (r *ClusterGroupUpgradeReconciler) doManagedPoliciesExist(
 	}
 
 	// If there are missing managed policies, return.
-	if len(managedPoliciesMissing) != 0 {
-		return false, managedPoliciesMissing, managedPoliciesPresent, nil
+	if len(managedPoliciesInfo.missingPolicies) != 0 || len(managedPoliciesInfo.invalidPolicies) != 0 {
+		return false, managedPoliciesInfo, nil
 	}
 
-	return true, nil, managedPoliciesPresent, nil
+	return true, managedPoliciesInfo, nil
 }
 
 func (r *ClusterGroupUpgradeReconciler) processManagedPolicyForUpgradeContent(
@@ -943,13 +988,14 @@ func (r *ClusterGroupUpgradeReconciler) copyManagedInformPolicy(
 
 	// Set new policy remediationAction.
 	newPolicy.Object["spec"] = managedPolicy.Object["spec"]
-	err := r.updateConfigurationPolicyNameForCopiedPolicy(clusterGroupUpgrade, newPolicy.Object["spec"], managedPolicy.GetName())
+	specObject := newPolicy.Object["spec"].(map[string]interface{})
+	specObject["remediationAction"] = utils.RemediationActionEnforce
+
+	// Update the ConfigurationPolicy of the new policy.
+	err := r.updateConfigurationPolicyForCopiedPolicy(ctx, clusterGroupUpgrade, newPolicy, managedPolicy.GetName(), managedPolicy.GetNamespace())
 	if err != nil {
 		return "", err
 	}
-
-	specObject := newPolicy.Object["spec"].(map[string]interface{})
-	specObject["remediationAction"] = utils.RemediationActionEnforce
 
 	// Create the new policy in the desired namespace.
 	err = r.createNewPolicyFromStructure(ctx, clusterGroupUpgrade, newPolicy)
@@ -960,33 +1006,71 @@ func (r *ClusterGroupUpgradeReconciler) copyManagedInformPolicy(
 	return newPolicy.GetName(), nil
 }
 
-func (r *ClusterGroupUpgradeReconciler) updateConfigurationPolicyNameForCopiedPolicy(
-	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, spec interface{}, managedPolicyName string) error {
-	specObject := spec.(map[string]interface{})
+func (r *ClusterGroupUpgradeReconciler) updateConfigurationPolicyForCopiedPolicy(
+	ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, policy *unstructured.Unstructured, managedPolicyName, managedPolicyNamespace string) error {
 
-	// Get the policy templates.
-	policyTemplates := specObject["policy-templates"]
-	policyTemplatesArr := policyTemplates.([]interface{})
+	// Go through the policy policy-templates.
+	policySpec := policy.Object["spec"].(map[string]interface{})
+	policyTemplates := policySpec["policy-templates"].([]interface{})
+	for _, plcTmpl := range policyTemplates {
+		// Update the metadata name of the ConfigurationPolicy.
+		plcTmplDef := plcTmpl.(map[string]interface{})["objectDefinition"].(map[string]interface{})
+		metadata := plcTmplDef["metadata"]
+		r.updateConfigurationPolicyName(clusterGroupUpgrade, metadata)
 
-	// Go through the template array.
-	for _, template := range policyTemplatesArr {
-		// Get to the metadata name of the ConfigurationPolicy.
-		objectDefinition := template.(map[string]interface{})["objectDefinition"]
-		if objectDefinition == nil {
-			return fmt.Errorf("policy %s is missing its spec.policy-templates.objectDefinition", managedPolicyName)
+		// Go through the object-templates of the ConfigurationPolicy.
+		plcTmplDefSpec := plcTmplDef["spec"].(map[string]interface{})
+		configPlcTmpls := plcTmplDefSpec["object-templates"].([]interface{})
+		for _, configPlcObjTmpl := range configPlcTmpls {
+			configPlcObjTmplDef := configPlcObjTmpl.(map[string]interface{})["objectDefinition"]
+			// Ensure the resources referenced in the hub template policy exist if applicable
+			err := r.updateConfigurationPolicyHubTemplate(ctx, configPlcObjTmplDef, clusterGroupUpgrade.GetNamespace(), managedPolicyName, managedPolicyNamespace)
+			if err != nil {
+				return err
+			}
 		}
-		objectDefinitionContent := objectDefinition.(map[string]interface{})
-		metadata := objectDefinitionContent["metadata"]
-		if metadata == nil {
-			return fmt.Errorf("policy %s is missing its spec.policy-templates.objectDefinition.metadata", managedPolicyName)
+	}
+
+	return nil
+}
+
+func (r *ClusterGroupUpgradeReconciler) updateConfigurationPolicyHubTemplate(
+	ctx context.Context, objectDef interface{}, cguNamespace, managedPolicyName, managedPolicyNamespace string) error {
+	// Process only if the managed policy is not created in the CGU namespace
+	if managedPolicyNamespace == cguNamespace {
+		return nil
+	}
+
+	objectDefJSON, err := json.Marshal(objectDef)
+	if err != nil {
+		return fmt.Errorf("Could not marshal data: %s", err)
+	}
+
+	// Check if the object definition has a hub template and process only if there's a template pattern "{{hub" in it.
+	if strings.Contains(string(objectDefJSON), "{{hub") {
+		tmplResolver := &utils.TemplateResolver{
+			Client:          r.Client,
+			Log:             r.Log,
+			Ctx:             ctx,
+			TargetNamespace: cguNamespace,
+			PolicyName:      managedPolicyName,
+			PolicyNamespace: managedPolicyNamespace,
 		}
-		// Update the metadata name
-		metadataContent := metadata.(map[string]interface{})
-		name := utils.GetResourceName(clusterGroupUpgrade, metadataContent["name"].(string))
-		safeName := utils.GetSafeResourceName(name, clusterGroupUpgrade, utils.MaxPolicyNameLength, 0)
-		metadataContent["name"] = safeName
+
+		if _, err = tmplResolver.ResolveObjectHubTemplates(objectDef); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+func (r *ClusterGroupUpgradeReconciler) updateConfigurationPolicyName(
+	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, metadata interface{}) {
+
+	metadataContent := metadata.(map[string]interface{})
+	name := utils.GetResourceName(clusterGroupUpgrade, metadataContent["name"].(string))
+	safeName := utils.GetSafeResourceName(name, clusterGroupUpgrade, utils.MaxPolicyNameLength, 0)
+	metadataContent["name"] = safeName
 }
 
 func (r *ClusterGroupUpgradeReconciler) createNewPolicyFromStructure(
@@ -1028,9 +1112,14 @@ func (r *ClusterGroupUpgradeReconciler) createNewPolicyFromStructure(
 	return nil
 }
 
+// getPolicyContent goes through all the managed policies that have been validated at the beginning
+// to get the configured resource content if it's a Subscription CR.
+// returns:     []ranv1alpha1.PolicyContent      a list of resource content
+//              error/nil
 //nolint:unparam
 func (r *ClusterGroupUpgradeReconciler) getPolicyContent(
 	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, managedPolicy *unstructured.Unstructured) ([]ranv1alpha1.PolicyContent, error) {
+
 	managedPolicyName := managedPolicy.GetName()
 	specObject := managedPolicy.Object["spec"].(map[string]interface{})
 
@@ -1043,33 +1132,21 @@ func (r *ClusterGroupUpgradeReconciler) getPolicyContent(
 	for _, template := range policyTemplatesArr {
 		// Get to the metadata name of the ConfigurationPolicy.
 		objectDefinition := template.(map[string]interface{})["objectDefinition"]
-		if objectDefinition == nil {
-			return nil, fmt.Errorf("policy %s is missing its spec.policy-templates.objectDefinition", managedPolicyName)
-		}
 		objectDefinitionContent := objectDefinition.(map[string]interface{})
 
 		// Get the spec.
 		spec := objectDefinitionContent["spec"]
-		if spec == nil {
-			return nil, fmt.Errorf("policy %s is missing its spec.policy-templates.objectDefinition.spec", managedPolicyName)
-		}
 
 		// Get the object-templates from the spec.
 		specContent := spec.(map[string]interface{})
 		objectTemplates := specContent["object-templates"]
-		if objectTemplates == nil {
-			return nil, fmt.Errorf("policy %s is missing its spec.policy-templates.objectDefinition.spec.object-templates", managedPolicyName)
-		}
 
 		objectTemplatesContent := objectTemplates.([]interface{})
 		for _, objectTemplate := range objectTemplatesContent {
 			objectTemplateContent := objectTemplate.(map[string]interface{})
 			innerObjectDefinition := objectTemplateContent["objectDefinition"]
-			if innerObjectDefinition == nil {
-				return nil, fmt.Errorf("policy %s is missing its spec.policy-templates.objectDefinition.spec.object-templates.objectDefinition", managedPolicyName)
-			}
-
 			innerObjectDefinitionContent := innerObjectDefinition.(map[string]interface{})
+
 			// Get the object's metadata.
 			objectDefinitionMetadata := innerObjectDefinitionContent["metadata"]
 			if objectDefinitionMetadata == nil {
@@ -1420,27 +1497,35 @@ func (r *ClusterGroupUpgradeReconciler) getCopiedPolicies(ctx context.Context, c
 	return policiesList, nil
 }
 
-func (r *ClusterGroupUpgradeReconciler) reconcileResources(ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, managedPoliciesPresent []*unstructured.Unstructured) error {
+func (r *ClusterGroupUpgradeReconciler) reconcileResources(ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, managedPoliciesPresent []*unstructured.Unstructured) (bool, error) {
 	// Reconcile resources
+	isPolicyErr := false
 	for _, managedPolicy := range managedPoliciesPresent {
 
 		policyName, err := r.copyManagedInformPolicy(ctx, clusterGroupUpgrade, managedPolicy)
 		if err != nil {
-			return err
+			if _, ok := err.(*utils.PolicyErr); ok {
+				// If it's a policy error(i.e. unsupported hub template),
+				// break the loop to execute updateChildResourceNamesInStatus
+				// to update the CGU status with already created policies
+				isPolicyErr = true
+				break
+			}
+			return false, err
 		}
 
 		placementRuleName, err := r.ensureBatchPlacementRule(ctx, clusterGroupUpgrade, policyName, managedPolicy)
 		if err != nil {
-			return err
+			return false, err
 		}
 
 		err = r.ensureBatchPlacementBinding(ctx, clusterGroupUpgrade, policyName, placementRuleName, managedPolicy)
 		if err != nil {
-			return err
+			return false, err
 		}
 	}
 	err := r.updateChildResourceNamesInStatus(ctx, clusterGroupUpgrade)
-	return err
+	return isPolicyErr, err
 }
 
 func (r *ClusterGroupUpgradeReconciler) getPolicyClusterStatus(policy *unstructured.Unstructured) []interface{} {

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -790,13 +790,10 @@ func (r *ClusterGroupUpgradeReconciler) doManagedPoliciesExist(
 		}
 
 		for _, policyT := range childPolicy.Spec.PolicyTemplates {
-			configPolicy := &unstructured.Unstructured{}
-			json.Unmarshal(policyT.ObjectDefinition.Raw, configPolicy)
-
-			configPlcTAnnotations := configPolicy.GetAnnotations()
-			// Identify policies have invalid hub templates
-			_, ok := configPlcTAnnotations["policy.open-cluster-management.io/hub-templates-error"]
-			if ok || strings.Contains(string(policyT.ObjectDefinition.Raw), "{{hub") {
+			// Identify policies have invalid hub templates.
+			// If the child configuration policy contains a string pattern "{{hub",
+			// it means the hub template is invalid and fails to be processed on the hub cluster.
+			if strings.Contains(string(policyT.ObjectDefinition.Raw), "{{hub") {
 				policyInvalidHubTmpl[policyNameArr[1]] = true
 			}
 		}

--- a/controllers/precacheFsm.go
+++ b/controllers/precacheFsm.go
@@ -62,14 +62,14 @@ func (r *ClusterGroupUpgradeReconciler) precachingFsm(ctx context.Context,
 	r.setPrecachingStartedCondition(clusterGroupUpgrade)
 	specCondition := meta.FindStatusCondition(clusterGroupUpgrade.Status.Conditions, utils.PrecacheSpecValidCondition)
 	if specCondition == nil || specCondition.Status == metav1.ConditionFalse {
-		allManagedPoliciesExist, managedPoliciesMissing, managedPoliciesPresent, err := r.doManagedPoliciesExist(
+		allManagedPoliciesExist, managedPoliciesInfo, err := r.doManagedPoliciesExist(
 			ctx, clusterGroupUpgrade, false)
 		if err != nil {
 			return err
 		}
 		if !allManagedPoliciesExist {
 			statusMessage := fmt.Sprintf(
-				"The ClusterGroupUpgrade CR has managed policies that are missing: %s", managedPoliciesMissing)
+				"The ClusterGroupUpgrade CR has managed policies that are missing: %s", managedPoliciesInfo.missingPolicies)
 			utils.SetStatusCondition(
 				&clusterGroupUpgrade.Status.Conditions,
 				utils.ConditionTypes.PrecacheSpecValid,
@@ -80,7 +80,7 @@ func (r *ClusterGroupUpgradeReconciler) precachingFsm(ctx context.Context,
 			return nil
 		}
 
-		spec, err := r.extractPrecachingSpecFromPolicies(clusterGroupUpgrade, managedPoliciesPresent)
+		spec, err := r.extractPrecachingSpecFromPolicies(clusterGroupUpgrade, managedPoliciesInfo.presentPolicies)
 		if err != nil {
 			return err
 		}

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -103,3 +103,17 @@ const (
 // ExcludeFromClusterBackup is a label to exclude object from cluster-backup-operator
 // https://github.com/stolostron/cluster-backup-operator#steps-to-identify-backup-data
 const ExcludeFromClusterBackup = "velero.io/exclude-from-backup"
+
+// Policy errors
+const (
+	PlcMissTmplDef           = "policy is missing its spec.policy-templates.objectDefinition"
+	PlcMissTmplDefMeta       = "policy is missing its spec.policy-templates.objectDefinition.metadata"
+	PlcMissTmplDefSpec       = "policy is missing its spec.policy-templates.objectDefinition.spec"
+	ConfigPlcMissObjTmpl     = "policy is missing its spec.policy-templates.objectDefinition.spec.object-templates"
+	ConfigPlcMissObjTmplDef  = "policy is missing its spec.policy-templates.objectDefinition.spec.object-templates.objectDefinition"
+	PlcHasHubTmplErr         = "policy has hub template error, check the configuration policy's annotation 'policy.open-cluster-management.io/hub-templates-error' for detail"
+	PlcHubTmplFmtErr         = "template format is not supported in TALM"
+	PlcHubTmplFuncErr        = "template function is not supported in TALM"
+	PlcHubTmplPrinfInNameErr = "printf variable is not supported in the template function Name field"
+	PlcHubTmplPrinfInNsErr   = "printf variable is not supported in the template function Namespace field"
+)

--- a/controllers/utils/policy_template.go
+++ b/controllers/utils/policy_template.go
@@ -146,21 +146,21 @@ func (r *TemplateResolver) copyConfigmap(ctx context.Context, fromResource, toRe
 
 	copiedCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        toResource.Name,
-			Namespace:   toResource.Namespace,
-			Annotations: cm.GetAnnotations(),
+			Name:      toResource.Name,
+			Namespace: toResource.Namespace,
+			Labels:    cm.GetLabels(),
 		},
 		Data:       cm.Data,
 		BinaryData: cm.BinaryData,
 		Immutable:  cm.Immutable,
 	}
-	labels := cm.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string)
+
+	annotations := cm.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
 	}
-	labels["openshift-cluster-group-upgrades/fromCmName"] = cm.GetName()
-	labels["openshift-cluster-group-upgrades/fromCmNamespace"] = cm.GetNamespace()
-	copiedCM.SetLabels(labels)
+	annotations[DesiredResourceName] = fromResource.Namespace + "." + fromResource.Name
+	copiedCM.SetAnnotations(annotations)
 
 	existingCM := &corev1.ConfigMap{}
 	if err = r.Get(ctx, toResource, existingCM); err != nil {

--- a/controllers/utils/policy_template.go
+++ b/controllers/utils/policy_template.go
@@ -1,0 +1,183 @@
+package utils
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TemplateResolver contains information for processing hub templates.
+type TemplateResolver struct {
+	client.Client
+	Ctx             context.Context
+	Log             logr.Logger
+	TargetNamespace string
+	PolicyName      string
+	PolicyNamespace string
+}
+
+// ResolveObjectHubTemplates searches from the configuration policy object template for all string values
+// that contain hub templates and triggers template resource replication for each finding.
+// returns: the updated policy object template
+//          error/nil
+//nolint:gocritic
+func (r *TemplateResolver) ResolveObjectHubTemplates(objectDef interface{}) (interface{}, error) {
+
+	var err error
+	if objMap, isMap := objectDef.(map[string]interface{}); isMap {
+		for key, value := range objMap {
+			if objMap[key], err = r.ResolveObjectHubTemplates(value); err != nil {
+				return objectDef, err
+			}
+		}
+	} else if objSlice, isSlice := objectDef.([]interface{}); isSlice {
+		for key, value := range objSlice {
+			if objSlice[key], err = r.ResolveObjectHubTemplates(value); err != nil {
+				return objectDef, err
+			}
+		}
+	} else if objString, isString := objectDef.(string); isString {
+		if strings.Contains(objString, "{{hub") {
+			r.Log.Info("Found hub template in policy", "policy", r.PolicyName, "template", objString)
+			if objectDef, err = r.replicateHubTemplateResource(objString); err != nil {
+				r.Log.Error(err, "Failed to resolve hub template")
+				return objectDef, err
+			}
+		}
+	}
+
+	return objectDef, nil
+}
+
+// ReplicateHubTemplateResource processes the hub templates string to identify the template function and
+// template resource, then copies the template resource to the CGU namespace and updates the hub templates
+// with replicated resource if conditions are met.
+// returns:  the updated template string
+//           error/nil
+func (r *TemplateResolver) replicateHubTemplateResource(templates string) (string, error) {
+	// This regular expression is to extract all hub templates from a string.
+	re1 := regexp.MustCompile(`{{hub\s+.*?\s+hub}}`)
+
+	// This regular expression is to get the function name, resource name and namespace referenced in the function from a hub template.
+	// The following captured groups represent for:
+	// 		$1: any characters before the template function
+	// 		$2: template function
+	// 		$3: resource namespace field
+	// 		$4: resource namespace with printf variable
+	// 		$5: resource namespace with a fixed string
+	// 		$6: resource name field
+	// 		$7: resource name with printf variable
+	// 		$8: resource name with a fixed string
+	// 		$9: any characters after the resource name field
+	re2 := regexp.MustCompile(`({{hub.*)(fromConfigMap|fromSecret|lookup)\s+((\(\s*printf\s.+?\s*\))|"(.*?)")\s+((\(\s*printf\s.+?\s*\))|"(.*?)")(.*hub}})`)
+
+	var resolvedTemplates = templates
+	// Get all hub templates appeared in a string
+	discoveredTemplates := re1.FindAllString(templates, -1)
+	// Process each hub template
+	for _, template := range discoveredTemplates {
+		matches := re2.FindAllStringSubmatch(template, -1)
+
+		// Hub template doesn't match the regular expression
+		if len(matches) == 0 {
+			return "", &PolicyErr{template, PlcHubTmplFmtErr}
+		}
+
+		for _, match := range matches {
+			function := match[2]
+			if function != "fromConfigMap" {
+				return "", &PolicyErr{function, PlcHubTmplFuncErr}
+			}
+
+			if match[4] != "" {
+				return "", &PolicyErr{match[4], PlcHubTmplPrinfInNsErr}
+			}
+			namespace := match[5]
+
+			if match[7] != "" {
+				return "", &PolicyErr{match[7], PlcHubTmplPrinfInNameErr}
+			}
+			name := match[8]
+
+			fromNamespace := namespace
+			if namespace == "" {
+				// namespace is empty
+				fromNamespace = r.PolicyNamespace
+			}
+
+			fromResource := types.NamespacedName{
+				Name:      name,
+				Namespace: fromNamespace,
+			}
+
+			toResource := types.NamespacedName{
+				Name:      r.PolicyNamespace + "." + name,
+				Namespace: r.TargetNamespace,
+			}
+
+			if err := r.copyConfigmap(r.Ctx, fromResource, toResource); err != nil {
+				return "", err
+			}
+
+			// Update the hub templating with the replicated configmap name and namespace
+			updatedTemplate := re2.ReplaceAllString(template, `$1$2`+` "`+toResource.Namespace+`"`+` "`+toResource.Name+`"`+`$9`)
+			resolvedTemplates = strings.ReplaceAll(resolvedTemplates, template, updatedTemplate)
+		}
+	}
+
+	return resolvedTemplates, nil
+}
+
+//nolint:gocritic
+func (r *TemplateResolver) copyConfigmap(ctx context.Context, fromResource, toResource types.NamespacedName) error {
+	// Get the original configmap referenced in the inform policy
+	cm := &corev1.ConfigMap{}
+	err := r.Get(ctx, fromResource, cm)
+	if err != nil {
+		return err
+	}
+
+	copiedCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        toResource.Name,
+			Namespace:   toResource.Namespace,
+			Annotations: cm.GetAnnotations(),
+		},
+		Data:       cm.Data,
+		BinaryData: cm.BinaryData,
+		Immutable:  cm.Immutable,
+	}
+	labels := cm.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels["openshift-cluster-group-upgrades/fromCmName"] = cm.GetName()
+	labels["openshift-cluster-group-upgrades/fromCmNamespace"] = cm.GetNamespace()
+	copiedCM.SetLabels(labels)
+
+	existingCM := &corev1.ConfigMap{}
+	if err = r.Get(ctx, toResource, existingCM); err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+
+		if err := r.Create(ctx, copiedCM); err != nil {
+			r.Log.Error(err, "Fail to create config map", "name", copiedCM.Name, "namespace", copiedCM.Namespace)
+			return err
+		}
+	} else {
+		err = r.Update(ctx, copiedCM)
+		if err != nil {
+			r.Log.Error(err, "Fail to update config map", "name", copiedCM.Name, "namespace", copiedCM.Namespace)
+			return err
+		}
+	}
+	return nil
+}

--- a/controllers/utils/policy_template_test.go
+++ b/controllers/utils/policy_template_test.go
@@ -1,0 +1,160 @@
+package utils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func init() {
+	testscheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ConfigMap{})
+}
+
+func TestResolveHubTemplate(t *testing.T) {
+
+	testcases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "Valid hub templates",
+			input: `
+apiVersion: test.openshift.io/v1
+kind: TestResource
+metadata:
+    name: resource-sample
+    namespace: resource-namespace
+spec:
+    test1: '{{hub fromConfigMap "ztp-common" "common-cm" "common-key" hub}}'
+    test2: '{{hub fromConfigMap "" "common-cm" "common-key" hub}}'
+    test3: '{{hub fromConfigMap "ztp-common" "common-cm" (printf "%s-name" .ManagedClusterName) hub}}'
+    test4: '{{hub (printf "%s-name" .ManagedClusterName) | fromConfigMap "ztp-common" "common-cm" hub}}'
+    test5: '{{hub ( printf "%s-name" .ManagedClusterName ) | fromConfigMap "ztp-common" "common-cm" hub}}'
+    test6: '{{hub (printf "%s-name" .ManagedClusterName | fromConfigMap "ztp-common" "common-cm") hub}}'
+    test7: '{{hub ( printf "%s-name" .ManagedClusterName | fromConfigMap "ztp-common"  "common-cm" ) hub}}'
+    test8: 'test-value-{{hub fromConfigMap "ztp-common" "common-cm" (printf "%s-name" .ManagedClusterName) hub}}'
+    test9: '{{hub fromConfigMap "ztp-common" "common-cm" (printf "%s-name" .ManagedClusterName) hub}}-value'
+    test10: |
+        {{hub fromConfigMap "ztp-common" "common-cm" "common-key" hub}}
+    test11: |
+        {{hub fromConfigMap "ztp-common" "common-cm" "common-key" hub}}-value
+    test12:
+        - '{{hub (fromConfigMap "ztp-common" "common-cm" "common-key") | toInt hub}}'
+        - "{{hub (fromConfigMap \"ztp-common\" \"common-cm\" \"common-key\") | toBool hub}}"
+        - '{{hub (printf "%s-name" .ManagedClusterName | fromConfigMap "ztp-common" "common-cm") | base64enc hub}}'
+        - '{{hub (printf "%s-name" .ManagedClusterName | fromConfigMap "ztp-common" "common-cm") | toInt hub}}-{{hub fromConfigMap "ztp-common" "common-cm" "common-key" | toInt hub}}'
+`,
+			expected: `
+apiVersion: test.openshift.io/v1
+kind: TestResource
+metadata:
+    name: resource-sample
+    namespace: resource-namespace
+spec:
+    test1: '{{hub fromConfigMap "ztp-install" "ztp-common.common-cm" "common-key" hub}}'
+    test2: '{{hub fromConfigMap "ztp-install" "ztp-common.common-cm" "common-key" hub}}'
+    test3: '{{hub fromConfigMap "ztp-install" "ztp-common.common-cm" (printf "%s-name" .ManagedClusterName) hub}}'
+    test4: '{{hub (printf "%s-name" .ManagedClusterName) | fromConfigMap "ztp-install" "ztp-common.common-cm" hub}}'
+    test5: '{{hub ( printf "%s-name" .ManagedClusterName ) | fromConfigMap "ztp-install" "ztp-common.common-cm" hub}}'
+    test6: '{{hub (printf "%s-name" .ManagedClusterName | fromConfigMap "ztp-install" "ztp-common.common-cm") hub}}'
+    test7: '{{hub ( printf "%s-name" .ManagedClusterName | fromConfigMap "ztp-install" "ztp-common.common-cm" ) hub}}'
+    test8: 'test-value-{{hub fromConfigMap "ztp-install" "ztp-common.common-cm" (printf "%s-name" .ManagedClusterName) hub}}'
+    test9: '{{hub fromConfigMap "ztp-install" "ztp-common.common-cm" (printf "%s-name" .ManagedClusterName) hub}}-value'
+    test10: |
+        {{hub fromConfigMap "ztp-install" "ztp-common.common-cm" "common-key" hub}}
+    test11: |
+        {{hub fromConfigMap "ztp-install" "ztp-common.common-cm" "common-key" hub}}-value
+    test12:
+        - '{{hub (fromConfigMap "ztp-install" "ztp-common.common-cm" "common-key") | toInt hub}}'
+        - "{{hub (fromConfigMap \"ztp-install\" \"ztp-common.common-cm\" \"common-key\") | toBool hub}}"
+        - '{{hub (printf "%s-name" .ManagedClusterName | fromConfigMap "ztp-install" "ztp-common.common-cm") | base64enc hub}}'
+        - '{{hub (printf "%s-name" .ManagedClusterName | fromConfigMap "ztp-install" "ztp-common.common-cm") | toInt hub}}-{{hub fromConfigMap "ztp-install" "ztp-common.common-cm" "common-key" | toInt hub}}'
+`,
+		},
+		{
+			name: "Unsupported hub template fromSecret",
+			input: `
+apiVersion: test.openshift.io/v1
+kind: TestResource
+metadata:
+    name: resource-sample
+    namespace: resource-namespace
+spec:
+    test1: '{{hub fromSecret "ztp-common" "common-cm" "common-key" hub}}'
+`,
+			expected: "fromSecret: " + PlcHubTmplFuncErr,
+		},
+		{
+			name: "Unsupported Printf in the Name field in fromConfigMap function",
+			input: `
+apiVersion: test.openshift.io/v1
+kind: TestResource
+metadata:
+    name: resource-sample
+    namespace: resource-namespace
+spec:
+    test1: '{{hub fromConfigMap "ztp-common" (printf "%s-data" .ManagedClusterName) "common-key" hub}}'
+`,
+			expected: PlcHubTmplPrinfInNameErr,
+		},
+		{
+			name: "Unsupported Printf in the Namespace field in fromConfigMap function",
+			input: `
+apiVersion: test.openshift.io/v1
+kind: TestResource
+metadata:
+    name: resource-sample
+    namespace: resource-namespace
+spec:
+    test1: '{{hub fromConfigMap ( printf "%s-data" .ManagedClusterName ) "ztp-common"  "common-key" hub}}'
+`,
+			expected: PlcHubTmplPrinfInNsErr,
+		},
+	}
+
+	for _, tc := range testcases {
+		objs := []client.Object{
+			&corev1.ConfigMap{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "common-cm",
+					Namespace: "ztp-common",
+				},
+			},
+		}
+
+		r := &TemplateResolver{
+			Client:          fake.NewClientBuilder().WithScheme(testscheme).WithObjects(objs...).Build(),
+			Ctx:             context.TODO(),
+			Log:             logr.Discard(),
+			TargetNamespace: "ztp-install",
+			PolicyName:      "resource-sample-ori",
+			PolicyNamespace: "ztp-common",
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			var inputData interface{}
+			if err := yaml.Unmarshal([]byte(tc.input), &inputData); err != nil {
+				t.Errorf("Unexpected error: %v", err.Error())
+			}
+
+			actualResult, err := r.ResolveObjectHubTemplates(inputData)
+			if err != nil {
+				assert.ErrorContains(t, err, tc.expected)
+			} else {
+				var expectedResult interface{}
+				if err := yaml.Unmarshal([]byte(tc.expected), &expectedResult); err != nil {
+					t.Errorf("Unexpected error: %v", err.Error())
+				}
+				assert.Equal(t, expectedResult, actualResult)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,10 @@ require (
 	sigs.k8s.io/controller-runtime v0.9.3-0.20210709165254-650ea59f19cc
 )
 
-require golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27
+require (
+	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
 
 require (
 	cloud.google.com/go v0.65.0 // indirect
@@ -88,7 +91,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiextensions-apiserver v0.21.3 // indirect
 	k8s.io/component-base v0.21.3 // indirect
 	k8s.io/klog/v2 v2.9.0 // indirect


### PR DESCRIPTION
ACM hub cluster resource-specific template functions are restricted to the same
namespace as the policy is defined on the hub cluster due to security concerns,
so TALM cannot work with hub cluster template as TALM creates the copied policies
in the namespace where the CGU is created. This commit updates to support the
hub-side resource-specific function fromConfigMap by replicating the configmap
to the CGU namespace.

Changes included:
 - validate managed policies before reconciling resources, requeue with medium interval
   and update CGU status when invalid policies found
 - search for hub templates in each managed policy and replicate configmap in the CGU namespace
 - update the policy hub template with replicated configmap
 - requeue with medium interval when unsupported templates found
   i.e. printf variable in resource Name/Namespace field
        fromSecret/lookup functions
 - unittest for valid and invalid hub templates usage