### PR TITLE
[release-4.11] OCPBUGS-1839: CGU Finalizer should not re-select clusters

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -1856,11 +1856,16 @@ func (r *ClusterGroupUpgradeReconciler) handleCguFinalizer(
 		if controllerutil.ContainsFinalizer(clusterGroupUpgrade, utils.CleanupFinalizer) {
 			// Run finalization logic for cguFinalizer. If the finalization logic fails, don't remove the finalizer so
 			// that we can retry during the next reconciliation.
-			clusters, err := r.getAllClustersForUpgrade(ctx, clusterGroupUpgrade)
-			if err != nil {
-				return utils.StopReconciling, fmt.Errorf("cannot obtain all the details about the clusters in the CR: %s", err)
+
+			// Get the list of clusters from the remediation plan
+			var clusters []string
+			// If there was an error selecting clusters or if no clusters required remediation
+			// then the plan will be empty, and no multicloud objects would have ever been created
+			for _, clusterBatch := range clusterGroupUpgrade.Status.RemediationPlan {
+				clusters = append(clusters, clusterBatch...)
 			}
-			err = utils.DeleteMultiCloudObjects(ctx, r.Client, clusterGroupUpgrade, clusters)
+
+			err := utils.DeleteMultiCloudObjects(ctx, r.Client, clusterGroupUpgrade, clusters)
 			if err != nil {
 				return utils.StopReconciling, err
 			}


### PR DESCRIPTION
* Backported from OCPBUGS-1739
* While LabelSelectors were not added until 4.12, it is still a problem here because the CGU Finalizer should not be re-selecting clusters
