### PR TITLE
Bug 2115480: Reconcile immediately after timeout

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -370,6 +370,9 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 							r.Log.Info("[Reconcile] Calculating batch timeout (minutes)", "currentBatchTimeout", fmt.Sprintf("%f", currentBatchTimeout.Minutes()))
 
 							if time.Since(clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt.Time) > currentBatchTimeout {
+								// We want to immediately continue to the next reconcile regardless of the timeout action
+								nextReconcile = requeueImmediately()
+
 								// Check if this was a canary or not
 								if len(clusterGroupUpgrade.Spec.RemediationStrategy.Canaries) != 0 &&
 									clusterGroupUpgrade.Status.Status.CurrentBatch <= len(clusterGroupUpgrade.Spec.RemediationStrategy.Canaries) {


### PR DESCRIPTION
* After timing out on a batch we should reconcile immediately
* If we don't we will just waste 5 minutes of timeout waiting for the next loop