### PR TITLE
CNF-6019: Fix issue with status not being updated when a non-managed cluster is specified

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -162,6 +162,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 				metav1.ConditionFalse,
 				fmt.Sprintf("Unable to select clusters: %s", err),
 			)
+			err = r.updateStatus(ctx, clusterGroupUpgrade)
 			return
 		}
 		utils.SetStatusCondition(


### PR DESCRIPTION
* Status must be updated before returning when the clusters selected condition is set to the error state