### PR TITLE
Fix precaching check_space bug

### DIFF
--- a/pre-cache/check_space
+++ b/pre-cache/check_space
@@ -6,10 +6,10 @@ SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
 NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
 TOKEN=$(cat ${SERVICEACCOUNT}/token)
 CACERT=${SERVICEACCOUNT}/ca.crt
-let high=$(curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/nodes/${NODE_NAME}/proxy/configz | \
+high=$(curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/nodes/${NODE_NAME}/proxy/configz | \
             chroot /host jq '.kubeletconfig.imageGCHighThresholdPercent')
-let size=$(df -h /var/lib/ | awk '{ print $2 }' | sed -n '2p' | sed  's/G//')
-let used=$(df -h /var/lib/ | awk '{ print $3 }' | sed -n '2p' | sed  's/G//')
+size=$(df /var/lib/ | awk '{ print $2 }' | sed -n '2p')
+used=$(df /var/lib/ | awk '{ print $3 }' | sed -n '2p')
 echo "highThresholdPercent: $high diskSize:$size used:$used"
-rc=$(awk "BEGIN {avail=${size}/100.0*${high}-${used} ; print avail<${SPACE_REQUIRED}}")
+rc=$(awk "BEGIN {avail=${size}/100.0*${high}-${used} ; print avail<${SPACE_REQUIRED}*1024*1024}")
 exit $rc

--- a/pre-cache/check_space
+++ b/pre-cache/check_space
@@ -3,7 +3,6 @@ set -e
 
 APISERVER=https://kubernetes.default.svc
 SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
-NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
 TOKEN=$(cat ${SERVICEACCOUNT}/token)
 CACERT=${SERVICEACCOUNT}/ca.crt
 high=$(curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/nodes/${NODE_NAME}/proxy/configz | \

--- a/pre-cache/precache.sh
+++ b/pre-cache/precache.sh
@@ -9,7 +9,7 @@ cp -rf /etc/config /host/tmp/precache/config
 # only check space for OCP upgrade
 if [ -n "$(cat /etc/config/platform.image)" ]; then
     /opt/precache/check_space
-    [ $? -ne 0 ] && echo "not enough space for precaching" && exit 17
+    [ $? -ne 0 ] && echo "not enough space for precaching" > /dev/stderr && exit 17
 fi
 chroot /host /tmp/precache/release
 chroot /host /tmp/precache/olm


### PR DESCRIPTION
script assumed `df -h` outputs the size only in Gigabytes which resulted in parsing error when the space was shown in Terrabytes. Replaced `df -h` with `df`.