### PR TITLE
OCPBUGS-7175: Ignore child policies with invalid name

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -932,7 +932,11 @@ func (r *ClusterGroupUpgradeReconciler) doManagedPoliciesExist(
 	policyEnforce := make(map[string]bool)
 	policyInvalidHubTmpl := make(map[string]bool)
 	for _, childPolicy := range childPoliciesList {
-		policyNameArr := utils.GetParentPolicyNameAndNamespace(childPolicy.Name)
+		policyNameArr, err := utils.GetParentPolicyNameAndNamespace(childPolicy.Name)
+		if err != nil {
+			r.Log.Info("[doManagedPoliciesExist] Ignoring child policy " + childPolicy.Name + "with invalid name")
+			continue
+		}
 
 		// Identify policies with remediationAction enforce to ignore
 		if strings.EqualFold(string(childPolicy.Spec.RemediationAction), "enforce") {

--- a/controllers/managedclusterForCGU_controller.go
+++ b/controllers/managedclusterForCGU_controller.go
@@ -187,8 +187,12 @@ func (r *ManagedClusterForCguReconciler) newClusterGroupUpgrade(
 				// err convert from string to int
 				return fmt.Errorf("%s in policy %s is not an interger: %s", ztpDeployWaveAnnotation, cPolicy.GetName(), err)
 			}
-			policyName := utils.GetParentPolicyNameAndNamespace(cPolicy.GetName())[1]
-			policyWaveMap[policyName] = deployWaveInt
+			policyName, err := utils.GetParentPolicyNameAndNamespace(cPolicy.GetName())
+			if err != nil {
+				r.Log.Info("Ignoring policy " + cPolicy.Name + " with invalid name")
+				continue
+			}
+			policyWaveMap[policyName[1]] = deployWaveInt
 		}
 	}
 

--- a/controllers/utils/policy_util.go
+++ b/controllers/utils/policy_util.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -120,11 +121,15 @@ func GetResourceName(clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, initi
 
 // GetParentPolicyNameAndNamespace gets the parent policy name and namespace from a given child policy
 // returns: []string       a two-element slice which the first element is policy namespace and the second one is policy name
-func GetParentPolicyNameAndNamespace(childPolicyName string) []string {
+func GetParentPolicyNameAndNamespace(childPolicyName string) ([]string, error) {
 	// The format of a child policy name is parent_policy_namespace.parent_policy_name.
 	// Extract the parent policy name and namespace by splitting the child policy name into two substrings separated by "."
 	// and we are safe to split with the separator "." as the namespace is disallowed to contain "."
-	return strings.SplitN(childPolicyName, ".", 2)
+	res := strings.SplitN(childPolicyName, ".", 2)
+	if len(res) != 2 {
+		return nil, errors.New("child policy name " + childPolicyName + " is not valid.")
+	}
+	return res, nil
 }
 
 // InspectPolicyObjects validates the policy objects, checks if it contains a status section in any object templates

--- a/controllers/utils/policy_util_test.go
+++ b/controllers/utils/policy_util_test.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetParentPolicyNameAndNamespace(t *testing.T) {
+	res, err := GetParentPolicyNameAndNamespace("default.upgrade")
+	assert.NoError(t, err)
+	assert.Equal(t, len(res), 2)
+
+	res, err = GetParentPolicyNameAndNamespace("upgrade")
+	assert.Error(t, err)
+
+	res, err = GetParentPolicyNameAndNamespace("default.upgrade.cluster")
+	assert.Equal(t, res[0], "default")
+	assert.Equal(t, res[1], "upgrade.cluster")
+}


### PR DESCRIPTION
Child policy should have the format: parent-namespace.parent-name if a child policy does not have this format ignore it

Signed-off-by: Saeid Askari <saskari@redhat.com>