### PR TITLE
OCPBUGS-2600: remove LD_LIBRARY_PATH from precaching container

### DIFF
--- a/Dockerfile.precache
+++ b/Dockerfile.precache
@@ -7,5 +7,3 @@ COPY pre-cache/release \
      pre-cache/pull \
      pre-cache/precache.sh \
      /opt/precache
-ENV PATH="/opt/precache:/host/usr/bin:/host/usr/libexec:${PATH}"
-ENV LD_LIBRARY_PATH="/host/usr/lib64"


### PR DESCRIPTION
This commit removes obsolete code causing incompatibilities between ubi8-based containers and underlying RHCOS hosts.

Signed-off-by: Vitaly Grinberg <vgrinber@redhat.com>
/cc @jc-rh @nishant-parekh 