### PR TITLE
CNF-6019: Update validation stage with additional checks

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -203,7 +203,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 				utils.ConditionTypes.Validated,
 				utils.ConditionReasons.Completed,
 				metav1.ConditionTrue,
-				"Completed upgrade validation",
+				"Completed validation",
 			)
 
 			// Build the upgrade batches.

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -190,15 +190,21 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 			return
 		}
 		if allManagedPoliciesExist {
-			if !meta.IsStatusConditionTrue(clusterGroupUpgrade.Status.Conditions, string(utils.ConditionTypes.Validated)) {
-				utils.SetStatusCondition(
-					&clusterGroupUpgrade.Status.Conditions,
-					utils.ConditionTypes.Validated,
-					utils.ConditionReasons.Completed,
-					metav1.ConditionTrue,
-					"All managed policies exist",
-				)
+
+			err = r.validateOpenshiftUpgradeVersion(clusterGroupUpgrade, managedPoliciesInfo.presentPolicies)
+			if err != nil {
+				nextReconcile = requeueWithLongInterval()
+				err = r.updateStatus(ctx, clusterGroupUpgrade)
+				return
 			}
+
+			utils.SetStatusCondition(
+				&clusterGroupUpgrade.Status.Conditions,
+				utils.ConditionTypes.Validated,
+				utils.ConditionReasons.Completed,
+				metav1.ConditionTrue,
+				"Completed upgrade validation",
+			)
 
 			// Build the upgrade batches.
 			err = r.buildRemediationPlan(ctx, clusterGroupUpgrade, managedPoliciesInfo.presentPolicies)

--- a/controllers/precache.go
+++ b/controllers/precache.go
@@ -120,51 +120,6 @@ func (r *ClusterGroupUpgradeReconciler) extractPrecachingSpecFromPolicies(
 		for _, object := range objects {
 			kind := object["kind"]
 			switch kind {
-			case utils.ClusterVersionGroupVersionKind().Kind:
-				cvSpec := object["spec"].(map[string]interface{})
-				desiredUpdate, found := cvSpec["desiredUpdate"]
-				if !found {
-					continue
-				}
-				image, found := desiredUpdate.(map[string]interface{})["image"]
-				if found && image != "" {
-					if len(spec.PlatformImage) > 0 && spec.PlatformImage != image {
-						msg := fmt.Sprintf("Platform image must be set once, but %s and %s were given",
-							spec.PlatformImage, image)
-						utils.SetStatusCondition(
-							&clusterGroupUpgrade.Status.Conditions,
-							utils.ConditionTypes.PrecacheSpecValid,
-							utils.ConditionReasons.InvalidPlatformImage,
-							metav1.ConditionFalse,
-							msg,
-						)
-						return *new(ranv1alpha1.PrecachingSpec), nil
-					}
-					spec.PlatformImage = fmt.Sprintf("%s", image)
-				} else {
-					upstream := object["spec"].(map[string]interface {
-					})["upstream"].(string)
-					channel := object["spec"].(map[string]interface {
-					})["channel"].(string)
-					version := object["spec"].(map[string]interface {
-					})["desiredUpdate"].(map[string]interface{})["version"].(string)
-
-					image, err = r.getImageForVersionFromUpdateGraph(upstream, channel, version)
-
-					if err != nil {
-						utils.SetStatusCondition(
-							&clusterGroupUpgrade.Status.Conditions,
-							utils.ConditionTypes.PrecacheSpecValid,
-							utils.ConditionReasons.InvalidPlatformImage,
-							metav1.ConditionFalse,
-							err.Error(),
-						)
-						return *new(ranv1alpha1.PrecachingSpec), nil
-					}
-
-					spec.PlatformImage = image.(string)
-				}
-				r.Log.Info("[extractPrecachingSpecFromPolicies]", "ClusterVersion image", spec.PlatformImage)
 			case utils.SubscriptionGroupVersionKind().Kind:
 				packChan := fmt.Sprintf("%s:%s", object["spec"].(map[string]interface{})["name"],
 					object["spec"].(map[string]interface{})["channel"])
@@ -181,6 +136,15 @@ func (r *ClusterGroupUpgradeReconciler) extractPrecachingSpecFromPolicies(
 			}
 		}
 	}
+
+	// Get the platform image spec from the policies
+	_, _, _, image, err := r.extractCVOSpecFromPolicies(clusterGroupUpgrade, policies)
+	if err != nil {
+		return *new(ranv1alpha1.PrecachingSpec), err
+	}
+	spec.PlatformImage = image
+	r.Log.Info("[extractPrecachingSpecFromPolicies]", "ClusterVersion image", spec.PlatformImage)
+
 	return spec, nil
 }
 

--- a/controllers/precache.go
+++ b/controllers/precache.go
@@ -108,7 +108,6 @@ func (r *ClusterGroupUpgradeReconciler) getImageForVersionFromUpdateGraph(
 //        All the clusters in the CGU must have same catalog source(s)
 // returns: precachingSpec, error
 func (r *ClusterGroupUpgradeReconciler) extractPrecachingSpecFromPolicies(
-	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade,
 	policies []*unstructured.Unstructured) (ranv1alpha1.PrecachingSpec, error) {
 
 	var spec ranv1alpha1.PrecachingSpec

--- a/controllers/precache.go
+++ b/controllers/precache.go
@@ -138,7 +138,7 @@ func (r *ClusterGroupUpgradeReconciler) extractPrecachingSpecFromPolicies(
 	}
 
 	// Get the platform image spec from the policies
-	_, _, _, image, err := r.extractCVOSpecFromPolicies(clusterGroupUpgrade, policies)
+	image, err := r.extractOpenshiftImagePlatformFromPolicies(policies)
 	if err != nil {
 		return *new(ranv1alpha1.PrecachingSpec), err
 	}

--- a/controllers/precacheFsm.go
+++ b/controllers/precacheFsm.go
@@ -80,7 +80,7 @@ func (r *ClusterGroupUpgradeReconciler) precachingFsm(ctx context.Context,
 			return nil
 		}
 
-		spec, err := r.extractPrecachingSpecFromPolicies(clusterGroupUpgrade, managedPoliciesInfo.presentPolicies)
+		spec, err := r.extractPrecachingSpecFromPolicies(managedPoliciesInfo.presentPolicies)
 		if err != nil {
 			return err
 		}

--- a/controllers/validation.go
+++ b/controllers/validation.go
@@ -9,9 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func (r *ClusterGroupUpgradeReconciler) extractCVOSpecFromPolicies(
-	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade,
-	policies []*unstructured.Unstructured) (string, string, string, string, error) {
+func (r *ClusterGroupUpgradeReconciler) extractOpenshiftImagePlatformFromPolicies(
+	policies []*unstructured.Unstructured) (string, error) {
 
 	var upstream string
 	var channel string
@@ -21,7 +20,7 @@ func (r *ClusterGroupUpgradeReconciler) extractCVOSpecFromPolicies(
 	for _, policy := range policies {
 		objects, err := r.stripPolicy(policy.Object)
 		if err != nil {
-			return "", "", "", "", err
+			return "", err
 		}
 		for _, object := range objects {
 			kind := object["kind"]
@@ -34,57 +33,66 @@ func (r *ClusterGroupUpgradeReconciler) extractCVOSpecFromPolicies(
 				}
 				desiredUpdateImage, found := desiredUpdate.(map[string]interface{})["image"]
 				if found && desiredUpdateImage == "" {
-					return "", "", "", "", errors.New("platform image defined but value is missing")
+					return "", errors.New("platform image defined but value is missing")
 				}
 
 				upgradeDefinedMultipleTimes := false
 
 				if object["spec"] != "" {
-					nextUpstream := object["spec"].(map[string]interface{})["upstream"].(string)
-					if upstream == "" {
-						upstream = nextUpstream
-					} else if upstream != nextUpstream {
-						upgradeDefinedMultipleTimes = true
+
+					if object["spec"].(map[string]interface{})["upstream"] != nil {
+						nextUpstream := object["spec"].(map[string]interface{})["upstream"].(string)
+						if upstream == "" {
+							upstream = nextUpstream
+						} else if upstream != nextUpstream {
+							upgradeDefinedMultipleTimes = true
+						}
 					}
 
-					nextChannel := object["spec"].(map[string]interface{})["channel"].(string)
-					if channel == "" {
-						channel = nextChannel
-					} else if channel != nextChannel {
-						upgradeDefinedMultipleTimes = true
+					if object["spec"].(map[string]interface{})["channel"] != nil {
+						nextChannel := object["spec"].(map[string]interface{})["channel"].(string)
+						if channel == "" {
+							channel = nextChannel
+						} else if channel != nextChannel {
+							upgradeDefinedMultipleTimes = true
+						}
 					}
 
-					nextVersion := object["spec"].(map[string]interface{})["desiredUpdate"].(map[string]interface{})["version"].(string)
-					if version == "" {
-						version = nextVersion
-					} else if version != nextVersion {
-						upgradeDefinedMultipleTimes = true
+					if object["spec"].(map[string]interface{})["desiredUpdate"] != nil {
+						if object["spec"].(map[string]interface{})["desiredUpdate"].(map[string]interface{})["version"] != nil {
+							nextVersion := object["spec"].(map[string]interface{})["desiredUpdate"].(map[string]interface{})["version"].(string)
+							if version == "" {
+								version = nextVersion
+							} else if version != nextVersion {
+								upgradeDefinedMultipleTimes = true
+							}
+						}
 					}
 				}
 
 				if upgradeDefinedMultipleTimes {
-					return "", "", "", "", errors.New("platform image defined more then once with conflicting values")
+					return "", errors.New("platform image defined more then once with conflicting values")
 				}
 
 				image, err = r.getImageForVersionFromUpdateGraph(upstream, channel, version)
 				if err != nil {
-					return "", "", "", "", err
+					return "", err
 				}
 				if image == "" {
-					return "", "", "", "", errors.New("unable to find platform image for specified upstream, channel, and version")
+					return "", errors.New("unable to find platform image for specified upstream, channel, and version")
 				}
 			default:
 				continue
 			}
 		}
 	}
-	return channel, upstream, version, image, nil
+	return image, nil
 }
 
 func (r *ClusterGroupUpgradeReconciler) validateOpenshiftUpgradeVersion(
 	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, policies []*unstructured.Unstructured) error {
 
-	_, _, _, _, err := r.extractCVOSpecFromPolicies(clusterGroupUpgrade, policies)
+	_, err := r.extractOpenshiftImagePlatformFromPolicies(policies)
 	if err != nil {
 		utils.SetStatusCondition(
 			&clusterGroupUpgrade.Status.Conditions,

--- a/controllers/validation.go
+++ b/controllers/validation.go
@@ -1,0 +1,100 @@
+package controllers
+
+import (
+	"errors"
+
+	ranv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/api/v1alpha1"
+	utils "github.com/openshift-kni/cluster-group-upgrades-operator/controllers/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func (r *ClusterGroupUpgradeReconciler) extractCVOSpecFromPolicies(
+	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade,
+	policies []*unstructured.Unstructured) (string, string, string, string, error) {
+
+	var upstream string
+	var channel string
+	var version string
+	var image string
+
+	for _, policy := range policies {
+		objects, err := r.stripPolicy(policy.Object)
+		if err != nil {
+			return "", "", "", "", err
+		}
+		for _, object := range objects {
+			kind := object["kind"]
+			switch kind {
+			case utils.ClusterVersionGroupVersionKind().Kind:
+				cvSpec := object["spec"].(map[string]interface{})
+				desiredUpdate, found := cvSpec["desiredUpdate"]
+				if !found {
+					continue
+				}
+				desiredUpdateImage, found := desiredUpdate.(map[string]interface{})["image"]
+				if found && desiredUpdateImage == "" {
+					return "", "", "", "", errors.New("platform image defined but value is missing")
+				}
+
+				upgradeDefinedMultipleTimes := false
+
+				if object["spec"] != "" {
+					nextUpstream := object["spec"].(map[string]interface{})["upstream"].(string)
+					if upstream == "" {
+						upstream = nextUpstream
+					} else if upstream != nextUpstream {
+						upgradeDefinedMultipleTimes = true
+					}
+
+					nextChannel := object["spec"].(map[string]interface{})["channel"].(string)
+					if channel == "" {
+						channel = nextChannel
+					} else if channel != nextChannel {
+						upgradeDefinedMultipleTimes = true
+					}
+
+					nextVersion := object["spec"].(map[string]interface{})["desiredUpdate"].(map[string]interface{})["version"].(string)
+					if version == "" {
+						version = nextVersion
+					} else if version != nextVersion {
+						upgradeDefinedMultipleTimes = true
+					}
+				}
+
+				if upgradeDefinedMultipleTimes {
+					return "", "", "", "", errors.New("platform image defined more then once with conflicting values")
+				}
+
+				image, err = r.getImageForVersionFromUpdateGraph(upstream, channel, version)
+				if err != nil {
+					return "", "", "", "", err
+				}
+				if image == "" {
+					return "", "", "", "", errors.New("unable to find platform image for specified upstream, channel, and version")
+				}
+			default:
+				continue
+			}
+		}
+	}
+	return channel, upstream, version, image, nil
+}
+
+func (r *ClusterGroupUpgradeReconciler) validateOpenshiftUpgradeVersion(
+	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, policies []*unstructured.Unstructured) error {
+
+	_, _, _, _, err := r.extractCVOSpecFromPolicies(clusterGroupUpgrade, policies)
+	if err != nil {
+		utils.SetStatusCondition(
+			&clusterGroupUpgrade.Status.Conditions,
+			utils.ConditionTypes.Validated,
+			utils.ConditionReasons.InvalidPlatformImage,
+			metav1.ConditionFalse,
+			err.Error(),
+		)
+		return err
+	}
+
+	return nil
+}

--- a/deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+++ b/deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
@@ -31,11 +31,11 @@ spec:
             metadata:
               name: PlatformUpgrade
             spec:
-              channel: "4.9"
+              channel: "stable-4.9"
               desiredUpdate:
                 force: false
-                upstream: upstream
                 version: 4.9.8
+              upstream: https://api.openshift.com/api/upgrades_info/v1/graph
         remediationAction: inform
         severity: low
   remediationAction: inform

--- a/deploy/acm/policies/all_policies/policy1-common-cluster-version-policy.yaml
+++ b/deploy/acm/policies/all_policies/policy1-common-cluster-version-policy.yaml
@@ -28,11 +28,11 @@ spec:
             metadata:
               name: PlatformUpgrade
             spec:
-              channel: "4.9"
+              channel: "stable-4.9"
               desiredUpdate:
                 force: false
-                upstream: upstream
                 version: 4.9.8
+              upstream: https://api.openshift.com/api/upgrades_info/v1/graph
         remediationAction: inform
         severity: low
   remediationAction: inform

--- a/deploy/acm/policies/blocking_mechanisms/policy1-common-cluster-version-policy.yaml
+++ b/deploy/acm/policies/blocking_mechanisms/policy1-common-cluster-version-policy.yaml
@@ -28,11 +28,11 @@ spec:
             metadata:
               name: PlatformUpgrade
             spec:
-              channel: "4.9"
+              channel: "stable-4.9"
               desiredUpdate:
                 force: false
-                upstream: upstream
                 version: 4.9.8
+              upstream: https://api.openshift.com/api/upgrades_info/v1/graph
         remediationAction: inform
         severity: low
   remediationAction: inform

--- a/samples/precache/cluster-version-child-policy.yaml
+++ b/samples/precache/cluster-version-child-policy.yaml
@@ -33,7 +33,7 @@ spec:
             spec:
               clusterID: 0ed655d1-393e-40bb-b103-4dc9a89f54d3
               channel: "4.11"
-              upstream: upstream
+              upstream: https://api.openshift.com/api/upgrades_info/v1/graph
               desiredUpdate:
                 force: false
                 version: "4.9.11"

--- a/samples/precache/cluster-version-parent-policy.yaml
+++ b/samples/precache/cluster-version-parent-policy.yaml
@@ -33,7 +33,7 @@ spec:
             spec:
               clusterID: 0ed655d1-393e-40bb-b103-4dc9a89f54d3
               channel: "4.11"
-              upstream: upstream
+              upstream: https://api.openshift.com/api/upgrades_info/v1/graph
               desiredUpdate:
                 force: false
                 version: "4.9.11"

--- a/tests/kuttl/tests/adjust-max-concurrency/00-assert.yaml
+++ b/tests/kuttl/tests/adjust-max-concurrency/00-assert.yaml
@@ -20,7 +20,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/adjust-max-concurrency/00-assert.yaml
+++ b/tests/kuttl/tests/adjust-max-concurrency/00-assert.yaml
@@ -20,7 +20,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/blocking-mechanisms/00-assert.yaml
+++ b/tests/kuttl/tests/blocking-mechanisms/00-assert.yaml
@@ -27,7 +27,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated
@@ -105,7 +105,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated
@@ -190,7 +190,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/blocking-mechanisms/00-assert.yaml
+++ b/tests/kuttl/tests/blocking-mechanisms/00-assert.yaml
@@ -27,7 +27,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated
@@ -105,7 +105,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated
@@ -190,7 +190,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/blocking-mechanisms/01-assert.yaml
+++ b/tests/kuttl/tests/blocking-mechanisms/01-assert.yaml
@@ -27,7 +27,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated
@@ -106,7 +106,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated
@@ -192,7 +192,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/blocking-mechanisms/01-assert.yaml
+++ b/tests/kuttl/tests/blocking-mechanisms/01-assert.yaml
@@ -27,7 +27,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated
@@ -106,7 +106,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated
@@ -192,7 +192,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/blocking-mechanisms/02-assert.yaml
+++ b/tests/kuttl/tests/blocking-mechanisms/02-assert.yaml
@@ -28,7 +28,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated
@@ -112,7 +112,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/blocking-mechanisms/02-assert.yaml
+++ b/tests/kuttl/tests/blocking-mechanisms/02-assert.yaml
@@ -28,7 +28,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated
@@ -112,7 +112,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/cluster-selector/00-assert.yaml
+++ b/tests/kuttl/tests/cluster-selector/00-assert.yaml
@@ -30,7 +30,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/cluster-selector/00-assert.yaml
+++ b/tests/kuttl/tests/cluster-selector/00-assert.yaml
@@ -30,7 +30,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/operator-upgrade/00-assert.yaml
+++ b/tests/kuttl/tests/operator-upgrade/00-assert.yaml
@@ -22,7 +22,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/operator-upgrade/00-assert.yaml
+++ b/tests/kuttl/tests/operator-upgrade/00-assert.yaml
@@ -22,7 +22,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/operator-upgrade/01-assert.yaml
+++ b/tests/kuttl/tests/operator-upgrade/01-assert.yaml
@@ -22,7 +22,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/operator-upgrade/01-assert.yaml
+++ b/tests/kuttl/tests/operator-upgrade/01-assert.yaml
@@ -22,7 +22,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/policy-has-missing-cluster-status/00-assert.yaml
+++ b/tests/kuttl/tests/policy-has-missing-cluster-status/00-assert.yaml
@@ -24,7 +24,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/policy-has-missing-cluster-status/00-assert.yaml
+++ b/tests/kuttl/tests/policy-has-missing-cluster-status/00-assert.yaml
@@ -24,7 +24,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/policy-has-missing-cluster-status/01-assert.yaml
+++ b/tests/kuttl/tests/policy-has-missing-cluster-status/01-assert.yaml
@@ -24,7 +24,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/policy-has-missing-cluster-status/01-assert.yaml
+++ b/tests/kuttl/tests/policy-has-missing-cluster-status/01-assert.yaml
@@ -24,7 +24,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/skip-compliant-policies/00-assert.yaml
+++ b/tests/kuttl/tests/skip-compliant-policies/00-assert.yaml
@@ -25,7 +25,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/skip-compliant-policies/00-assert.yaml
+++ b/tests/kuttl/tests/skip-compliant-policies/00-assert.yaml
@@ -25,7 +25,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/upgrade-complete/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/00-assert.yaml
@@ -20,7 +20,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/upgrade-complete/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/00-assert.yaml
@@ -20,7 +20,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/upgrade-complete/01-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/01-assert.yaml
@@ -20,7 +20,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/upgrade-complete/01-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/01-assert.yaml
@@ -20,7 +20,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/upgrade-complete/02-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/02-assert.yaml
@@ -20,7 +20,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/upgrade-complete/02-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/02-assert.yaml
@@ -20,7 +20,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/upgrade-complete/03-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/03-assert.yaml
@@ -25,7 +25,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/upgrade-complete/03-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/03-assert.yaml
@@ -25,7 +25,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/upgrade-starts-complete/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-starts-complete/00-assert.yaml
@@ -19,7 +19,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: Completed upgrade validation
+  - message: Completed validation
     reason: Completed
     status: "True"
     type: Validated

--- a/tests/kuttl/tests/upgrade-starts-complete/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-starts-complete/00-assert.yaml
@@ -19,7 +19,7 @@ status:
     reason: Completed
     status: "True"
     type: ClustersSelected
-  - message: All managed policies exist
+  - message: Completed upgrade validation
     reason: Completed
     status: "True"
     type: Validated


### PR DESCRIPTION
* Move the validation of a specified openshift version from precaching to validation
* Whether or not precaching is enabled, if a CGU is specifing an Openshift version its important that we validate it
* Moved the extraction of the CVO details from policies into a helper function since it can be used twice