### PR TITLE
OCPBUGS-6944: recovery: Update container checks in upgrade-recovery.sh

### DIFF
--- a/recovery/bindata/upgrade-recovery.sh
+++ b/recovery/bindata/upgrade-recovery.sh
@@ -106,12 +106,12 @@ function display_current_status {
 
 function get_container_id {
     local name=$1
-    crictl ps 2>/dev/null | awk -v name="${name}" '{if ($(NF-2) == name) {print $1; exit 0}}'
+    crictl ps -o json 2>/dev/null | jq -r --arg name "${name}" '.containers[] | select(.metadata.name==$name).id'
 }
 
 function get_container_state {
     local name=$1
-    crictl ps 2>/dev/null | awk -v name="${name}" '{if ($(NF-2) == name) {print $(NF-3); exit 0}}'
+    crictl ps -o json 2>/dev/null | jq -r --arg name "${name}" '.containers[] | select(.metadata.name==$name).state'
 }
 
 function get_current_revision {
@@ -145,14 +145,14 @@ function wait_for_container_restart {
         cur_state=$(get_container_state "${name}")
         if [ -n "${cur_id}" ] && \
                 [ "${cur_id}" != "${orig_id}" ] && \
-                [ "${cur_state}" = "Running" ]; then
+                [ "${cur_state}" = "CONTAINER_RUNNING" ]; then
             break
         fi
         echo -n "." && sleep 10
     done
     echo
 
-    if [ "$(get_container_state ${name})" != "Running" ]; then
+    if [ "$(get_container_state ${name})" != "CONTAINER_RUNNING" ]; then
         fatal "${name} container is not Running. Please investigate"
     fi
 


### PR DESCRIPTION
The upgrade-recovery.sh tool uses "crictl ps" to check container status, but the format of the ps output has been updated. Rather than screen-scraping for a specific column, this update changes the script to use "crictl ps -o json", using "jq" to pull the desired data from the output.

Signed-off-by: Don Penney <dpenney@redhat.com>

/cc @jc-rh @Missxiaoguo @sabbir-47 