### PR TITLE
Enhancement CNF-4565: Do not create empty fields for managed policies that do not have appropriate content

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -848,6 +848,12 @@ func (r *ClusterGroupUpgradeReconciler) processManagedPolicyForUpgradeContent(
 			return err
 		}
 
+		// If the policy types did not return with useful data then continue to the next policy
+		// We don't want to create empty fields in the map with null values as that is confusing
+		if policyTypes == nil || len(policyTypes) == 0 {
+			continue
+		}
+
 		p, err := json.Marshal(policyTypes)
 		if err != nil {
 			return err

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -850,7 +850,7 @@ func (r *ClusterGroupUpgradeReconciler) processManagedPolicyForUpgradeContent(
 
 		// If the policy types did not return with useful data then continue to the next policy
 		// We don't want to create empty fields in the map with null values as that is confusing
-		if policyTypes == nil || len(policyTypes) == 0 {
+		if len(policyTypes) == 0 {
 			continue
 		}
 

--- a/tests/kuttl/tests/adjust-max-concurrency/00-assert.yaml
+++ b/tests/kuttl/tests/adjust-max-concurrency/00-assert.yaml
@@ -24,7 +24,6 @@ status:
   - cgu-adjust-max-conc-policy1-common-cluster-versio-kuttl
   - cgu-adjust-max-conc-policy2-common-pao-sub-policy-kuttl
   managedPoliciesContent:
-    policy1-common-cluster-version-policy: "null"
     policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","namespace":"openshift-performance-addon-operator"}]'
   managedPoliciesForUpgrade:
   - name: policy1-common-cluster-version-policy

--- a/tests/kuttl/tests/blocking-mechanisms/00-assert.yaml
+++ b/tests/kuttl/tests/blocking-mechanisms/00-assert.yaml
@@ -32,7 +32,6 @@ status:
   - cgu-a-policy2-common-pao-sub-policy-kuttl
   - cgu-a-policy3-common-ptp-sub-policy-kuttl
   managedPoliciesContent:
-    policy1-common-cluster-version-policy: "null"
     policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","namespace":"openshift-performance-addon-operator"}]'
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","namespace":"openshift-ptp"}]'
   managedPoliciesForUpgrade:
@@ -104,7 +103,6 @@ status:
   - cgu-b-policy3-common-ptp-sub-policy-kuttl
   - cgu-b-policy4-common-sriov-sub-policy-kuttl
   managedPoliciesContent:
-    policy1-common-cluster-version-policy: "null"
     policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","namespace":"openshift-performance-addon-operator"}]'
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","namespace":"openshift-ptp"}]'
     policy4-common-sriov-sub-policy: '[{"kind":"Subscription","name":"sriov-network-operator-subscription","namespace":"openshift-sriov-network-operator"}]'
@@ -183,7 +181,6 @@ status:
   - policy2-common-pao-sub-policy
   - policy3-common-ptp-sub-policy
   managedPoliciesContent:
-    policy1-common-cluster-version-policy: "null"
     policy4-common-sriov-sub-policy: '[{"kind":"Subscription","name":"sriov-network-operator-subscription","namespace":"openshift-sriov-network-operator"}]'
   managedPoliciesForUpgrade:
   - name: policy1-common-cluster-version-policy

--- a/tests/kuttl/tests/blocking-mechanisms/01-assert.yaml
+++ b/tests/kuttl/tests/blocking-mechanisms/01-assert.yaml
@@ -33,7 +33,6 @@ status:
   - cgu-a-policy2-common-pao-sub-policy-kuttl
   - cgu-a-policy3-common-ptp-sub-policy-kuttl
   managedPoliciesContent:
-    policy1-common-cluster-version-policy: "null"
     policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","namespace":"openshift-performance-addon-operator"}]'
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","namespace":"openshift-ptp"}]'
   managedPoliciesForUpgrade:
@@ -106,7 +105,6 @@ status:
   - cgu-b-policy3-common-ptp-sub-policy-kuttl
   - cgu-b-policy4-common-sriov-sub-policy-kuttl
   managedPoliciesContent:
-    policy1-common-cluster-version-policy: "null"
     policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","namespace":"openshift-performance-addon-operator"}]'
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","namespace":"openshift-ptp"}]'
     policy4-common-sriov-sub-policy: '[{"kind":"Subscription","name":"sriov-network-operator-subscription","namespace":"openshift-sriov-network-operator"}]'
@@ -185,7 +183,6 @@ status:
   - policy2-common-pao-sub-policy
   - policy3-common-ptp-sub-policy
   managedPoliciesContent:
-    policy1-common-cluster-version-policy: "null"
     policy4-common-sriov-sub-policy: '[{"kind":"Subscription","name":"sriov-network-operator-subscription","namespace":"openshift-sriov-network-operator"}]'
   managedPoliciesForUpgrade:
   - name: policy1-common-cluster-version-policy

--- a/tests/kuttl/tests/blocking-mechanisms/02-assert.yaml
+++ b/tests/kuttl/tests/blocking-mechanisms/02-assert.yaml
@@ -33,7 +33,6 @@ status:
   - cgu-a-policy2-common-pao-sub-policy-kuttl
   - cgu-a-policy3-common-ptp-sub-policy-kuttl
   managedPoliciesContent:
-    policy1-common-cluster-version-policy: "null"
     policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","namespace":"openshift-performance-addon-operator"}]'
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","namespace":"openshift-ptp"}]'
   managedPoliciesForUpgrade:
@@ -112,7 +111,6 @@ status:
   - cgu-b-policy3-common-ptp-sub-policy-kuttl
   - cgu-b-policy4-common-sriov-sub-policy-kuttl
   managedPoliciesContent:
-    policy1-common-cluster-version-policy: "null"
     policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","namespace":"openshift-performance-addon-operator"}]'
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","namespace":"openshift-ptp"}]'
     policy4-common-sriov-sub-policy: '[{"kind":"Subscription","name":"sriov-network-operator-subscription","namespace":"openshift-sriov-network-operator"}]'

--- a/tests/kuttl/tests/cluster-selector/00-assert.yaml
+++ b/tests/kuttl/tests/cluster-selector/00-assert.yaml
@@ -36,7 +36,6 @@ status:
   - cgu-cluster-selector-policy3-common-ptp-sub-polic-kuttl
   - cgu-cluster-selector-policy4-common-sriov-sub-pol-kuttl
   managedPoliciesContent:
-    policy1-common-cluster-version-policy: "null"
     policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","namespace":"openshift-performance-addon-operator"}]'
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","namespace":"openshift-ptp"}]'
     policy4-common-sriov-sub-policy: '[{"kind":"Subscription","name":"sriov-network-operator-subscription","namespace":"openshift-sriov-network-operator"}]'

--- a/tests/kuttl/tests/skip-compliant-policies/00-assert.yaml
+++ b/tests/kuttl/tests/skip-compliant-policies/00-assert.yaml
@@ -32,7 +32,6 @@ status:
   managedPoliciesCompliantBeforeUpgrade:
   - policy2-common-pao-sub-policy
   managedPoliciesContent:
-    policy1-common-cluster-version-policy: "null"
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","namespace":"openshift-ptp"}]'
     policy4-common-sriov-sub-policy: '[{"kind":"Subscription","name":"sriov-network-operator-subscription","namespace":"openshift-sriov-network-operator"}]'
   managedPoliciesForUpgrade:

--- a/tests/kuttl/tests/upgrade-complete/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/00-assert.yaml
@@ -24,7 +24,6 @@ status:
   - cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
   - cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
   managedPoliciesContent:
-    policy1-common-cluster-version-policy: "null"
     policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","namespace":"openshift-performance-addon-operator"}]'
   managedPoliciesForUpgrade:
   - name: policy1-common-cluster-version-policy

--- a/tests/kuttl/tests/upgrade-complete/01-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/01-assert.yaml
@@ -24,7 +24,6 @@ status:
   - cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
   - cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
   managedPoliciesContent:
-    policy1-common-cluster-version-policy: "null"
     policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","namespace":"openshift-performance-addon-operator"}]'
   managedPoliciesForUpgrade:
   - name: policy1-common-cluster-version-policy

--- a/tests/kuttl/tests/upgrade-complete/02-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/02-assert.yaml
@@ -24,7 +24,6 @@ status:
   - cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
   - cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
   managedPoliciesContent:
-    policy1-common-cluster-version-policy: "null"
     policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","namespace":"openshift-performance-addon-operator"}]'
   managedPoliciesForUpgrade:
   - name: policy1-common-cluster-version-policy


### PR DESCRIPTION
* Only create the managed policies field for policies that meet the general requirements for policy content, namely;
  1. Have kind subscription
  2. Have a namespace
  3. Have a name
* This will prevent policies from appearing with a content of `null` in the cgu status