### PR TITLE
CNF-6019: Improve backup and precaching conditions/reasons/messages

### DIFF
--- a/controllers/actions.go
+++ b/controllers/actions.go
@@ -19,10 +19,11 @@ func (r *ClusterGroupUpgradeReconciler) takeActionsBeforeEnable(
 	actionsBeforeEnable := clusterGroupUpgrade.Spec.Actions.BeforeEnable
 	// Add/delete cluster labels
 	if actionsBeforeEnable.AddClusterLabels != nil || actionsBeforeEnable.DeleteClusterLabels != nil {
-		clusters, err := r.getAllClustersForUpgrade(ctx, clusterGroupUpgrade)
+		clusters, err := r.getSuccessfulClustersList(ctx, clusterGroupUpgrade, "upgrade")
 		if err != nil {
 			return err
 		}
+		r.Log.Info("[actions]", "clusterList", clusters)
 		labels := map[string]map[string]string{
 			"add":    actionsBeforeEnable.AddClusterLabels,
 			"delete": actionsBeforeEnable.DeleteClusterLabels,
@@ -44,10 +45,11 @@ func (r *ClusterGroupUpgradeReconciler) takeActionsAfterCompletion(
 	actionsAfterCompletion := clusterGroupUpgrade.Spec.Actions.AfterCompletion
 	// Add/delete cluster labels
 	if actionsAfterCompletion.AddClusterLabels != nil || actionsAfterCompletion.DeleteClusterLabels != nil {
-		clusters, err := r.getAllClustersForUpgrade(ctx, clusterGroupUpgrade)
+		clusters, err := r.getSuccessfulClustersList(ctx, clusterGroupUpgrade, "upgrade")
 		if err != nil {
 			return err
 		}
+		r.Log.Info("[actions]", "clusterList", clusters)
 		labels := map[string]map[string]string{
 			"add":    actionsAfterCompletion.AddClusterLabels,
 			"delete": actionsAfterCompletion.DeleteClusterLabels,
@@ -169,10 +171,11 @@ func (r *ClusterGroupUpgradeReconciler) deleteResources(
 		return fmt.Errorf("failed to delete precaching objects for CGU %s: %v", clusterGroupUpgrade.Name, err)
 	}
 
-	clusters, err := r.getAllClustersForUpgrade(ctx, clusterGroupUpgrade)
+	clusters, err := r.getSuccessfulClustersList(ctx, clusterGroupUpgrade, "upgrade")
 	if err != nil {
 		return fmt.Errorf("cannot obtain all the details about the clusters in the CR: %s", err)
 	}
+	r.Log.Info("[actions]", "clusterList", clusters)
 	err = utils.DeleteMultiCloudObjects(ctx, r.Client, clusterGroupUpgrade, clusters)
 	if err != nil {
 		return fmt.Errorf("failed to delete MultiCloud objects for CGU %s: %v", clusterGroupUpgrade.Name, err)

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -267,7 +267,7 @@ func (r *ClusterGroupUpgradeReconciler) checkAllBackupDone(
 	}
 
 	// Compare the total number of clusters to their status
-	switch len(clusterGroupUpgrade.Status.Precaching.Status) {
+	switch len(clusterGroupUpgrade.Status.Backup.Status) {
 	// All clusters were successful
 	case successfulBackupCount:
 		utils.SetStatusCondition(

--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -211,7 +211,7 @@ func (r *ClusterGroupUpgradeReconciler) backupActive(ctx context.Context, cluste
 
 	switch condition {
 	case JobActive:
-		nextState = PrecacheStateActive
+		nextState = BackupStateActive
 
 	case JobSucceeded:
 		nextState = BackupStateSucceeded
@@ -305,4 +305,5 @@ func (r *ClusterGroupUpgradeReconciler) checkAllBackupDone(
 			fmt.Sprintf("Backup in progress for %d clusters", progressingBackupCount),
 		)
 	}
+
 }

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -171,7 +171,8 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 		}
 	}
 
-	if clusterGroupUpgrade.Status.Backup == nil || meta.IsStatusConditionTrue(clusterGroupUpgrade.Status.Conditions, string(utils.ConditionTypes.BackupSuceeded)) {
+	backupCondition := meta.FindStatusCondition(clusterGroupUpgrade.Status.Conditions, string(utils.ConditionTypes.BackupSuceeded))
+	if clusterGroupUpgrade.Status.Backup == nil || (backupCondition != nil && backupCondition.Status == metav1.ConditionTrue) {
 		err = r.reconcilePrecaching(ctx, clusterGroupUpgrade)
 		if err != nil {
 			r.Log.Error(err, "reconcilePrecaching error")

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -171,7 +171,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 		}
 	}
 
-	if clusterGroupUpgrade.Status.Backup == nil || meta.IsStatusConditionTrue(clusterGroupUpgrade.Status.Conditions, BackupStateDone) {
+	if clusterGroupUpgrade.Status.Backup == nil || meta.IsStatusConditionTrue(clusterGroupUpgrade.Status.Conditions, string(utils.ConditionTypes.BackupSuceeded)) {
 		err = r.reconcilePrecaching(ctx, clusterGroupUpgrade)
 		if err != nil {
 			r.Log.Error(err, "reconcilePrecaching error")

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -118,7 +118,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 	}()
 
 	nextReconcile = doNotRequeue()
-	// Wait a bit so that API server/etcd syncs up and this reconsile has a better chance of getting the updated CGU and policies
+	// Wait a bit so that API server/etcd syncs up and this reconcile has a better chance of getting the updated CGU and policies
 	time.Sleep(statusUpdateWaitInMilliSeconds * time.Millisecond)
 	clusterGroupUpgrade := &ranv1alpha1.ClusterGroupUpgrade{}
 	err = r.Get(ctx, req.NamespacedName, clusterGroupUpgrade)

--- a/controllers/managedClusterResources.go
+++ b/controllers/managedClusterResources.go
@@ -296,6 +296,7 @@ func (r *ClusterGroupUpgradeReconciler) jobAndViewCleanup(
 		return nil
 	}
 
+	// we must fetch all the clusters rather than the only successful ones.
 	clusters, err := r.getAllClustersForUpgrade(ctx, clusterGroupUpgrade)
 	if err != nil {
 		return fmt.Errorf("[jobandViewCleanup]cannot obtain the CGU cluster list: %s", err)

--- a/controllers/precache.go
+++ b/controllers/precache.go
@@ -39,11 +39,11 @@ func (r *ClusterGroupUpgradeReconciler) reconcilePrecaching(
 			}
 		}
 
-		doneCondition := meta.FindStatusCondition(
+		precachingCondition := meta.FindStatusCondition(
 			clusterGroupUpgrade.Status.Conditions, string(utils.ConditionTypes.PrecachingSuceeded))
 		r.Log.Info("[reconcilePrecaching]",
-			"FindStatusCondition", doneCondition)
-		if doneCondition != nil && doneCondition.Status == metav1.ConditionTrue {
+			"FindStatusCondition", precachingCondition)
+		if precachingCondition != nil && precachingCondition.Status == metav1.ConditionTrue {
 			// Precaching is done
 			return nil
 		}

--- a/controllers/precacheFsm.go
+++ b/controllers/precacheFsm.go
@@ -59,7 +59,7 @@ const (
 func (r *ClusterGroupUpgradeReconciler) precachingFsm(ctx context.Context,
 	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) error {
 
-	r.setPrecachingRequired(clusterGroupUpgrade)
+	r.setPrecachingStartedCondition(clusterGroupUpgrade)
 	specCondition := meta.FindStatusCondition(clusterGroupUpgrade.Status.Conditions, utils.PrecacheSpecValidCondition)
 	if specCondition == nil || specCondition.Status == metav1.ConditionFalse {
 		allManagedPoliciesExist, managedPoliciesMissing, managedPoliciesPresent, err := r.doManagedPoliciesExist(
@@ -70,11 +70,13 @@ func (r *ClusterGroupUpgradeReconciler) precachingFsm(ctx context.Context,
 		if !allManagedPoliciesExist {
 			statusMessage := fmt.Sprintf(
 				"The ClusterGroupUpgrade CR has managed policies that are missing: %s", managedPoliciesMissing)
-			meta.SetStatusCondition(&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
-				Type:    utils.PrecacheSpecValidCondition,
-				Status:  metav1.ConditionFalse,
-				Reason:  "NotAllManagedPoliciesExist",
-				Message: statusMessage})
+			utils.SetStatusCondition(
+				&clusterGroupUpgrade.Status.Conditions,
+				utils.ConditionTypes.PrecacheSpecValid,
+				utils.ConditionReasons.NotAllManagedPoliciesExist,
+				metav1.ConditionFalse,
+				statusMessage,
+			)
 			return nil
 		}
 
@@ -89,18 +91,22 @@ func (r *ClusterGroupUpgradeReconciler) precachingFsm(ctx context.Context,
 		}
 		ok, msg := r.checkPreCacheSpecConsistency(spec)
 		if !ok {
-			meta.SetStatusCondition(&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
-				Type:    utils.PrecacheSpecValidCondition,
-				Status:  metav1.ConditionFalse,
-				Reason:  "PrecacheSpecIsIncomplete",
-				Message: msg})
+			utils.SetStatusCondition(
+				&clusterGroupUpgrade.Status.Conditions,
+				utils.ConditionTypes.PrecacheSpecValid,
+				utils.ConditionReasons.InvalidPlatformImage,
+				metav1.ConditionFalse,
+				fmt.Sprintf("Precache spec is incomplete: %s", msg),
+			)
 			return nil
 		}
-		meta.SetStatusCondition(&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
-			Type:    utils.PrecacheSpecValidCondition,
-			Status:  metav1.ConditionTrue,
-			Reason:  "PrecacheSpecIsWellFormed",
-			Message: "Pre-caching spec is valid and consistent"})
+		utils.SetStatusCondition(
+			&clusterGroupUpgrade.Status.Conditions,
+			utils.ConditionTypes.PrecacheSpecValid,
+			utils.ConditionReasons.PrecacheSpecIsWellFormed,
+			metav1.ConditionTrue,
+			"Precache spec is valid and consistent",
+		)
 
 		clusterGroupUpgrade.Status.Precaching.Spec = &spec
 	}
@@ -344,48 +350,78 @@ func (r *ClusterGroupUpgradeReconciler) handleActive(ctx context.Context,
 	return nextState, nil
 }
 
-// setPrecachingRequired sets conditions of precaching required
-func (r *ClusterGroupUpgradeReconciler) setPrecachingRequired(
+// setPrecachingStartedCondition sets conditions of precaching required
+func (r *ClusterGroupUpgradeReconciler) setPrecachingStartedCondition(
 	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) {
-	meta.SetStatusCondition(
-		&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
-			Type:    "Ready",
-			Status:  metav1.ConditionFalse,
-			Reason:  "PrecachingRequired",
-			Message: "Precaching is not completed (required)"})
-
-	meta.SetStatusCondition(
-		&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
-			Type:    "PrecachingDone",
-			Status:  metav1.ConditionFalse,
-			Reason:  "PrecachingNotDone",
-			Message: "Precaching is required and not done"})
+	utils.SetStatusCondition(
+		&clusterGroupUpgrade.Status.Conditions,
+		utils.ConditionTypes.PrecachingSuceeded,
+		utils.ConditionReasons.InProgress,
+		metav1.ConditionFalse,
+		"Precaching is not completed",
+	)
 }
 
 // checkAllPrecachingDone handles alleviation of PrecachingDone==False condition
 func (r *ClusterGroupUpgradeReconciler) checkAllPrecachingDone(
 	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) {
-	// Handle completion
-	if func() bool {
-		for _, state := range clusterGroupUpgrade.Status.Precaching.Status {
-			if state != PrecacheStateSucceeded {
-				return false
-			}
+
+	// Counts for the various cluster states
+	var failedPrecacheCount int = 0
+	var progressingPrecacheCount int = 0
+	var successfulPrecacheCount int = 0
+
+	// Loop over all the clusters and take count of all their states
+	for _, state := range clusterGroupUpgrade.Status.Precaching.Status {
+		switch state {
+		case PrecacheStateSucceeded:
+			successfulPrecacheCount++
+		case PrecacheStateActive:
+		case PrecacheStateStarting:
+		case PrecacheStatePreparingToStart:
+			progressingPrecacheCount++
+		default:
+			failedPrecacheCount++
 		}
-		return true
-	}() {
-		meta.SetStatusCondition(
-			&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
-				Type:    "Ready",
-				Status:  metav1.ConditionFalse,
-				Reason:  "UpgradeNotStarted",
-				Message: "Precaching is completed"})
-		meta.SetStatusCondition(
-			&clusterGroupUpgrade.Status.Conditions, metav1.Condition{
-				Type:    "PrecachingDone",
-				Status:  metav1.ConditionTrue,
-				Reason:  "PrecachingCompleted",
-				Message: "Precaching is completed"})
-		meta.RemoveStatusCondition(&clusterGroupUpgrade.Status.Conditions, "PrecacheSpecValid")
+	}
+
+	// Compare the total number of clusters to their status
+	switch len(clusterGroupUpgrade.Status.Precaching.Status) {
+	// All clusters were successful
+	case successfulPrecacheCount:
+		utils.SetStatusCondition(
+			&clusterGroupUpgrade.Status.Conditions,
+			utils.ConditionTypes.PrecachingSuceeded,
+			utils.ConditionReasons.Completed,
+			metav1.ConditionTrue,
+			"Precaching is completed for all clusters",
+		)
+	// All clusters failed
+	case failedPrecacheCount:
+		utils.SetStatusCondition(
+			&clusterGroupUpgrade.Status.Conditions,
+			utils.ConditionTypes.PrecachingSuceeded,
+			utils.ConditionReasons.Failed,
+			metav1.ConditionTrue,
+			"Precaching failed for all clusters",
+		)
+	// All clusters are completed but some failed
+	case (failedPrecacheCount + successfulPrecacheCount):
+		utils.SetStatusCondition(
+			&clusterGroupUpgrade.Status.Conditions,
+			utils.ConditionTypes.PrecachingSuceeded,
+			utils.ConditionReasons.PartiallyDone,
+			metav1.ConditionTrue,
+			fmt.Sprintf("Precaching failed for %d clusters", failedPrecacheCount),
+		)
+	// Clusters are still in progress
+	default:
+		utils.SetStatusCondition(
+			&clusterGroupUpgrade.Status.Conditions,
+			utils.ConditionTypes.PrecachingSuceeded,
+			utils.ConditionReasons.InProgress,
+			metav1.ConditionTrue,
+			fmt.Sprintf("Precaching in progress for %d clusters", progressingPrecacheCount),
+		)
 	}
 }

--- a/controllers/precacheFsm.go
+++ b/controllers/precacheFsm.go
@@ -377,9 +377,7 @@ func (r *ClusterGroupUpgradeReconciler) checkAllPrecachingDone(
 		switch state {
 		case PrecacheStateSucceeded:
 			successfulPrecacheCount++
-		case PrecacheStateActive:
-		case PrecacheStateStarting:
-		case PrecacheStatePreparingToStart:
+		case PrecacheStateActive, PrecacheStateStarting, PrecacheStatePreparingToStart:
 			progressingPrecacheCount++
 		default:
 			failedPrecacheCount++
@@ -403,7 +401,7 @@ func (r *ClusterGroupUpgradeReconciler) checkAllPrecachingDone(
 			&clusterGroupUpgrade.Status.Conditions,
 			utils.ConditionTypes.PrecachingSuceeded,
 			utils.ConditionReasons.Failed,
-			metav1.ConditionTrue,
+			metav1.ConditionFalse,
 			"Precaching failed for all clusters",
 		)
 	// All clusters are completed but some failed
@@ -421,7 +419,7 @@ func (r *ClusterGroupUpgradeReconciler) checkAllPrecachingDone(
 			&clusterGroupUpgrade.Status.Conditions,
 			utils.ConditionTypes.PrecachingSuceeded,
 			utils.ConditionReasons.InProgress,
-			metav1.ConditionTrue,
+			metav1.ConditionFalse,
 			fmt.Sprintf("Precaching in progress for %d clusters", progressingPrecacheCount),
 		)
 	}

--- a/controllers/precacheFsm.go
+++ b/controllers/precacheFsm.go
@@ -119,10 +119,11 @@ func (r *ClusterGroupUpgradeReconciler) precachingFsm(ctx context.Context,
 	if len(clusterGroupUpgrade.Status.Precaching.Clusters) != 0 {
 		clusters = clusterGroupUpgrade.Status.Precaching.Clusters
 	} else {
-		clusters, err = r.getAllClustersForUpgrade(ctx, clusterGroupUpgrade)
+		clusters, err = r.getSuccessfulClustersList(ctx, clusterGroupUpgrade, "")
 		if err != nil {
 			return fmt.Errorf("cannot obtain the CGU cluster list: %s", err)
 		}
+		r.Log.Info("[precachingFsm]", "clusterList", clusters)
 		clusterGroupUpgrade.Status.Precaching.Clusters = clusters
 	}
 

--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -1,0 +1,77 @@
+package utils
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ConditionType is a string representing the condition's type
+type ConditionType string
+
+// ConditionTypes define the different types of conditions that will be set
+var ConditionTypes = struct {
+	BackupSuceeded     ConditionType
+	ClustersSelected   ConditionType
+	PrecacheSpecValid  ConditionType
+	PrecachingSuceeded ConditionType
+	Progressing        ConditionType
+	Succeeded          ConditionType
+	Validated          ConditionType
+}{
+	BackupSuceeded:     "BackupSuceeded",
+	ClustersSelected:   "ClustersSelected",
+	PrecacheSpecValid:  "PrecacheSpecValid",
+	PrecachingSuceeded: "PrecachingSuceeded",
+	Progressing:        "Progressing",
+	Succeeded:          "Succeeded",
+	Validated:          "Validated",
+}
+
+// ConditionReason is a string representing the condition's reason
+type ConditionReason string
+
+// ConditionReasons define the different reasons that conditions will be set for
+var ConditionReasons = struct {
+	Completed                  ConditionReason
+	Failed                     ConditionReason
+	IncompleteBlockingCR       ConditionReason
+	InProgress                 ConditionReason
+	InvalidPlatformImage       ConditionReason
+	MissingBlockingCR          ConditionReason
+	NotAllManagedPoliciesExist ConditionReason
+	NotEnabled                 ConditionReason
+	NotFound                   ConditionReason
+	NotPresent                 ConditionReason
+	PartiallyDone              ConditionReason
+	PrecacheSpecIsWellFormed   ConditionReason
+	UpgradeCompleted           ConditionReason
+	UpgradeTimedOut            ConditionReason
+}{
+	Completed:                  "Completed",
+	Failed:                     "Failed",
+	IncompleteBlockingCR:       "IncompleteBlockingCR",
+	InProgress:                 "InProgress",
+	InvalidPlatformImage:       "InvalidPlatformImage",
+	MissingBlockingCR:          "MissingBlockingCR",
+	NotAllManagedPoliciesExist: "NotAllManagedPoliciesExist",
+	NotEnabled:                 "NotEnabled",
+	NotFound:                   "NotFound",
+	NotPresent:                 "NotPresent",
+	PartiallyDone:              "PartiallyDone",
+	PrecacheSpecIsWellFormed:   "PrecacheSpecIsWellFormed",
+	UpgradeCompleted:           "UpgradeCompleted",
+	UpgradeTimedOut:            "UpgradeTimedOut",
+}
+
+// SetStatusCondition is a convenience wrapper for meta.SetStatusCondition that takes in the types defined here and converts them to strings
+func SetStatusCondition(existingConditions *[]metav1.Condition, conditionType ConditionType, conditionReason ConditionReason, conditionStatus metav1.ConditionStatus, message string) {
+	meta.SetStatusCondition(
+		existingConditions,
+		metav1.Condition{
+			Type:    string(conditionType),
+			Status:  conditionStatus,
+			Reason:  string(conditionReason),
+			Message: message,
+		},
+	)
+}


### PR DESCRIPTION
    CNF-6019: Improve backup and precaching conditions/reasons/messages
    * This is a vertical slice focused on improving the conditions/reasons/messages for TALM specifically around backup and precaching
    * This will unblock some work for CNF-5872
    * Will be easier to test the additional changes to the main reconcile loop later
