### PR TITLE
Execute afterCompletionAction on a per cluster basis

### DIFF
--- a/controllers/actions.go
+++ b/controllers/actions.go
@@ -40,6 +40,10 @@ func (r *ClusterGroupUpgradeReconciler) takeActionsBeforeEnable(
 func (r *ClusterGroupUpgradeReconciler) takeActionsAfterCompletion(
 	ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, cluster string) error {
 
+	clusterState := ranv1alpha1.ClusterState{
+		Name: cluster, State: utils.ClusterRemediationComplete}
+	clusterGroupUpgrade.Status.Clusters = append(clusterGroupUpgrade.Status.Clusters, clusterState)
+
 	actionsAfterCompletion := clusterGroupUpgrade.Spec.Actions.AfterCompletion
 	// Add/delete cluster labels
 	if actionsAfterCompletion.AddClusterLabels != nil || actionsAfterCompletion.DeleteClusterLabels != nil {

--- a/controllers/actions.go
+++ b/controllers/actions.go
@@ -26,37 +26,28 @@ func (r *ClusterGroupUpgradeReconciler) takeActionsBeforeEnable(
 			"delete": actionsBeforeEnable.DeleteClusterLabels,
 		}
 
-		if err := r.manageClusterLabels(ctx, clusters, labels); err != nil {
-			return err
+		for _, c := range clusters {
+			err := r.manageClusterLabels(ctx, c, labels)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
 	return nil
 }
 
-// takeActionsAfterCompletion takes the required actions after upgrade is completed
-// returns: error/nil
 func (r *ClusterGroupUpgradeReconciler) takeActionsAfterCompletion(
-	ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) error {
+	ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, cluster string) error {
 
 	actionsAfterCompletion := clusterGroupUpgrade.Spec.Actions.AfterCompletion
 	// Add/delete cluster labels
 	if actionsAfterCompletion.AddClusterLabels != nil || actionsAfterCompletion.DeleteClusterLabels != nil {
-		clusters := r.getClustersListFromRemediationPlan(clusterGroupUpgrade)
-		r.Log.Info("[actions]", "clusterList", clusters)
 		labels := map[string]map[string]string{
 			"add":    actionsAfterCompletion.AddClusterLabels,
 			"delete": actionsAfterCompletion.DeleteClusterLabels,
 		}
-
-		if err := r.manageClusterLabels(ctx, clusters, labels); err != nil {
-			return err
-		}
-	}
-
-	// Cleanup resources
-	if actionsAfterCompletion.DeleteObjects == nil || *actionsAfterCompletion.DeleteObjects {
-		err := r.deleteResources(ctx, clusterGroupUpgrade)
+		err := r.manageClusterLabels(ctx, cluster, labels)
 		if err != nil {
 			return err
 		}
@@ -67,22 +58,20 @@ func (r *ClusterGroupUpgradeReconciler) takeActionsAfterCompletion(
 
 // manageClusterLabels adds/deletes the cluster labels for selected clusters
 func (r *ClusterGroupUpgradeReconciler) manageClusterLabels(
-	ctx context.Context, clusters []string, labels map[string]map[string]string) error {
+	ctx context.Context, cluster string, labels map[string]map[string]string) error {
 
-	for _, c := range clusters {
-		managedCluster := &clusterv1.ManagedCluster{}
-		if err := r.Get(ctx, types.NamespacedName{Name: c}, managedCluster); err != nil {
-			if errors.IsNotFound(err) {
-				continue
-			}
-			return err
+	managedCluster := &clusterv1.ManagedCluster{}
+	if err := r.Get(ctx, types.NamespacedName{Name: cluster}, managedCluster); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
 		}
-		if err := r.addClusterLabels(ctx, managedCluster, labels["add"]); err != nil {
-			return fmt.Errorf("fail to add labels for cluster %s: %v", managedCluster.Name, err)
-		}
-		if err := r.deleteClusterLabels(ctx, managedCluster, labels["delete"]); err != nil {
-			return fmt.Errorf("fail to delete labels for cluster %s: %v", managedCluster.Name, err)
-		}
+		return err
+	}
+	if err := r.addClusterLabels(ctx, managedCluster, labels["add"]); err != nil {
+		return fmt.Errorf("fail to add labels for cluster %s: %v", managedCluster.Name, err)
+	}
+	if err := r.deleteClusterLabels(ctx, managedCluster, labels["delete"]); err != nil {
+		return fmt.Errorf("fail to delete labels for cluster %s: %v", managedCluster.Name, err)
 	}
 	return nil
 }

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -156,22 +156,18 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	if suceededCondition != nil {
 		if clusterGroupUpgrade.Status.Status.CompletedAt.IsZero() {
-			if suceededCondition.Status == metav1.ConditionTrue {
-				// Upgrade has successfully finished
-				r.Log.Info("Upgrade is completed")
-				// Take actions after upgrade is completed
-				if err = r.takeActionsAfterCompletion(ctx, clusterGroupUpgrade); err != nil {
-					return
-				}
-			} else {
-				// Upgrade has failed
-				// On failure we don't want to complete actions other then to delete the resources
+			deleteObjects := clusterGroupUpgrade.Spec.Actions.AfterCompletion.DeleteObjects
+			if deleteObjects == nil || *deleteObjects {
 				err = r.deleteResources(ctx, clusterGroupUpgrade)
 				if err != nil {
 					return
 				}
+			}
+
+			if suceededCondition.Status == metav1.ConditionTrue {
+				r.Recorder.Event(clusterGroupUpgrade, corev1.EventTypeNormal, suceededCondition.Reason, suceededCondition.Message)
+			} else {
 				r.Recorder.Event(clusterGroupUpgrade, corev1.EventTypeWarning, suceededCondition.Reason, suceededCondition.Message)
-				r.Log.Info("CGU has failed")
 				r.addClustersStatusOnTimeout(clusterGroupUpgrade)
 			}
 			// Set completion time only after post actions are executed with no errors
@@ -234,7 +230,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 			)
 
 			// Build the upgrade batches.
-			r.buildRemediationPlan(clusterGroupUpgrade, clusters, managedPoliciesInfo.presentPolicies)
+			r.buildRemediationPlan(ctx, clusterGroupUpgrade, clusters, managedPoliciesInfo.presentPolicies)
 
 			// Recheck clusters list for any changes to the plan
 			clusters = r.getClustersListFromRemediationPlan(clusterGroupUpgrade)
@@ -423,7 +419,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 			}
 
 			// Rebuild remediation plan since we are about to start the upgrade and want to make sure the non-successful clusters were filtered out
-			r.buildRemediationPlan(clusterGroupUpgrade, clusters, managedPoliciesInfo.presentPolicies)
+			r.buildRemediationPlan(ctx, clusterGroupUpgrade, clusters, managedPoliciesInfo.presentPolicies)
 
 			// Take actions before starting upgrade.
 			err = r.takeActionsBeforeEnable(ctx, clusterGroupUpgrade)
@@ -761,6 +757,10 @@ func (r *ClusterGroupUpgradeReconciler) getNextRemediationPoliciesForBatch(
 		if currentPolicyIndex >= numberOfPolicies {
 			clusterGroupUpgrade.Status.Status.CurrentBatchRemediationProgress[batchClusterName].PolicyIndex = nil
 			clusterGroupUpgrade.Status.Status.CurrentBatchRemediationProgress[batchClusterName].State = ranv1alpha1.Completed
+			err := r.takeActionsAfterCompletion(ctx, clusterGroupUpgrade, batchClusterName)
+			if err != nil {
+				return false, err
+			}
 		} else {
 			isBatchComplete = false
 			*clusterGroupUpgrade.Status.Status.CurrentBatchRemediationProgress[batchClusterName].PolicyIndex = currentPolicyIndex
@@ -1642,7 +1642,7 @@ func (r *ClusterGroupUpgradeReconciler) getClustersNonCompliantWithManagedPolici
 	return clustersNonCompliantMap
 }
 
-func (r *ClusterGroupUpgradeReconciler) buildRemediationPlan(
+func (r *ClusterGroupUpgradeReconciler) buildRemediationPlan(ctx context.Context,
 	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, clusters []string, managedPolicies []*unstructured.Unstructured) {
 	// Get all clusters from the CR that are non compliant with at least one of the managedPolicies.
 	clusterNonCompliantWithManagedPoliciesMap := r.getClustersNonCompliantWithManagedPolicies(clusters, managedPolicies)
@@ -1652,10 +1652,11 @@ func (r *ClusterGroupUpgradeReconciler) buildRemediationPlan(
 	isCanary := make(map[string]bool)
 	if clusterGroupUpgrade.Spec.RemediationStrategy.Canaries != nil && len(clusterGroupUpgrade.Spec.RemediationStrategy.Canaries) > 0 {
 		for _, canary := range clusterGroupUpgrade.Spec.RemediationStrategy.Canaries {
-			// TODO: make sure the canary clusters are in the list of clusters.
 			if clusterNonCompliantWithManagedPoliciesMap[canary] {
 				remediationPlan = append(remediationPlan, []string{canary})
 				isCanary[canary] = true
+			} else if *clusterGroupUpgrade.Spec.Enable {
+				r.takeActionsAfterCompletion(ctx, clusterGroupUpgrade, canary)
 			}
 		}
 	}
@@ -1663,10 +1664,14 @@ func (r *ClusterGroupUpgradeReconciler) buildRemediationPlan(
 	var batch []string
 	clusterCount := 0
 	for i := 0; i < len(clusters); i++ {
-		site := clusters[i]
-		if !isCanary[site] && clusterNonCompliantWithManagedPoliciesMap[site] {
-			batch = append(batch, site)
-			clusterCount++
+		cluster := clusters[i]
+		if !isCanary[cluster] {
+			if clusterNonCompliantWithManagedPoliciesMap[cluster] {
+				batch = append(batch, cluster)
+				clusterCount++
+			} else if *clusterGroupUpgrade.Spec.Enable {
+				r.takeActionsAfterCompletion(ctx, clusterGroupUpgrade, cluster)
+			}
 		}
 
 		if clusterCount == clusterGroupUpgrade.Status.ComputedMaxConcurrency || i == len(clusters)-1 {

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -168,7 +168,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 				r.Recorder.Event(clusterGroupUpgrade, corev1.EventTypeNormal, suceededCondition.Reason, suceededCondition.Message)
 			} else {
 				r.Recorder.Event(clusterGroupUpgrade, corev1.EventTypeWarning, suceededCondition.Reason, suceededCondition.Message)
-				r.addClustersStatusOnTimeout(clusterGroupUpgrade)
+				r.addTimedoutClustersInStatus(clusterGroupUpgrade)
 			}
 			// Set completion time only after post actions are executed with no errors
 			clusterGroupUpgrade.Status.Status.CompletedAt = metav1.Now()
@@ -513,7 +513,6 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 				// If the upgrade is completed for the current batch, cleanup and move to the next.
 				r.Log.Info("[Reconcile] Upgrade completed for batch", "batchIndex", clusterGroupUpgrade.Status.Status.CurrentBatch)
 				r.cleanupPlacementRules(ctx, clusterGroupUpgrade)
-				r.addClustersStatusOnCompleteBatch(clusterGroupUpgrade)
 				clusterGroupUpgrade.Status.Status.CurrentBatchStartedAt = metav1.Time{}
 				clusterGroupUpgrade.Status.Status.CurrentBatch++
 				nextReconcile = requeueImmediately()
@@ -560,7 +559,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 							)
 						} else {
 							r.Log.Info("Batch upgrade timed out")
-							r.addClustersStatusOnTimeout(clusterGroupUpgrade)
+							r.addTimedoutClustersInStatus(clusterGroupUpgrade)
 							switch clusterGroupUpgrade.Spec.BatchTimeoutAction {
 							case ranv1alpha1.BatchTimeoutAction.Abort:
 								// If the value was abort then we need to fail out
@@ -626,7 +625,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 	return
 }
 
-func (r *ClusterGroupUpgradeReconciler) addClustersStatusOnTimeout(
+func (r *ClusterGroupUpgradeReconciler) addTimedoutClustersInStatus(
 	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) {
 
 	// check if batch is initialized in case of timeout happened before the batch starting
@@ -657,9 +656,7 @@ func (r *ClusterGroupUpgradeReconciler) addClustersStatusOnTimeout(
 			// Assume the cluster timed out if the status was not defined when it should have been
 			// This implies that this batch did not even get a chance to start
 			clusterState.State = utils.ClusterRemediationTimedout
-		} else if clusterStatus.State == ranv1alpha1.Completed {
-			clusterState.State = utils.ClusterRemediationComplete
-		} else {
+		} else if clusterStatus.State == ranv1alpha1.InProgress {
 			clusterState.State = utils.ClusterRemediationTimedout
 
 			if clusterStatus.PolicyIndex == nil {
@@ -678,17 +675,6 @@ func (r *ClusterGroupUpgradeReconciler) addClustersStatusOnTimeout(
 					Status: utils.ClusterStatusNonCompliant}
 			}
 		}
-		clusterGroupUpgrade.Status.Clusters = append(clusterGroupUpgrade.Status.Clusters, clusterState)
-	}
-}
-
-func (r *ClusterGroupUpgradeReconciler) addClustersStatusOnCompleteBatch(
-	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) {
-	batchIndex := clusterGroupUpgrade.Status.Status.CurrentBatch - 1
-
-	for _, batchClusterName := range clusterGroupUpgrade.Status.RemediationPlan[batchIndex] {
-		clusterState := ranv1alpha1.ClusterState{
-			Name: batchClusterName, State: utils.ClusterRemediationComplete}
 		clusterGroupUpgrade.Status.Clusters = append(clusterGroupUpgrade.Status.Clusters, clusterState)
 	}
 }
@@ -1330,7 +1316,6 @@ func (r *ClusterGroupUpgradeReconciler) isUpgradeComplete(ctx context.Context, c
 	}
 
 	if isBatchComplete {
-		r.addClustersStatusOnCompleteBatch(clusterGroupUpgrade)
 		// Check previous batches
 		for i := 0; i < len(clusterGroupUpgrade.Status.RemediationPlan)-1; i++ {
 			for _, batchClusterName := range clusterGroupUpgrade.Status.RemediationPlan[i] {

--- a/deploy/acm/policies/patch-policies-status.sh
+++ b/deploy/acm/policies/patch-policies-status.sh
@@ -3,12 +3,12 @@
 curl -k -s -X PATCH -H "Accept: application/json, */*" \
 -H "Content-Type: application/merge-patch+json" \
 http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$1/policies/policy1-common-cluster-version-policy/status \
---data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"}, {"clustername":"spoke4","clusternamespace":"spoke4","compliant":"NonCompliant"}, {"clustername":"spoke6","clusternamespace":"spoke6","compliant":"NonCompliant"}]}}'
+--data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"}, {"clustername":"spoke4","clusternamespace":"spoke4","compliant":"NonCompliant"}, {"clustername":"spoke6","clusternamespace":"spoke6","compliant":"Compliant"}]}}'
 
 curl -k -s -X PATCH -H "Accept: application/json, */*" \
 -H "Content-Type: application/merge-patch+json" \
 http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$2/policies/policy2-common-pao-sub-policy/status \
---data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"}, {"clustername":"spoke2","clusternamespace":"spoke2","compliant":"NonCompliant"}, {"clustername":"spoke4","clusternamespace":"spoke4","compliant":"NonCompliant"}]}}'
+--data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"}, {"clustername":"spoke2","clusternamespace":"spoke2","compliant":"NonCompliant"}, {"clustername":"spoke4","clusternamespace":"spoke4","compliant":"NonCompliant"}, {"clustername":"spoke6","clusternamespace":"spoke6","compliant":"Compliant"}]}}'
 
 curl -k -s -X PATCH -H "Accept: application/json, */*" \
 -H "Content-Type: application/merge-patch+json" \

--- a/deploy/upgrades/upgrade-complete/cgu-upgrade-complete.yaml
+++ b/deploy/upgrades/upgrade-complete/cgu-upgrade-complete.yaml
@@ -6,6 +6,16 @@ metadata:
   annotations:
     cluster-group-upgrades-operator/name-suffix: kuttl      
 spec:
+  actions:
+    afterCompletion:
+      addClusterLabels:
+        ztp-done: ''
+      deleteClusterLabels:
+        ztp-running: ''
+      deleteObjects: true
+    beforeEnable:
+      addClusterLabels:
+        ztp-running: ''
   managedPolicies:
     - policy1-common-cluster-version-policy
     - policy2-common-pao-sub-policy

--- a/deploy/upgrades/upgrade-complete/cgu-upgrade-complete.yaml
+++ b/deploy/upgrades/upgrade-complete/cgu-upgrade-complete.yaml
@@ -23,5 +23,6 @@ spec:
   clusters:
   - spoke1
   - spoke4
+  - spoke6
   remediationStrategy:
     maxConcurrency: 1

--- a/deploy/upgrades/upgrade-starts-complete/cgu-upgrade-starts-complete.yaml
+++ b/deploy/upgrades/upgrade-starts-complete/cgu-upgrade-starts-complete.yaml
@@ -6,6 +6,16 @@ metadata:
   annotations:
     cluster-group-upgrades-operator/name-suffix: kuttl      
 spec:
+  actions:
+    afterCompletion:
+      addClusterLabels:
+        ztp-done: ''
+      deleteClusterLabels:
+        ztp-running: ''
+      deleteObjects: true
+    beforeEnable:
+      addClusterLabels:
+        ztp-running: ''
   managedPolicies:
     - policy1-common-cluster-version-policy
     - policy2-common-pao-sub-policy

--- a/tests/kuttl/tests/upgrade-complete/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/00-assert.yaml
@@ -7,6 +7,7 @@ spec:
   clusters:
   - spoke1
   - spoke4
+  - spoke6
   enable: false
   managedPolicies:
   - policy1-common-cluster-version-policy

--- a/tests/kuttl/tests/upgrade-complete/00-setup.yaml
+++ b/tests/kuttl/tests/upgrade-complete/00-setup.yaml
@@ -2,6 +2,13 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 
 commands:
+
+  # Recreate spokes for label verification
+  - command: oc delete -f ../../../../deploy/acm/managed-clusters/setup-managed-spoke-clusters.yaml 
+    namespaced: true
+  - command: oc apply -f ../../../../deploy/acm/managed-clusters/setup-managed-spoke-clusters.yaml 
+    namespaced: true
+
   # Create all the managed inform policies
   - command: oc apply -f ../../../../deploy/acm/policies/all_policies/policy1-common-cluster-version-policy.yaml
     namespaced: true

--- a/tests/kuttl/tests/upgrade-complete/01-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/01-assert.yaml
@@ -63,3 +63,17 @@ status:
       spoke1:
         policyIndex: 0
         state: InProgress
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-running: ""
+  name: spoke1
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-running: ""
+  name: spoke4

--- a/tests/kuttl/tests/upgrade-complete/01-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/01-assert.yaml
@@ -7,6 +7,7 @@ spec:
   clusters:
   - spoke1
   - spoke4
+  - spoke6
   enable: true
   managedPolicies:
   - policy1-common-cluster-version-policy
@@ -77,3 +78,10 @@ metadata:
   labels:
     ztp-running: ""
   name: spoke4
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-done: ""
+  name: spoke6

--- a/tests/kuttl/tests/upgrade-complete/01-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/01-assert.yaml
@@ -16,6 +16,9 @@ spec:
     maxConcurrency: 1
     timeout: 240
 status:
+  clusters:
+    - name: spoke6
+      state: complete  
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted

--- a/tests/kuttl/tests/upgrade-complete/02-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/02-assert.yaml
@@ -16,6 +16,11 @@ spec:
     maxConcurrency: 1
     timeout: 241
 status:
+  clusters:
+    - name: spoke6
+      state: complete        
+    - name: spoke1
+      state: complete    
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
@@ -33,9 +38,6 @@ status:
   - cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
   managedPoliciesContent:
     policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-performance-addon-operator"}]'
-  clusters:
-    - name: spoke1
-      state: complete
   managedPoliciesForUpgrade:
   - name: policy1-common-cluster-version-policy
     namespace: default

--- a/tests/kuttl/tests/upgrade-complete/02-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/02-assert.yaml
@@ -65,3 +65,17 @@ status:
       spoke4:
         policyIndex: 0
         state: InProgress
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-done: ""
+  name: spoke1
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-running: ""
+  name: spoke4

--- a/tests/kuttl/tests/upgrade-complete/02-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/02-assert.yaml
@@ -7,6 +7,7 @@ spec:
   clusters:
   - spoke1
   - spoke4
+  - spoke6
   enable: true
   managedPolicies:
   - policy1-common-cluster-version-policy

--- a/tests/kuttl/tests/upgrade-complete/03-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/03-assert.yaml
@@ -45,3 +45,17 @@ status:
   remediationPlan:
   - - spoke1
   - - spoke4
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-done: ""
+  name: spoke1
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-done: ""
+  name: spoke4

--- a/tests/kuttl/tests/upgrade-complete/03-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/03-assert.yaml
@@ -17,6 +17,8 @@ spec:
     timeout: 240
 status:
   clusters:
+    - name: spoke6
+      state: complete      
     - name: spoke1
       state: complete
     - name: spoke4

--- a/tests/kuttl/tests/upgrade-complete/03-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/03-assert.yaml
@@ -7,6 +7,7 @@ spec:
   clusters:
   - spoke1
   - spoke4
+  - spoke6
   enable: true
   managedPolicies:
   - policy1-common-cluster-version-policy

--- a/tests/kuttl/tests/upgrade-starts-complete/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-starts-complete/00-assert.yaml
@@ -14,7 +14,9 @@ spec:
     maxConcurrency: 1
     timeout: 240
 status:
-
+  clusters:
+    - name: spoke1
+      state: complete
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted

--- a/tests/kuttl/tests/upgrade-starts-complete/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-starts-complete/00-assert.yaml
@@ -14,6 +14,7 @@ spec:
     maxConcurrency: 1
     timeout: 240
 status:
+
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
@@ -35,3 +36,10 @@ status:
   - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   status: {}
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-done: ""
+  name: spoke1

--- a/tests/kuttl/tests/upgrade-starts-complete/00-setup.yaml
+++ b/tests/kuttl/tests/upgrade-starts-complete/00-setup.yaml
@@ -2,6 +2,12 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 
 commands:
+  # Recreate spokes for label verification
+  - command: oc delete -f ../../../../deploy/acm/managed-clusters/setup-managed-spoke-clusters.yaml 
+    namespaced: true
+  - command: oc apply -f ../../../../deploy/acm/managed-clusters/setup-managed-spoke-clusters.yaml 
+    namespaced: true
+    
   # Create all the managed inform policies
   - command: oc apply -f ../../../../deploy/acm/policies/all_policies/policy1-common-cluster-version-policy.yaml
     namespaced: true

--- a/tests/kuttl/tests/upgrade-timeout/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-timeout/00-assert.yaml
@@ -7,6 +7,7 @@ spec:
   clusters:
   - spoke1
   - spoke4
+  - spoke6
   enable: false
   managedPolicies:
   - policy1-common-cluster-version-policy

--- a/tests/kuttl/tests/upgrade-timeout/01-assert.yaml
+++ b/tests/kuttl/tests/upgrade-timeout/01-assert.yaml
@@ -7,6 +7,7 @@ spec:
   clusters:
   - spoke1
   - spoke4
+  - spoke6
   enable: true
   managedPolicies:
   - policy1-common-cluster-version-policy
@@ -15,6 +16,9 @@ spec:
     maxConcurrency: 1
     timeout: 240
 status:
+  clusters:
+    - name: spoke6
+      state: complete  
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
@@ -63,3 +67,24 @@ status:
       spoke1:
         policyIndex: 0
         state: InProgress
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-running: ""
+  name: spoke1
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-running: ""
+  name: spoke4
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-done: ""
+  name: spoke6

--- a/tests/kuttl/tests/upgrade-timeout/02-assert.yaml
+++ b/tests/kuttl/tests/upgrade-timeout/02-assert.yaml
@@ -7,6 +7,7 @@ spec:
   clusters:
   - spoke1
   - spoke4
+  - spoke6
   enable: true
   managedPolicies:
   - policy1-common-cluster-version-policy
@@ -15,6 +16,11 @@ spec:
     maxConcurrency: 1
     timeout: 241
 status:
+  clusters:
+    - name: spoke6
+      state: complete  
+    - name: spoke1
+      state: complete        
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
@@ -32,9 +38,6 @@ status:
   - cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
   managedPoliciesContent:
     policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-performance-addon-operator"}]'
-  clusters:
-    - name: spoke1
-      state: complete
   managedPoliciesForUpgrade:
   - name: policy1-common-cluster-version-policy
     namespace: default
@@ -65,3 +68,24 @@ status:
       spoke4:
         policyIndex: 0
         state: InProgress
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-done: ""
+  name: spoke1
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-running: ""
+  name: spoke4
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-done: ""
+  name: spoke6

--- a/tests/kuttl/tests/upgrade-timeout/03-assert.yaml
+++ b/tests/kuttl/tests/upgrade-timeout/03-assert.yaml
@@ -7,6 +7,7 @@ spec:
   clusters:
   - spoke1
   - spoke4
+  - spoke6
   enable: true
   managedPolicies:
   - policy1-common-cluster-version-policy
@@ -16,6 +17,8 @@ spec:
     timeout: 0
 status:
   clusters:
+    - name: spoke6
+      state: complete    
     - name: spoke1
       state: complete
     - currentPolicy:
@@ -48,3 +51,24 @@ status:
   remediationPlan:
   - - spoke1
   - - spoke4
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-done: ""
+  name: spoke1
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-running: ""
+  name: spoke4
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-done: ""
+  name: spoke6


### PR DESCRIPTION
This also fixes the already compliant cluster cases for both labelling and cluster status update.