### PR TITLE
add pod security labels

### DIFF
--- a/controllers/managedClusterResources_test.go
+++ b/controllers/managedClusterResources_test.go
@@ -48,6 +48,8 @@ spec:
       kind: Namespace
       metadata:
         name: openshift-talo-pre-cache
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
         annotations:
           workload.openshift.io/allowed: management
 `,

--- a/controllers/templates/backup-templates.go
+++ b/controllers/templates/backup-templates.go
@@ -15,6 +15,8 @@ spec:
       kind: Namespace
       metadata: 
         name: openshift-talo-backup
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
         annotations:
           workload.openshift.io/allowed: management
 

--- a/controllers/templates/precache-templates.go
+++ b/controllers/templates/precache-templates.go
@@ -34,6 +34,8 @@ spec:
       kind: Namespace
       metadata:
         name: openshift-talo-pre-cache
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
         annotations:
           workload.openshift.io/allowed: management
 `


### PR DESCRIPTION
Adds pod security labels for backup and precaching namespaces. This is needed to allow these workloads to run privileged.

Signed-off-by: Vitaly Grinberg <vgrinber@redhat.com>

/cc @jc-rh  @sabbir-47 