### PR TITLE
Follow redirects when downloading operator-sdk tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ OPERATOR_SDK_VERSION = $(shell $(OPERATOR_SDK) version 2>/dev/null | sed 's/^ope
 OPERATOR_SDK_VERSION_REQ = v1.16.0-ocp
 operator-sdk: ## Download operator-sdk locally if necessary.
 ifneq ($(OPERATOR_SDK_VERSION_REQ),$(OPERATOR_SDK_VERSION))
-	curl https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/4.10.17/operator-sdk-v1.16.0-ocp-linux-x86_64.tar.gz | tar -xz -C bin/
+	curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/4.10.17/operator-sdk-v1.16.0-ocp-linux-x86_64.tar.gz | tar -xz -C bin/
 endif
 
 kustomize: ## Download kustomize locally if necessary.


### PR DESCRIPTION
Fix the ci-job operator-sdk download issue

Signed-off-by: Angie Wang <angwang@redhat.com>