### PR TITLE
OCPBUGS-11986: Fix the default time format in zap logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 )
 
 require (
+	go.uber.org/zap v1.21.0
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/code-generator v0.23.5
@@ -79,7 +80,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
-	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20220321153916-2c7772ba3064 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -71,6 +72,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
The zap logger version in release-4.12 has a bug which leaves the default time format in epoch style:
`1.68184446972598e+09`

4.10 and 4.11 use an earlier version and 4.13 uses a later version. Both use the ISO8601 format as the default:
`2023-04-21T14:21:43-04:00`

We can't update the zap version in 4.12 as it's limited to go 1.7. Hence this fix to set the format explicitly