### PR TITLE
[release-4.10] Enhancement CNF-5302: Do not apply any changes after timeout has elapsed (Cherry Pick)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In order to model the various phases of an upgrade, the ClusterGroupUpgrade CR c
     * If the **ClusterGroupUpgrade** has the first batch as canaries and the policies for this first batch are not compliant within the batch timeout
     * If the policies for the upgrade have not turned to compliant within the *timeout* value specified in the *remediationStrategy*
 * **UpgradeTimedOut**
-  * In this state, the controller will periodically check if all the policies for the **ClusterGroupUpgrade** are compliant, and in that case it will transition to **UpgradeCompleted**. This is to give a chance for upgrades to catch up, as they could be taking long to complete due to network, CPU or other issues but they are not really stuck and they can indeed complete
+  * In this state, the controller will remove all the *managedPolicies* copies created for the **ClusterGroupUpgrade**. This is to ensure that changes are not made after the **ClusterGroupUpgrade** has passed its specified timeout. The user may re-run the **ClusterGroupUpgrade** again (perhaps with a longer timeout) if they still need to enforce changes on the clusters.
 * **UpgradeCompleted**
   * In this state, the upgrades of the clusters are complete
   * If the *action.afterCompletion.deleteObjects* field is set to **true** (which is the default value), the controller will delete the underlying RHACM objects (policies, placement bindings, placement rules, managed cluster views) once the upgrade completes. This is to avoid having RHACM Hub to continously check for compliance since the upgrade has been successful.


### PR DESCRIPTION
* Enhancement [CNF-5302](https://issues.redhat.com//browse/CNF-5302): Do not apply any changes after timeout has elapsed
* Delete any policies created by the CGU if the CGU times out
* This will prevent a policy that was created but did not reconcile in time from applying at some indeterminate time later
* Enhancement [CNF-5302](https://issues.redhat.com//browse/CNF-5302): Add fixes after discussing PR
* Remove some code that is now unnecessary around checking if policies were reconciled before timing out
* Remove now unnecessary work around for checking for upgraded clusters
* Do not set completion time or most post actions on timeout
* Remove log messages that were for diagnostic purposes
* Clarify readme update