### PR TITLE
OCPBUGS-2048: Fix issue with null value for managedPoliciesContent field

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -595,6 +595,11 @@ func (r *ClusterGroupUpgradeReconciler) addClustersStatusOnTimeout(
 		return
 	}
 
+	// check if there was a remediation plan at all
+	if len(clusterGroupUpgrade.Status.RemediationPlan) == 0 {
+		return
+	}
+
 	batchIndex := clusterGroupUpgrade.Status.Status.CurrentBatch - 1
 
 	for _, batchClusterName := range clusterGroupUpgrade.Status.RemediationPlan[batchIndex] {

--- a/controllers/monitoring.go
+++ b/controllers/monitoring.go
@@ -31,6 +31,11 @@ func (r *ClusterGroupUpgradeReconciler) processManagedPolicyForMonitoredObjects(
 			return err
 		}
 
+		// Attempting to marshal nil objects will result in a null value showing up in the managedPoliciesContent field
+		if monitoredObjects == nil {
+			continue
+		}
+
 		p, err := json.Marshal(monitoredObjects)
 		if err != nil {
 			return err


### PR DESCRIPTION
* Prevent a null value from showing up for a policy under managedPoliciesContent field
* Also fix an issue where under certain circumstances an index out of range error could occur when checking for cluster time (hit while working on the bug)