### PR TITLE
OCPBUGS-11769: Identify managed policies with ambiguous names

### DIFF
--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -32,45 +32,47 @@ type ConditionReason string
 
 // ConditionReasons define the different reasons that conditions will be set for
 var ConditionReasons = struct {
-	Completed                  ConditionReason
-	ClusterSelectionCompleted  ConditionReason
-	ValidationCompleted        ConditionReason
-	BackupCompleted            ConditionReason
-	PrecachingCompleted        ConditionReason
-	Failed                     ConditionReason
-	IncompleteBlockingCR       ConditionReason
-	InProgress                 ConditionReason
-	InvalidPlatformImage       ConditionReason
-	MissingBlockingCR          ConditionReason
-	NotAllManagedPoliciesExist ConditionReason
-	NotEnabled                 ConditionReason
-	NotStarted                 ConditionReason
-	ClusterNotFound            ConditionReason
-	NotPresent                 ConditionReason
-	PartiallyDone              ConditionReason
-	PrecacheSpecIncomplete     ConditionReason
-	PrecacheSpecIsWellFormed   ConditionReason
-	TimedOut                   ConditionReason
+	Completed                     ConditionReason
+	ClusterSelectionCompleted     ConditionReason
+	ValidationCompleted           ConditionReason
+	BackupCompleted               ConditionReason
+	PrecachingCompleted           ConditionReason
+	Failed                        ConditionReason
+	IncompleteBlockingCR          ConditionReason
+	InProgress                    ConditionReason
+	InvalidPlatformImage          ConditionReason
+	MissingBlockingCR             ConditionReason
+	NotAllManagedPoliciesExist    ConditionReason
+	AmbiguousManagedPoliciesNames ConditionReason
+	NotEnabled                    ConditionReason
+	NotStarted                    ConditionReason
+	ClusterNotFound               ConditionReason
+	NotPresent                    ConditionReason
+	PartiallyDone                 ConditionReason
+	PrecacheSpecIncomplete        ConditionReason
+	PrecacheSpecIsWellFormed      ConditionReason
+	TimedOut                      ConditionReason
 }{
-	Completed:                  "Completed",
-	ClusterSelectionCompleted:  "ClusterSelectionCompleted",
-	ValidationCompleted:        "ValidationCompleted",
-	BackupCompleted:            "BackupCompleted",
-	PrecachingCompleted:        "PrecachingCompleted",
-	Failed:                     "Failed",
-	IncompleteBlockingCR:       "IncompleteBlockingCR",
-	InProgress:                 "InProgress",
-	InvalidPlatformImage:       "InvalidPlatformImage",
-	MissingBlockingCR:          "MissingBlockingCR",
-	NotAllManagedPoliciesExist: "NotAllManagedPoliciesExist",
-	NotEnabled:                 "NotEnabled",
-	NotStarted:                 "NotStarted",
-	ClusterNotFound:            "ClusterNotFound",
-	NotPresent:                 "NotPresent",
-	PartiallyDone:              "PartiallyDone",
-	PrecacheSpecIncomplete:     "PrecacheSpecIncomplete",
-	PrecacheSpecIsWellFormed:   "PrecacheSpecIsWellFormed",
-	TimedOut:                   "TimedOut",
+	Completed:                     "Completed",
+	ClusterSelectionCompleted:     "ClusterSelectionCompleted",
+	ValidationCompleted:           "ValidationCompleted",
+	BackupCompleted:               "BackupCompleted",
+	PrecachingCompleted:           "PrecachingCompleted",
+	Failed:                        "Failed",
+	IncompleteBlockingCR:          "IncompleteBlockingCR",
+	InProgress:                    "InProgress",
+	InvalidPlatformImage:          "InvalidPlatformImage",
+	MissingBlockingCR:             "MissingBlockingCR",
+	NotAllManagedPoliciesExist:    "NotAllManagedPoliciesExist",
+	AmbiguousManagedPoliciesNames: "AmbiguousManagedPoliciesNames",
+	NotEnabled:                    "NotEnabled",
+	NotStarted:                    "NotStarted",
+	ClusterNotFound:               "ClusterNotFound",
+	NotPresent:                    "NotPresent",
+	PartiallyDone:                 "PartiallyDone",
+	PrecacheSpecIncomplete:        "PrecacheSpecIncomplete",
+	PrecacheSpecIsWellFormed:      "PrecacheSpecIsWellFormed",
+	TimedOut:                      "TimedOut",
 }
 
 // SetStatusCondition is a convenience wrapper for meta.SetStatusCondition that takes in the types defined here and converts them to strings

--- a/controllers/utils/policy_util.go
+++ b/controllers/utils/policy_util.go
@@ -211,3 +211,22 @@ func ShouldSoak(policy *unstructured.Unstructured, firstCompliantAt metav1.Time)
 	}
 	return true, nil
 }
+
+// UpdateManagedPolicyNamespaceList updates policyNs with the corresponding namespaces of a managed policy
+// as contained in the policyNameArr parameter.
+func UpdateManagedPolicyNamespaceList(policyNs map[string][]string, policyNameArr []string) {
+	crtPolicyName := policyNameArr[1]
+	crtPolicyNs := policyNameArr[0]
+
+	// If the current managed policy namespace doesn't exist in the namespace list, add it.
+	nsFound := false
+	for _, nsEntry := range policyNs[crtPolicyName] {
+		if crtPolicyNs == nsEntry {
+			nsFound = true
+			break
+		}
+	}
+	if nsFound == false {
+		policyNs[crtPolicyName] = append(policyNs[crtPolicyName], crtPolicyNs)
+	}
+}

--- a/controllers/utils/policy_util_test.go
+++ b/controllers/utils/policy_util_test.go
@@ -55,3 +55,46 @@ func TestShouldSoak(t *testing.T) {
 	_, err = ShouldSoak(policy, v1.Now())
 	assert.Error(t, err)
 }
+
+func TestUpdateManagedPolicyNamespaceList(t *testing.T) {
+	testcases := []struct {
+		policiesNs     map[string][]string
+		policyNameArr  []string
+		expectedResult map[string][]string
+	}{
+		{
+			policiesNs: map[string][]string{
+				"policy1": {"aaa", "bbb"},
+				"policy2": {"aaa"},
+			},
+			policyNameArr: []string{"bbb", "policy2"},
+			expectedResult: map[string][]string{
+				"policy1": {"aaa", "bbb"},
+				"policy2": {"aaa", "bbb"},
+			},
+		},
+		{
+			policiesNs:    map[string][]string{},
+			policyNameArr: []string{"bbb", "policy2"},
+			expectedResult: map[string][]string{
+				"policy2": {"bbb"},
+			},
+		},
+		{
+			policiesNs: map[string][]string{
+				"policy1": {"aaa", "bbb"},
+				"policy2": {"aaa"},
+			},
+			policyNameArr: []string{"aaa", "policy1"},
+			expectedResult: map[string][]string{
+				"policy1": {"aaa", "bbb"},
+				"policy2": {"aaa"},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		UpdateManagedPolicyNamespaceList(tc.policiesNs, tc.policyNameArr)
+		assert.Equal(t, tc.policiesNs, tc.expectedResult)
+	}
+}

--- a/deploy/acm/policies/all_policies/child-aaa-ns-policy2-common-pao-sub-policy.yaml
+++ b/deploy/acm/policies/all_policies/child-aaa-ns-policy2-common-pao-sub-policy.yaml
@@ -1,0 +1,57 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  labels:
+    policy.open-cluster-management.io/root-policy: policy2-common-pao-sub-policy
+  name: aaa.policy2-common-pao-sub-policy
+spec:
+  disabled: false
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: common-pao-sub-policy-config
+      spec:
+        namespaceselector:
+          exclude:
+          - kube-*
+          include:
+          - '*'
+        object-templates:
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: Subscription
+            metadata:
+              name: performance-addon-operator
+              namespace: openshift-performance-addon-operator
+            spec:
+              channel: "4.9"
+              name: performance-addon-operator
+              source: redhat-operators
+              sourceNamespace: openshift-marketplace
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+              annotations:
+                workload.openshift.io/allowed: management
+              labels:
+                openshift.io/cluster-monitoring: "true"
+              name: openshift-performance-addon-operator
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1
+            kind: OperatorGroup
+            metadata:
+              name: performance-addon-operator
+              namespace: openshift-performance-addon-operator
+        remediationAction: inform
+        severity: low
+  remediationAction: inform

--- a/deploy/acm/policies/all_policies/child-aaa-ns-policy3-common-ptp-sub-policy.yaml
+++ b/deploy/acm/policies/all_policies/child-aaa-ns-policy3-common-ptp-sub-policy.yaml
@@ -1,0 +1,60 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  labels:
+    policy.open-cluster-management.io/root-policy: policy3-common-ptp-sub-policy
+  name: aaa.policy3-common-ptp-sub-policy
+spec:
+  disabled: false
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: common-ptp-sub-policy-config
+      spec:
+        namespaceselector:
+          exclude:
+          - kube-*
+          include:
+          - '*'
+        object-templates:
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: Subscription
+            metadata:
+              name: ptp-operator-subscription
+              namespace: openshift-ptp
+            spec:
+              channel: "4.9"
+              name: ptp-operator
+              source: redhat-operators
+              sourceNamespace: openshift-marketplace
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+              annotations:
+                workload.openshift.io/allowed: management
+              labels:
+                openshift.io/cluster-monitoring: "true"
+              name: openshift-ptp
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1
+            kind: OperatorGroup
+            metadata:
+              name: ptp-operators
+              namespace: openshift-ptp
+            spec:
+              targetNamespaces:
+              - openshift-ptp
+        remediationAction: inform
+        severity: low
+  remediationAction: inform

--- a/deploy/acm/policies/all_policies/child-bbb-ns-policy2-common-pao-sub-policy.yaml
+++ b/deploy/acm/policies/all_policies/child-bbb-ns-policy2-common-pao-sub-policy.yaml
@@ -1,0 +1,57 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  labels:
+    policy.open-cluster-management.io/root-policy: policy2-common-pao-sub-policy
+  name: bbb.policy2-common-pao-sub-policy
+spec:
+  disabled: false
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: common-pao-sub-policy-config
+      spec:
+        namespaceselector:
+          exclude:
+          - kube-*
+          include:
+          - '*'
+        object-templates:
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: Subscription
+            metadata:
+              name: performance-addon-operator
+              namespace: openshift-performance-addon-operator
+            spec:
+              channel: "4.9"
+              name: performance-addon-operator
+              source: redhat-operators
+              sourceNamespace: openshift-marketplace
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+              annotations:
+                workload.openshift.io/allowed: management
+              labels:
+                openshift.io/cluster-monitoring: "true"
+              name: openshift-performance-addon-operator
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1
+            kind: OperatorGroup
+            metadata:
+              name: performance-addon-operator
+              namespace: openshift-performance-addon-operator
+        remediationAction: inform
+        severity: low
+  remediationAction: inform

--- a/deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+++ b/deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
@@ -1,0 +1,60 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  labels:
+    policy.open-cluster-management.io/root-policy: policy3-common-ptp-sub-policy
+  name: bbb.policy3-common-ptp-sub-policy
+spec:
+  disabled: false
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: common-ptp-sub-policy-config
+      spec:
+        namespaceselector:
+          exclude:
+          - kube-*
+          include:
+          - '*'
+        object-templates:
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: Subscription
+            metadata:
+              name: ptp-operator-subscription
+              namespace: openshift-ptp
+            spec:
+              channel: "4.9"
+              name: ptp-operator
+              source: redhat-operators
+              sourceNamespace: openshift-marketplace
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+              annotations:
+                workload.openshift.io/allowed: management
+              labels:
+                openshift.io/cluster-monitoring: "true"
+              name: openshift-ptp
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1
+            kind: OperatorGroup
+            metadata:
+              name: ptp-operators
+              namespace: openshift-ptp
+            spec:
+              targetNamespaces:
+              - openshift-ptp
+        remediationAction: inform
+        severity: low
+  remediationAction: inform

--- a/deploy/upgrades/duplicated-managed-policy-name/cgu-duplicated-managed-policy-name.yaml
+++ b/deploy/upgrades/duplicated-managed-policy-name/cgu-duplicated-managed-policy-name.yaml
@@ -1,0 +1,21 @@
+apiVersion: ran.openshift.io/v1alpha1
+kind: ClusterGroupUpgrade
+metadata:
+  name: cgu
+  namespace: default
+  annotations:
+    cluster-group-upgrades-operator/name-suffix: kuttl      
+spec:
+  managedPolicies:
+    - policy1-common-cluster-version-policy
+    - policy2-common-pao-sub-policy
+    - policy3-common-ptp-sub-policy
+    - policy4-common-sriov-sub-policy
+  enable: false
+  clusters:
+  - spoke1
+  - spoke2
+  - spoke4
+  - spoke6
+  remediationStrategy:
+    maxConcurrency: 2

--- a/deploy/upgrades/duplicated-managed-policy-name/patch-policies-status.sh
+++ b/deploy/upgrades/duplicated-managed-policy-name/patch-policies-status.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ -n "$1" ]; then
+    curl -k -s -X PATCH -H "Accept: application/json, */*" \
+    -H "Content-Type: application/merge-patch+json" \
+    http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$1/policies/policy1-common-cluster-version-policy/status \
+    --data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"}]}}'
+fi
+
+if [ -n "$2" ]; then
+    curl -k -s -X PATCH -H "Accept: application/json, */*" \
+    -H "Content-Type: application/merge-patch+json" \
+    http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$2/policies/policy2-common-pao-sub-policy/status \
+    --data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"}, {"clustername":"spoke2","clusternamespace":"spoke2","compliant":"NonCompliant"}, {"clustername":"spoke6","clusternamespace":"spoke6","compliant":"NonCompliant"}]}}'
+fi
+
+if [ -n "$3" ]; then
+    curl -k -s -X PATCH -H "Accept: application/json, */*" \
+    -H "Content-Type: application/merge-patch+json" \
+    http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$3/policies/policy3-common-ptp-sub-policy/status \
+    --data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"},{"clustername":"spoke2","clusternamespace":"spoke2","compliant":"NonCompliant"} {"clustername":"spoke4","clusternamespace":"spoke4","compliant":"NonCompliant"},{"clustername":"spoke6","clusternamespace":"spoke6","compliant":"NonCompliant"}]}}'
+fi
+
+if [ -n "$4" ]; then
+    curl -k -s -X PATCH -H "Accept: application/json, */*" \
+    -H "Content-Type: application/merge-patch+json" \
+    http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$4/policies/policy4-common-sriov-sub-policy/status \
+    --data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"}, {"clustername":"spoke4","clusternamespace":"spoke4","compliant":"NonCompliant"}, {"clustername":"spoke6","clusternamespace":"spoke6","compliant":"NonCompliant"}]}}'
+fi
+

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -10,7 +10,7 @@ commands:
 testDirs:
 - tests/kuttl/tests/
 crdDir: ./config/crd/bases/
-timeout: 25
+timeout: 65
 parallel: 1
 namespace: default
 

--- a/tests/kuttl/tests/duplicated-managed-policy-name/00-assert.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/00-assert.yaml
@@ -1,0 +1,39 @@
+apiVersion: ran.openshift.io/v1alpha1
+kind: ClusterGroupUpgrade
+metadata:
+  name: cgu
+  namespace: default
+spec:
+  actions:
+    afterCompletion:
+      deleteObjects: true
+    beforeEnable: {}
+  backup: false
+  clusters:
+  - spoke1
+  - spoke2
+  - spoke4
+  - spoke6
+  enable: false
+  managedPolicies:
+  - policy1-common-cluster-version-policy
+  - policy2-common-pao-sub-policy
+  - policy3-common-ptp-sub-policy
+  - policy4-common-sriov-sub-policy
+  preCaching: false
+  remediationStrategy:
+    maxConcurrency: 2
+    timeout: 240
+status:
+  computedMaxConcurrency: 2
+  conditions:
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: "True"
+    type: ClustersSelected
+  - message: 'Managed policy name should be unique, but was found in multiple namespaces: {"policy2-common-pao-sub-policy":["aaa","bbb"],"policy3-common-ptp-sub-policy":["aaa","bbb","default"]} '
+    reason: AmbiguousManagedPoliciesNames
+    status: "False"
+    type: Validated
+  status: {}
+

--- a/tests/kuttl/tests/duplicated-managed-policy-name/00-setup.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/00-setup.yaml
@@ -1,0 +1,74 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+
+commands:
+  # Create the two namespaces to hold the managed policies with the same name.
+  - command: oc create namespace aaa
+    namespaced: true
+  - command: oc create namespace bbb
+    namespaced: true
+
+  # Create all the managed inform policies
+  - command: oc apply -f ../../../../deploy/acm/policies/all_policies/policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=aaa -f ../../../../deploy/acm/policies/all_policies/policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=bbb -f ../../../../deploy/acm/policies/all_policies/policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=aaa -f ../../../../deploy/acm/policies/all_policies/policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=bbb -f ../../../../deploy/acm/policies/all_policies/policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=default -f ../../../../deploy/acm/policies/all_policies/policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply -f ../../../../deploy/acm/policies/all_policies/policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+
+  # Patch the inform policies to reflect the compliance status.
+  - command: ../../../../deploy/acm/policies/patch-policies-status.sh default "" default default
+    ignoreFailure: false
+  - command: ../../../../deploy/acm/policies/patch-policies-status.sh "" aaa aaa ""
+    ignoreFailure: false
+  - command: ../../../../deploy/acm/policies/patch-policies-status.sh "" bbb bbb ""
+    ignoreFailure: false
+
+  # Create all the child policies to map the inform policies above.
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+
+  # Apply the CGU.
+  - command: oc apply -f ../../../../deploy/upgrades/duplicated-managed-policy-name/cgu-duplicated-managed-policy-name.yaml
+    namespaced: true

--- a/tests/kuttl/tests/duplicated-managed-policy-name/01-assert.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/01-assert.yaml
@@ -1,0 +1,39 @@
+apiVersion: ran.openshift.io/v1alpha1
+kind: ClusterGroupUpgrade
+metadata:
+  name: cgu
+  namespace: default
+spec:
+  actions:
+    afterCompletion:
+      deleteObjects: true
+    beforeEnable: {}
+  backup: false
+  clusters:
+  - spoke1
+  - spoke2
+  - spoke4
+  - spoke6
+  enable: true
+  managedPolicies:
+  - policy1-common-cluster-version-policy
+  - policy2-common-pao-sub-policy
+  - policy3-common-ptp-sub-policy
+  - policy4-common-sriov-sub-policy
+  preCaching: false
+  remediationStrategy:
+    maxConcurrency: 2
+    timeout: 240
+status:
+  computedMaxConcurrency: 2
+  conditions:
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: "True"
+    type: ClustersSelected
+  - message: 'Managed policy name should be unique, but was found in multiple namespaces: {"policy2-common-pao-sub-policy":["aaa","bbb"],"policy3-common-ptp-sub-policy":["aaa","bbb","default"]} '
+    reason: AmbiguousManagedPoliciesNames
+    status: "False"
+    type: Validated
+  status: {}
+

--- a/tests/kuttl/tests/duplicated-managed-policy-name/01-start-upgrade.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/01-start-upgrade.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+
+commands:
+  # Start the upgrade by enabling the CGU.
+  - command: oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu --patch '{"spec":{"enable":true}}' --type=merge
+    ignoreFailure: false

--- a/tests/kuttl/tests/duplicated-managed-policy-name/02-assert.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/02-assert.yaml
@@ -1,0 +1,102 @@
+apiVersion: ran.openshift.io/v1alpha1
+kind: ClusterGroupUpgrade
+metadata:
+  name: cgu
+  namespace: default
+spec:
+  actions:
+    afterCompletion:
+      deleteObjects: true
+    beforeEnable: {}
+  backup: false
+  clusters:
+  - spoke1
+  - spoke2
+  - spoke4
+  - spoke6
+  enable: true
+  managedPolicies:
+  - policy1-common-cluster-version-policy
+  - policy2-common-pao-sub-policy
+  - policy3-common-ptp-sub-policy
+  - policy4-common-sriov-sub-policy
+  preCaching: false
+  remediationStrategy:
+    maxConcurrency: 2
+    timeout: 240
+status:
+  computedMaxConcurrency: 2
+  conditions:
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: "True"
+    type: ClustersSelected
+  - message: Completed validation
+    reason: ValidationCompleted
+    status: "True"
+    type: Validated
+  - message: Remediating non-compliant policies
+    reason: InProgress
+    status: "True"
+    type: Progressing
+  copiedPolicies:
+  - cgu-policy1-common-cluster-version-policy-kuttl
+  - cgu-policy2-common-pao-sub-policy-kuttl
+  - cgu-policy3-common-ptp-sub-policy-kuttl
+  - cgu-policy4-common-sriov-sub-policy-kuttl
+  managedPoliciesContent:
+    policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-performance-addon-operator"}]'
+    policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'
+    policy4-common-sriov-sub-policy: '[{"kind":"Subscription","name":"sriov-network-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-sriov-network-operator"}]'
+  managedPoliciesForUpgrade:
+  - name: policy1-common-cluster-version-policy
+    namespace: default
+  - name: policy2-common-pao-sub-policy
+    namespace: aaa
+  - name: policy3-common-ptp-sub-policy
+    namespace: bbb
+  - name: policy4-common-sriov-sub-policy
+    namespace: default
+  managedPoliciesNs:
+    policy1-common-cluster-version-policy: default
+    policy2-common-pao-sub-policy: aaa
+    policy3-common-ptp-sub-policy: bbb
+    policy4-common-sriov-sub-policy: default
+  placementBindings:
+  - cgu-policy1-common-cluster-version-policy-placement-kuttl
+  - cgu-policy2-common-pao-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  placementRules:
+  - cgu-policy1-common-cluster-version-policy-placement-kuttl
+  - cgu-policy2-common-pao-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  remediationPlan:
+  - - spoke1
+    - spoke2
+  - - spoke4
+    - spoke6
+  safeResourceNames:
+    cgu-common-cluster-version-policy-config: cgu-common-cluster-version-policy-config-kuttl
+    cgu-common-pao-sub-policy-config: cgu-common-pao-sub-policy-config-kuttl
+    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    cgu-default-subscription-performance-addon-operator: cgu-default-subscription-performance-addon-operator-kuttl
+    cgu-policy1-common-cluster-version-policy: cgu-policy1-common-cluster-version-policy-kuttl
+    cgu-policy1-common-cluster-version-policy-placement: cgu-policy1-common-cluster-version-policy-placement-kuttl
+    cgu-policy2-common-pao-sub-policy: cgu-policy2-common-pao-sub-policy-kuttl
+    cgu-policy2-common-pao-sub-policy-placement: cgu-policy2-common-pao-sub-policy-placement-kuttl
+    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  status:
+    currentBatch: 1
+    currentBatchRemediationProgress:
+      spoke1:
+        policyIndex: 0
+        state: InProgress
+      spoke2:
+        policyIndex: 1
+        state: InProgress

--- a/tests/kuttl/tests/duplicated-managed-policy-name/02-remove-duplicated-policies.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/02-remove-duplicated-policies.yaml
@@ -1,0 +1,23 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+
+commands:
+  # Remove all the conflicting managed and child policies.
+  - command: oc delete --namespace=bbb -f ../../../../deploy/acm/policies/all_policies/policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=aaa -f ../../../../deploy/acm/policies/all_policies/policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=default -f ../../../../deploy/acm/policies/all_policies/policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
+    namespaced: true

--- a/tests/kuttl/tests/duplicated-managed-policy-name/03-cleanup.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/03-cleanup.yaml
@@ -1,0 +1,45 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+
+commands:
+  # Delete the two namespaces created to hold the managed policies.
+  - command: oc delete namespace aaa
+    namespaced: true
+  - command: oc delete namespace bbb
+    namespaced: true
+  # Remove all the managed inform policies
+  - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+
+  # Remove all the child policies.
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+
+  # Delete the CGU.
+  - command: oc delete -f ../../../../deploy/upgrades/duplicated-managed-policy-name/cgu-duplicated-managed-policy-name.yaml
+    namespaced: true


### PR DESCRIPTION
Differentiate between managed policies with the same name in different namespaces:
- determine all the namespaces where we can find managed policies
- if there is at least one managed policy name that can be found in more than one namespace fail the CGU validation and include a condition message that contains the conflicting policy names and namespaces