### PR TITLE
[release-4.12] OCPBUGS-7477: Keep conditions in order of the status transition time

### DIFF
--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -73,6 +73,13 @@ var ConditionReasons = struct {
 
 // SetStatusCondition is a convenience wrapper for meta.SetStatusCondition that takes in the types defined here and converts them to strings
 func SetStatusCondition(existingConditions *[]metav1.Condition, conditionType ConditionType, conditionReason ConditionReason, conditionStatus metav1.ConditionStatus, message string) {
+	conditions := *existingConditions
+	condition := meta.FindStatusCondition(*existingConditions, string(conditionType))
+	if condition != nil &&
+		condition.Status != conditionStatus &&
+		conditions[len(conditions)-1].Type != string(conditionType) {
+		meta.RemoveStatusCondition(existingConditions, string(conditionType))
+	}
 	meta.SetStatusCondition(
 		existingConditions,
 		metav1.Condition{

--- a/controllers/utils/conditions_test.go
+++ b/controllers/utils/conditions_test.go
@@ -1,0 +1,83 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetStatusCondition(t *testing.T) {
+
+	testcases := []struct {
+		name             string
+		beforeConditions []metav1.Condition
+		afterConditions  []metav1.Condition
+		condition        metav1.Condition
+	}{
+		{
+			"Add condition",
+			[]metav1.Condition{},
+			[]metav1.Condition{
+				metav1.Condition{
+					Type: string(ConditionTypes.Progressing),
+				},
+			},
+			metav1.Condition{
+				Type: string(ConditionTypes.Progressing),
+			},
+		},
+		{
+			"Setting same condition should not change order",
+			[]metav1.Condition{
+				metav1.Condition{
+					Type: string(ConditionTypes.BackupSuceeded), Status: metav1.ConditionTrue,
+				},
+				metav1.Condition{
+					Type: string(ConditionTypes.Progressing),
+				},
+			},
+			[]metav1.Condition{
+				metav1.Condition{
+					Type: string(ConditionTypes.BackupSuceeded), Status: metav1.ConditionTrue,
+				},
+				metav1.Condition{
+					Type: string(ConditionTypes.Progressing),
+				},
+			},
+			metav1.Condition{
+				Type: string(ConditionTypes.BackupSuceeded), Status: metav1.ConditionTrue,
+			},
+		},
+		{
+			"Change in the status should change the order",
+			[]metav1.Condition{
+				metav1.Condition{
+					Type: string(ConditionTypes.BackupSuceeded), Status: metav1.ConditionTrue,
+				},
+				metav1.Condition{
+					Type: string(ConditionTypes.Progressing),
+				},
+			},
+			[]metav1.Condition{
+				metav1.Condition{
+					Type: string(ConditionTypes.Progressing),
+				},
+				metav1.Condition{
+					Type: string(ConditionTypes.BackupSuceeded), Status: metav1.ConditionFalse,
+				},
+			},
+			metav1.Condition{
+				Type: string(ConditionTypes.BackupSuceeded), Status: metav1.ConditionFalse,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		SetStatusCondition(&tc.beforeConditions, ConditionType(tc.condition.Type), ConditionReason(tc.condition.Reason), tc.condition.Status, tc.condition.Message)
+		assert.Equal(t, len(tc.beforeConditions), len(tc.afterConditions))
+		for i := 0; i < len(tc.beforeConditions); i++ {
+			assert.Equal(t, tc.beforeConditions[i].Type, tc.afterConditions[i].Type)
+		}
+	}
+}

--- a/tests/kuttl/tests/pre-caching/00-assert.yaml
+++ b/tests/kuttl/tests/pre-caching/00-assert.yaml
@@ -30,14 +30,14 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
-  - message: Precaching in progress for 4 clusters
-    reason: InProgress
-    status: "False"
-    type: PrecachingSuceeded
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
     status: "True"
     type: PrecacheSpecValid
+  - message: Precaching in progress for 4 clusters
+    reason: InProgress
+    status: "False"
+    type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
   - cgu-policy4-common-sriov-sub-policy-kuttl

--- a/tests/kuttl/tests/pre-caching/01-assert.yaml
+++ b/tests/kuttl/tests/pre-caching/01-assert.yaml
@@ -31,14 +31,14 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
-  - message: Precaching in progress for 4 clusters
-    reason: InProgress
-    status: "False"
-    type: PrecachingSuceeded
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
     status: "True"
     type: PrecacheSpecValid
+  - message: Precaching in progress for 4 clusters
+    reason: InProgress
+    status: "False"
+    type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
   - cgu-policy4-common-sriov-sub-policy-kuttl

--- a/tests/kuttl/tests/pre-caching/02-assert.yaml
+++ b/tests/kuttl/tests/pre-caching/02-assert.yaml
@@ -31,14 +31,14 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
-  - message: Precaching in progress for 4 clusters
-    reason: InProgress
-    status: "False"
-    type: PrecachingSuceeded
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
     status: "True"
     type: PrecacheSpecValid
+  - message: Precaching in progress for 4 clusters
+    reason: InProgress
+    status: "False"
+    type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
   - cgu-policy4-common-sriov-sub-policy-kuttl

--- a/tests/kuttl/tests/pre-caching/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching/03-assert.yaml
@@ -31,14 +31,14 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
-  - message: Precaching in progress for 4 clusters
-    reason: InProgress
-    status: "False"
-    type: PrecachingSuceeded
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
     status: "True"
     type: PrecacheSpecValid
+  - message: Precaching in progress for 4 clusters
+    reason: InProgress
+    status: "False"
+    type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
   - cgu-policy4-common-sriov-sub-policy-kuttl

--- a/tests/kuttl/tests/pre-caching/04-assert.yaml
+++ b/tests/kuttl/tests/pre-caching/04-assert.yaml
@@ -31,14 +31,14 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
-  - message: Precaching in progress for 4 clusters
-    reason: InProgress
-    status: "False"
-    type: PrecachingSuceeded
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
     status: "True"
     type: PrecacheSpecValid
+  - message: Precaching in progress for 4 clusters
+    reason: InProgress
+    status: "False"
+    type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
   - cgu-policy4-common-sriov-sub-policy-kuttl

--- a/tests/kuttl/tests/pre-caching/05-assert.yaml
+++ b/tests/kuttl/tests/pre-caching/05-assert.yaml
@@ -31,14 +31,14 @@ status:
     reason: ValidationCompleted
     status: "True"
     type: Validated
-  - message: Precaching is completed for all clusters
-    reason: PrecachingCompleted
-    status: "True"
-    type: PrecachingSuceeded
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
     status: "True"
     type: PrecacheSpecValid
+  - message: Precaching is completed for all clusters
+    reason: PrecachingCompleted
+    status: "True"
+    type: PrecachingSuceeded
   - message: Not enabled
     reason: NotEnabled
     status: "False"


### PR DESCRIPTION
…(#438)

* OCPBUGS-7217: Conditions are in order of the time updated

When setting condition, if the condition is changed it should be the last condition in the list, so that printercolumn works as expected

Signed-off-by: Saeid Askari <saskari@redhat.com>

* Add unit test

Signed-off-by: Saeid Askari <saskari@redhat.com>

---------

Signed-off-by: Saeid Askari <saskari@redhat.com>