### PR TITLE
CNF-6019: Fix issue with backup introduced in first vertical slice

### DIFF
--- a/controllers/backup.go
+++ b/controllers/backup.go
@@ -17,7 +17,6 @@ const (
 	BackupStateStarting         = "Starting"
 	BackupStateActive           = "Active"
 	BackupStateSucceeded        = "Succeeded"
-	BackupStateDone             = "BackupDone"
 	BackupStateTimeout          = "BackupTimeout"
 	BackupStateError            = "UnrecoverableError"
 )
@@ -255,7 +254,7 @@ func (r *ClusterGroupUpgradeReconciler) checkAllBackupDone(
 	// Loop over all the clusters and take count of all their states
 	for _, state := range clusterGroupUpgrade.Status.Backup.Status {
 		switch state {
-		case BackupStateDone:
+		case BackupStateSucceeded:
 			successfulBackupCount++
 		case BackupStateActive, BackupStateStarting, BackupStatePreparingToStart:
 			progressingBackupCount++


### PR DESCRIPTION
I'm not sure why this Done state even existed or how I ended up using it instead of the succeeded state. Its not used anywhere else so I've just removed it and updated the switch case to the correct state.

Precaching is not affected by the same issue as it already uses the correct state, and does not have a misleading Done state.


