### PR TITLE
OCPBUGS-7217: Keep conditions in order of the status transition time

### DIFF
--- a/controllers/precacheFsm.go
+++ b/controllers/precacheFsm.go
@@ -60,7 +60,6 @@ const (
 func (r *ClusterGroupUpgradeReconciler) precachingFsm(ctx context.Context,
 	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, clusters []string, policies []*unstructured.Unstructured) error {
 
-	r.setPrecachingStartedCondition(clusterGroupUpgrade)
 	specCondition := meta.FindStatusCondition(clusterGroupUpgrade.Status.Conditions, utils.PrecacheSpecValidCondition)
 	if specCondition == nil || specCondition.Status == metav1.ConditionFalse {
 		spec, err := r.extractPrecachingSpecFromPolicies(policies)
@@ -93,6 +92,13 @@ func (r *ClusterGroupUpgradeReconciler) precachingFsm(ctx context.Context,
 
 		clusterGroupUpgrade.Status.Precaching.Spec = &spec
 	}
+	utils.SetStatusCondition(
+		&clusterGroupUpgrade.Status.Conditions,
+		utils.ConditionTypes.PrecachingSuceeded,
+		utils.ConditionReasons.InProgress,
+		metav1.ConditionFalse,
+		"Precaching is required and not done",
+	)
 
 	for _, cluster := range clusters {
 		var currentState string
@@ -312,18 +318,6 @@ func (r *ClusterGroupUpgradeReconciler) handleActive(ctx context.Context,
 			condition, currentState)
 	}
 	return nextState, nil
-}
-
-// setPrecachingStartedCondition sets conditions of precaching required
-func (r *ClusterGroupUpgradeReconciler) setPrecachingStartedCondition(
-	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) {
-	utils.SetStatusCondition(
-		&clusterGroupUpgrade.Status.Conditions,
-		utils.ConditionTypes.PrecachingSuceeded,
-		utils.ConditionReasons.InProgress,
-		metav1.ConditionFalse,
-		"Precaching is required and not done",
-	)
 }
 
 // checkAllPrecachingDone handles alleviation of PrecachingDone==False condition

--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -75,11 +75,11 @@ var ConditionReasons = struct {
 
 // SetStatusCondition is a convenience wrapper for meta.SetStatusCondition that takes in the types defined here and converts them to strings
 func SetStatusCondition(existingConditions *[]metav1.Condition, conditionType ConditionType, conditionReason ConditionReason, conditionStatus metav1.ConditionStatus, message string) {
-	arr := *existingConditions
+	conditions := *existingConditions
 	condition := meta.FindStatusCondition(*existingConditions, string(conditionType))
 	if condition != nil &&
 		condition.Status != conditionStatus &&
-		arr[len(arr)-1].Type != string(conditionType) {
+		conditions[len(conditions)-1].Type != string(conditionType) {
 		meta.RemoveStatusCondition(existingConditions, string(conditionType))
 	}
 	meta.SetStatusCondition(

--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -75,6 +75,13 @@ var ConditionReasons = struct {
 
 // SetStatusCondition is a convenience wrapper for meta.SetStatusCondition that takes in the types defined here and converts them to strings
 func SetStatusCondition(existingConditions *[]metav1.Condition, conditionType ConditionType, conditionReason ConditionReason, conditionStatus metav1.ConditionStatus, message string) {
+	arr := *existingConditions
+	condition := meta.FindStatusCondition(*existingConditions, string(conditionType))
+	if condition != nil &&
+		condition.Status != conditionStatus &&
+		arr[len(arr)-1].Type != string(conditionType) {
+		meta.RemoveStatusCondition(existingConditions, string(conditionType))
+	}
 	meta.SetStatusCondition(
 		existingConditions,
 		metav1.Condition{

--- a/controllers/utils/conditions_test.go
+++ b/controllers/utils/conditions_test.go
@@ -1,0 +1,83 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetStatusCondition(t *testing.T) {
+
+	testcases := []struct {
+		name             string
+		beforeConditions []metav1.Condition
+		afterConditions  []metav1.Condition
+		condition        metav1.Condition
+	}{
+		{
+			"Add condition",
+			[]metav1.Condition{},
+			[]metav1.Condition{
+				metav1.Condition{
+					Type: string(ConditionTypes.Progressing),
+				},
+			},
+			metav1.Condition{
+				Type: string(ConditionTypes.Progressing),
+			},
+		},
+		{
+			"Setting same condition should not change order",
+			[]metav1.Condition{
+				metav1.Condition{
+					Type: string(ConditionTypes.BackupSuceeded), Status: metav1.ConditionTrue,
+				},
+				metav1.Condition{
+					Type: string(ConditionTypes.Progressing),
+				},
+			},
+			[]metav1.Condition{
+				metav1.Condition{
+					Type: string(ConditionTypes.BackupSuceeded), Status: metav1.ConditionTrue,
+				},
+				metav1.Condition{
+					Type: string(ConditionTypes.Progressing),
+				},
+			},
+			metav1.Condition{
+				Type: string(ConditionTypes.BackupSuceeded), Status: metav1.ConditionTrue,
+			},
+		},
+		{
+			"Change in the status should change the order",
+			[]metav1.Condition{
+				metav1.Condition{
+					Type: string(ConditionTypes.BackupSuceeded), Status: metav1.ConditionTrue,
+				},
+				metav1.Condition{
+					Type: string(ConditionTypes.Progressing),
+				},
+			},
+			[]metav1.Condition{
+				metav1.Condition{
+					Type: string(ConditionTypes.Progressing),
+				},
+				metav1.Condition{
+					Type: string(ConditionTypes.BackupSuceeded), Status: metav1.ConditionFalse,
+				},
+			},
+			metav1.Condition{
+				Type: string(ConditionTypes.BackupSuceeded), Status: metav1.ConditionFalse,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		SetStatusCondition(&tc.beforeConditions, ConditionType(tc.condition.Type), ConditionReason(tc.condition.Reason), tc.condition.Status, tc.condition.Message)
+		assert.Equal(t, len(tc.beforeConditions), len(tc.afterConditions))
+		for i := 0; i < len(tc.beforeConditions); i++ {
+			assert.Equal(t, tc.beforeConditions[i].Type, tc.afterConditions[i].Type)
+		}
+	}
+}

--- a/tests/kuttl/tests/pre-caching-complete/00-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/00-assert.yaml
@@ -22,10 +22,6 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -34,6 +30,10 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
     status: "False"

--- a/tests/kuttl/tests/pre-caching-complete/00-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/00-assert.yaml
@@ -22,6 +22,10 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -34,10 +38,6 @@ status:
     reason: InProgress
     status: "False"
     type: PrecachingSuceeded
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
   - cgu-policy4-common-sriov-sub-policy-kuttl

--- a/tests/kuttl/tests/pre-caching-complete/01-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/01-assert.yaml
@@ -23,6 +23,10 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,10 +39,6 @@ status:
     reason: InProgress
     status: "False"
     type: PrecachingSuceeded
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
   - cgu-policy4-common-sriov-sub-policy-kuttl

--- a/tests/kuttl/tests/pre-caching-complete/01-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/01-assert.yaml
@@ -23,10 +23,6 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,6 +31,10 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
     status: "False"

--- a/tests/kuttl/tests/pre-caching-complete/02-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/02-assert.yaml
@@ -23,6 +23,10 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,10 +39,6 @@ status:
     reason: InProgress
     status: "False"
     type: PrecachingSuceeded
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
   - cgu-policy4-common-sriov-sub-policy-kuttl

--- a/tests/kuttl/tests/pre-caching-complete/02-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/02-assert.yaml
@@ -23,10 +23,6 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,6 +31,10 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
     status: "False"

--- a/tests/kuttl/tests/pre-caching-complete/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/03-assert.yaml
@@ -23,6 +23,10 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,10 +39,6 @@ status:
     reason: InProgress
     status: "False"
     type: PrecachingSuceeded
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
   - cgu-policy4-common-sriov-sub-policy-kuttl

--- a/tests/kuttl/tests/pre-caching-complete/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/03-assert.yaml
@@ -23,10 +23,6 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,6 +31,10 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
     status: "False"

--- a/tests/kuttl/tests/pre-caching-complete/04-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/04-assert.yaml
@@ -23,6 +23,10 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,10 +39,6 @@ status:
     reason: InProgress
     status: "False"
     type: PrecachingSuceeded
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
   - cgu-policy4-common-sriov-sub-policy-kuttl

--- a/tests/kuttl/tests/pre-caching-complete/04-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/04-assert.yaml
@@ -23,10 +23,6 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,6 +31,10 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
     status: "False"

--- a/tests/kuttl/tests/pre-caching-complete/05-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/05-assert.yaml
@@ -23,6 +23,10 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,10 +39,6 @@ status:
     reason: PrecachingCompleted
     status: "True"
     type: PrecachingSuceeded
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   - message: Not enabled
     reason: NotEnabled
     status: "False"

--- a/tests/kuttl/tests/pre-caching-complete/05-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/05-assert.yaml
@@ -23,10 +23,6 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,6 +31,10 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: Precaching is completed for all clusters
     reason: PrecachingCompleted
     status: "True"

--- a/tests/kuttl/tests/pre-caching-missing-sub-policy/00-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-missing-sub-policy/00-assert.yaml
@@ -27,10 +27,6 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
-  - message: Precaching is required and not done
-    reason: InProgress
-    status: "False"
-    type: PrecachingSuceeded
   - message: "Precaching spec is incomplete: inconsistent precaching configuration: olm index provided, but no packages"
     reason: PrecacheSpecIncomplete
     status: "False"

--- a/tests/kuttl/tests/pre-caching-missing-sub-policy/01-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-missing-sub-policy/01-assert.yaml
@@ -30,14 +30,14 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
-  - message: Precaching in progress for 4 clusters
-    reason: InProgress
-    status: "False"
-    type: PrecachingSuceeded
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
     status: "True"
     type: PrecacheSpecValid
+  - message: Precaching in progress for 4 clusters
+    reason: InProgress
+    status: "False"
+    type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy0-common-config-policy-kuttl
   - cgu-policy3-common-ptp-sub-policy-kuttl

--- a/tests/kuttl/tests/pre-caching-partial-complete/00-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/00-assert.yaml
@@ -22,10 +22,6 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -34,6 +30,10 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
     status: "False"

--- a/tests/kuttl/tests/pre-caching-partial-complete/00-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/00-assert.yaml
@@ -22,6 +22,10 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -34,10 +38,6 @@ status:
     reason: InProgress
     status: "False"
     type: PrecachingSuceeded
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
   - cgu-policy4-common-sriov-sub-policy-kuttl

--- a/tests/kuttl/tests/pre-caching-partial-complete/01-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/01-assert.yaml
@@ -23,6 +23,10 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,10 +39,6 @@ status:
     reason: InProgress
     status: "False"
     type: PrecachingSuceeded
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
   - cgu-policy4-common-sriov-sub-policy-kuttl

--- a/tests/kuttl/tests/pre-caching-partial-complete/01-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/01-assert.yaml
@@ -23,10 +23,6 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,6 +31,10 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
     status: "False"

--- a/tests/kuttl/tests/pre-caching-partial-complete/02-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/02-assert.yaml
@@ -23,6 +23,10 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,10 +39,6 @@ status:
     reason: InProgress
     status: "False"
     type: PrecachingSuceeded
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
   - cgu-policy4-common-sriov-sub-policy-kuttl

--- a/tests/kuttl/tests/pre-caching-partial-complete/02-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/02-assert.yaml
@@ -23,10 +23,6 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,6 +31,10 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
     status: "False"

--- a/tests/kuttl/tests/pre-caching-partial-complete/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/03-assert.yaml
@@ -23,6 +23,10 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,10 +39,6 @@ status:
     reason: InProgress
     status: "False"
     type: PrecachingSuceeded
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
   - cgu-policy4-common-sriov-sub-policy-kuttl

--- a/tests/kuttl/tests/pre-caching-partial-complete/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/03-assert.yaml
@@ -23,10 +23,6 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,6 +31,10 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
     status: "False"

--- a/tests/kuttl/tests/pre-caching-partial-complete/04-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/04-assert.yaml
@@ -23,6 +23,10 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,10 +39,6 @@ status:
     reason: InProgress
     status: "False"
     type: PrecachingSuceeded
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
   - cgu-policy4-common-sriov-sub-policy-kuttl

--- a/tests/kuttl/tests/pre-caching-partial-complete/04-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/04-assert.yaml
@@ -23,10 +23,6 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -35,6 +31,10 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
     status: "False"

--- a/tests/kuttl/tests/pre-caching-partial-complete/05-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/05-assert.yaml
@@ -23,14 +23,6 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
-  - message: Precaching failed for 1 clusters 
-    reason: PartiallyDone
-    status: "True"
-    type: PrecachingSuceeded
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -39,6 +31,14 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
+  - message: Precaching failed for 1 clusters 
+    reason: PartiallyDone
+    status: "True"
+    type: PrecachingSuceeded
   - message: Not enabled
     reason: NotEnabled
     status: "False"

--- a/tests/kuttl/tests/pre-caching-partial-complete/05-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/05-assert.yaml
@@ -23,6 +23,14 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
+  - message: Precaching failed for 1 clusters 
+    reason: PartiallyDone
+    status: "True"
+    type: PrecachingSuceeded
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -31,14 +39,6 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
-  - message: Precaching failed for 1 clusters
-    status: "True"
-    reason: PartiallyDone    
-    type: PrecachingSuceeded
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   - message: Not enabled
     reason: NotEnabled
     status: "False"

--- a/tests/kuttl/tests/pre-caching-partial-complete/06-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/06-assert.yaml
@@ -23,6 +23,14 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
+  - message: Precaching failed for 1 clusters 
+    reason: PartiallyDone
+    status: "True"
+    type: PrecachingSuceeded
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -31,14 +39,6 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
-  - message: Precaching failed for 1 clusters
-    status: "True"
-    reason: PartiallyDone    
-    type: PrecachingSuceeded
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
   - message: Remediating non-compliant policies
     reason: InProgress
     status: "True"

--- a/tests/kuttl/tests/pre-caching-partial-complete/06-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/06-assert.yaml
@@ -23,14 +23,6 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-  - message: Precaching spec is valid and consistent
-    reason: PrecacheSpecIsWellFormed
-    status: "True"
-    type: PrecacheSpecValid
-  - message: Precaching failed for 1 clusters 
-    reason: PartiallyDone
-    status: "True"
-    type: PrecachingSuceeded
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
     status: "True"
@@ -39,6 +31,14 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: "True"
+    type: PrecacheSpecValid
+  - message: Precaching failed for 1 clusters 
+    reason: PartiallyDone
+    status: "True"
+    type: PrecachingSuceeded
   - message: Remediating non-compliant policies
     reason: InProgress
     status: "True"


### PR DESCRIPTION
When setting condition, if the condition status is changed it should be the last condition in the list, so that printercolumn works as expected

Signed-off-by: Saeid Askari <saskari@redhat.com>