### PR TITLE
CNF-5558: Improve cluster selection when combining multiple methods of specifing clusters in a CGU

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ A few important ones to consider are:
 * **ClustersSelected**
   * In this state, the list of clusters that will be considered for the **ClusterGroupUpgrade** will be checked.
   * If any of the clusters are not present then the condition will block further progress of the **ClusterGroupUpgrade**
-  * The cluster list will be generated in a set order which may later be divided into batches if necessary. The list order is the combination of the specific clusters from the **clusters** option, the clusters selected by the **labelSelectors** option, and the clusters selected by the **clusterSelectors** option. All of these selected clusters are then sorted into one alphabetical list.
+  * The cluster list will be generated in a set order which may later be divided into batches if necessary. The order is:
+    * All the clusters explicitly specified using the *cluster* option on the *ClusterGroupUpgrade* configuration (This subset will be processed in the order defined in the configuration)
+    * All the clusters that match the *clusterLabelSelectors* and *clusterSelector* options on the *ClusterGroupUpgrade* configuration (This subset will be sorted in alphabetical order)
 * **NotEnabled**
   * In this state, the **ClusterGroupUpgrade** CR has just been created and the *enable* field is set to *false*
   * The controller will build a remediation plan based on the *clusters* list and with *enable* fields like:

--- a/deploy/upgrades/skip-compliant-policies/skip-compliant-policies.yaml
+++ b/deploy/upgrades/skip-compliant-policies/skip-compliant-policies.yaml
@@ -13,10 +13,10 @@ spec:
     - policy4-common-sriov-sub-policy
   enable: true
   clusters:
-  - spoke1
-  - spoke2
-  - spoke5
   - spoke6
+  - spoke2
+  - spoke1
+  - spoke5
   remediationStrategy:
     maxConcurrency: 4
 

--- a/tests/kuttl/tests/cluster-selector/00-assert.yaml
+++ b/tests/kuttl/tests/cluster-selector/00-assert.yaml
@@ -74,9 +74,9 @@ status:
   remediationPlan:
   - - spoke1
     - spoke2
+  - - spoke5
+    - spoke6
   - - spoke4
-    - spoke5
-  - - spoke6
   safeResourceNames:
     cgu-cluster-selector-common-cluster-version-policy-config: cgu-cluster-selector-common-cluster-version-policy-config-kuttl
     cgu-cluster-selector-common-pao-sub-policy-config: cgu-cluster-selector-common-pao-sub-policy-config-kuttl

--- a/tests/kuttl/tests/skip-compliant-policies/00-assert.yaml
+++ b/tests/kuttl/tests/skip-compliant-policies/00-assert.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: default
 spec:
   clusters:
-  - spoke1
-  - spoke2
-  - spoke5
   - spoke6
+  - spoke2
+  - spoke1
+  - spoke5
   enable: true
   managedPolicies:
   - policy1-common-cluster-version-policy
@@ -62,10 +62,10 @@ status:
   - cgu-policy3-common-ptp-sub-policy-placement-kuttl
   - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   remediationPlan:
-  - - spoke1
+  - - spoke6
     - spoke2
+    - spoke1
     - spoke5
-    - spoke6
   safeResourceNames:
     cgu-common-cluster-version-policy-config: cgu-common-cluster-version-policy-config-kuttl
     cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl


### PR DESCRIPTION
* After discussing with Jun yesterday, it is not a super great idea to sort the entire list
* If clusters are manually specified in the CGU, then the user probably wants them done in the order they specified
* Clusters chosen via selectors / label selectors will be sorted alphabetically and processed after any explicitly listed clusters
