### PR TITLE
Use overlayfs storage driver

### DIFF
--- a/Dockerfile.precache
+++ b/Dockerfile.precache
@@ -8,6 +8,5 @@ COPY pre-cache/release \
      pre-cache/precache.sh \
      pre-cache/copy-env.sh \
      /opt/precache
-COPY pre-cache/storage.conf /etc/containers/
 ENV PATH="/opt/precache:/host/usr/bin:/host/usr/libexec:${PATH}"
 ENV LD_LIBRARY_PATH="/host/usr/lib64"

--- a/pre-cache/copy-env.sh
+++ b/pre-cache/copy-env.sh
@@ -22,7 +22,9 @@ for lib in "${libs[@]}"; do
 done
 
 # Copy containers policy and cacert of disconnected registries if present
+mkdir /etc/containers
 cp /host/etc/containers/policy.json /etc/containers/policy.json
+cp /host/etc/containers/storage.conf /etc/containers/storage.conf
 cp /host/etc/containers/registries.conf /etc/containers/registries.conf || true
 cp -a /host/etc/docker /etc/ || true
 # shellcheck disable=SC2015

--- a/pre-cache/storage.conf
+++ b/pre-cache/storage.conf
@@ -1,7 +1,0 @@
-[storage]
-driver = "vfs"
-runroot = "/var/run/containers/storage"
-graphroot = "/var/lib/containers/storage"
-[storage.options]
-size = ""
-override_kernel_check = "true"


### PR DESCRIPTION
This commit is fixing the following error in pre-caching: 'libsubid.so.3: cannot open shared object file:
 No such file or directory\n"'
The libsubid.so.3 is a podman dependency used when container storage is configured with vfs driver.
This library was absent from UBI images for some time (https://bugzilla.redhat.com/show_bug.cgi?id=2084179) Pre-caching implementation had a remainder from experimenting with vfs driver, that this commit removes, eliminating the need for libsubid.so.3.

/cc @alosadagrande  @jc-rh 