### PR TITLE
Bug OCPBUGS-1159: Fix treating missing clusters in policy compliance status as compliant

### DIFF
--- a/deploy/upgrades/blocking-mechanisms/patch-policies-status.sh
+++ b/deploy/upgrades/blocking-mechanisms/patch-policies-status.sh
@@ -8,15 +8,20 @@ http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$1/po
 curl -k -s -X PATCH -H "Accept: application/json, */*" \
 -H "Content-Type: application/merge-patch+json" \
 http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$2/policies/policy2-common-pao-sub-policy/status \
---data '{"status":{"compliant":"Compliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"Compliant"}, {"clustername":"spoke2","clusternamespace":"spoke2","compliant":"Compliant"}, {"clustername":"spoke5","clusternamespace":"spoke5","compliant":"Compliant"}, {"clustername":"spoke6","clusternamespace":"spoke6","compliant":"Compliant"}]}}'
+--data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"}, {"clustername":"spoke2","clusternamespace":"spoke2","compliant":"NonCompliant"}, {"clustername":"spoke4","clusternamespace":"spoke4","compliant":"NonCompliant"}, {"clustername":"spoke6","clusternamespace":"spoke6","compliant":"Compliant"}]}}'
 
 curl -k -s -X PATCH -H "Accept: application/json, */*" \
 -H "Content-Type: application/merge-patch+json" \
 http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$3/policies/policy3-common-ptp-sub-policy/status \
---data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke2","clusternamespace":"spoke2","compliant":"NonCompliant"}, {"clustername":"spoke4","clusternamespace":"spoke4","compliant":"NonCompliant"}]}}'
+--data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke2","clusternamespace":"spoke2","compliant":"NonCompliant"}, {"clustername":"spoke4","clusternamespace":"spoke4","compliant":"NonCompliant"},{"clustername":"spoke6","clusternamespace":"spoke6","compliant":"Compliant"}]}}'
 
 curl -k -s -X PATCH -H "Accept: application/json, */*" \
 -H "Content-Type: application/merge-patch+json" \
 http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$4/policies/policy4-common-sriov-sub-policy/status \
+--data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke4","clusternamespace":"spoke4","compliant":"NonCompliant"}, {"clustername":"spoke5","clusternamespace":"spoke5","compliant":"NonCompliant"}, {"clustername":"spoke6","clusternamespace":"spoke6","compliant":"NonCompliant"}]}}'
+
+curl -k -s -X PATCH -H "Accept: application/json, */*" \
+-H "Content-Type: application/merge-patch+json" \
+http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$4/policies/policy5-subscriptions/status \
 --data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke4","clusternamespace":"spoke4","compliant":"NonCompliant"}, {"clustername":"spoke5","clusternamespace":"spoke5","compliant":"NonCompliant"}, {"clustername":"spoke6","clusternamespace":"spoke6","compliant":"NonCompliant"}]}}'
 

--- a/tests/kuttl/tests/blocking-mechanisms/00-setup-blocking-mechanisms.yaml
+++ b/tests/kuttl/tests/blocking-mechanisms/00-setup-blocking-mechanisms.yaml
@@ -13,7 +13,7 @@ commands:
     namespaced: true
 
   # Patch the inform policies to reflect the compliance status.
-  - command: ../../../../deploy/acm/policies/patch-policies-status.sh default default default default
+  - command: ../../../../deploy/upgrades/blocking-mechanisms/patch-policies-status.sh default default default default
     ignoreFailure: false
 
   # Create all the child policies to map the inform policies above.


### PR DESCRIPTION
Now checks specifically if the cluster is compliant with policy and don't consider missing clusters as compliant.

Signed-off-by: Saeid Askari <saskari@redhat.com>