### PR TITLE
OCPBUGS-4200: Prevent segfault due to nil memory access in certain situations

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -638,6 +638,8 @@ func (r *ClusterGroupUpgradeReconciler) addClustersStatusOnTimeout(
 
 	// If the index is longer then the remediation plan that would cause a nil access below
 	if batchIndex >= len(clusterGroupUpgrade.Status.RemediationPlan) {
+		r.Log.Info("Batch index out of range")
+		r.Log.Info("[addClustersStatusOnTimeout]", "RemediationPlan", clusterGroupUpgrade.Status.RemediationPlan)
 		return
 	}
 
@@ -654,6 +656,15 @@ func (r *ClusterGroupUpgradeReconciler) addClustersStatusOnTimeout(
 			clusterState.State = utils.ClusterRemediationComplete
 		} else {
 			clusterState.State = utils.ClusterRemediationTimedout
+
+			if clusterStatus.PolicyIndex == nil {
+				r.Log.Info("[addClustsersStatusOnTimeout] Undefined policy index for cluster")
+				r.Log.Info("[addClustersStatusOnTimeout]", "batchClusterName", batchClusterName)
+				r.Log.Info("[addClustersStatusOnTimeout]", "batchIndex", batchIndex)
+				r.Log.Info("[addClustersStatusOnTimeout]", "RemediationPlan", clusterGroupUpgrade.Status.RemediationPlan)
+				continue
+			}
+
 			policyIndex := *clusterStatus.PolicyIndex
 			// Avoid panics because of index out of bound in edge cases
 			if policyIndex < len(clusterGroupUpgrade.Status.ManagedPoliciesForUpgrade) {


### PR DESCRIPTION
* Add checks to prevent a seg fault while processing a cluster timeout
* Add logging to make it easier to identify when errors are found in addClustersStatusOnTimeout function