### PR TITLE
OCPBUGS-2072: CGU-Hangs-When-A-ManagedCluster-is-Unavailable

### DIFF
--- a/controllers/actions.go
+++ b/controllers/actions.go
@@ -167,10 +167,14 @@ func (r *ClusterGroupUpgradeReconciler) deleteResources(
 	if err != nil {
 		return fmt.Errorf("failed to delete MultiCloud objects for CGU %s: %v", clusterGroupUpgrade.Name, err)
 	}
-	err = r.jobAndViewCleanup(ctx, clusterGroupUpgrade, clusters)
-	if err != nil {
-		return fmt.Errorf("failed to delete precaching objects for CGU %s: %v", clusterGroupUpgrade.Name, err)
+
+	if clusterGroupUpgrade.Status.Precaching != nil || clusterGroupUpgrade.Status.Backup != nil {
+		err = r.jobAndViewCleanup(ctx, clusterGroupUpgrade)
+		if err != nil {
+			return fmt.Errorf("failed to delete precaching objects for CGU %s: %v", clusterGroupUpgrade.Name, err)
+		}
 	}
+
 	clusterGroupUpgrade.Status.SafeResourceNames = nil
 	return nil
 }

--- a/controllers/precacheFsm.go
+++ b/controllers/precacheFsm.go
@@ -160,7 +160,7 @@ func (r *ClusterGroupUpgradeReconciler) handleNotStarted(ctx context.Context,
 	r.Log.Info("[precachingFsm]", "currentState", currentState, "condition", "entry",
 		"cluster", cluster, "nextState", nextState)
 
-	err := r.deleteAllViews(ctx, cluster, precacheAllViews)
+	err := r.deleteManagedClusterObjects(ctx, cluster, precacheAllViews, utils.ManagedClusterViewPrefix)
 	if err != nil {
 		return currentState, err
 	}


### PR DESCRIPTION
- Not reachable cluster case handled for backup
- Introduced timeout for backup that prevent CGU from hanging
- Remaining MCA are deleted for non reachable clusters

Signed-off-by: Sabbir Hasan <sahasan@redhat.com>

/cc @jc-rh @fontivan 