### PR TITLE
[release-4.10] Enhancement CNF-3932: Configurable action on batch timeout (Cherry Pick)

### DIFF
--- a/api/v1alpha1/clustergroupupgrade_types.go
+++ b/api/v1alpha1/clustergroupupgrade_types.go
@@ -72,6 +72,15 @@ type AfterCompletion struct {
 	DeleteObjects *bool `json:"deleteObjects,omitempty"`
 }
 
+// BatchTimeoutAction selections
+var BatchTimeoutAction = struct {
+	Continue string
+	Abort    string
+}{
+	Continue: "Continue",
+	Abort:    "Abort",
+}
+
 // OperatorUpgradeSpec defines the configuration of an operator upgrade
 type OperatorUpgradeSpec struct {
 	Channel   string `json:"channel,omitempty"`
@@ -120,6 +129,12 @@ type ClusterGroupUpgradeSpec struct {
 	BlockingCRs []BlockingCR `json:"blockingCRs,omitempty"`
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Actions",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Actions Actions `json:"actions,omitempty"`
+	// The Batch Timeout Action can be specified to control what happens when a batch times out. The default value is `Continue`.
+	// The possible values are:
+	//   - Continue
+	//   - Abort
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="BatchTimeoutAction",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	BatchTimeoutAction string `json:"batchTimeoutAction,omitempty"`
 }
 
 // ClusterRemediationProgress stores the remediation progress of a cluster

--- a/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -41,6 +41,13 @@ spec:
         path: actions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'The Batch Timeout Action can be specified to control what happens
+          when a batch times out. The default value is `Continue`. The possible values
+          are:   - Continue   - Abort'
+        displayName: BatchTimeoutAction
+        path: batchTimeoutAction
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Blocking CRs
         path: blockingCRs
         x-descriptors:

--- a/bundle/manifests/ran.openshift.io_clustergroupupgrades.yaml
+++ b/bundle/manifests/ran.openshift.io_clustergroupupgrades.yaml
@@ -89,6 +89,11 @@ spec:
                         type: object
                     type: object
                 type: object
+              batchTimeoutAction:
+                description: 'The Batch Timeout Action can be specified to control
+                  what happens when a batch times out. The default value is `Continue`.
+                  The possible values are:   - Continue   - Abort'
+                type: string
               blockingCRs:
                 items:
                   description: BlockingCR defines the Upgrade CRs that block the current

--- a/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
+++ b/config/crd/bases/ran.openshift.io_clustergroupupgrades.yaml
@@ -91,6 +91,11 @@ spec:
                         type: object
                     type: object
                 type: object
+              batchTimeoutAction:
+                description: 'The Batch Timeout Action can be specified to control
+                  what happens when a batch times out. The default value is `Continue`.
+                  The possible values are:   - Continue   - Abort'
+                type: string
               blockingCRs:
                 items:
                   description: BlockingCR defines the Upgrade CRs that block the current

--- a/config/manifests/bases/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -27,6 +27,13 @@ spec:
         path: actions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'The Batch Timeout Action can be specified to control what happens
+          when a batch times out. The default value is `Continue`. The possible values
+          are:   - Continue   - Abort'
+        displayName: BatchTimeoutAction
+        path: batchTimeoutAction
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Blocking CRs
         path: blockingCRs
         x-descriptors:

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -349,9 +349,21 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 							})
 						} else {
 							r.Log.Info("Batch upgrade timed out")
-							clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt = metav1.Time{}
-							if clusterGroupUpgrade.Status.Status.CurrentBatch < len(clusterGroupUpgrade.Status.RemediationPlan) {
-								clusterGroupUpgrade.Status.Status.CurrentBatch++
+							switch clusterGroupUpgrade.Spec.BatchTimeoutAction {
+							case ranv1alpha1.BatchTimeoutAction.Abort:
+								// If the value was abort then we need to fail out
+								meta.SetStatusCondition(&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
+									Type:    "Ready",
+									Status:  metav1.ConditionFalse,
+									Reason:  "UpgradeTimedOut",
+									Message: "The ClusterGroupUpgrade CR policies are taking too long to complete",
+								})
+							default:
+								// If the value was continue or not defined then continue
+								clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt = metav1.Time{}
+								if clusterGroupUpgrade.Status.Status.CurrentBatch < len(clusterGroupUpgrade.Status.RemediationPlan) {
+									clusterGroupUpgrade.Status.Status.CurrentBatch++
+								}
 							}
 						}
 					}


### PR DESCRIPTION
* Enhancement [CNF-3932](https://issues.redhat.com//browse/CNF-3932): Configurable action on batch timeout
* Allow specifying what to do when a batch timeout occurs
* Available options include:
    - Continue
    - Abort
* The default option if it is not specified is Continue
* May be expanded in the future with additional options
* Fix comment to meet linter requirements
* Remove explicit continue & just use default