### PR TITLE
Cleanup KUTTL child policies

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -10,7 +10,7 @@ commands:
 testDirs:
 - tests/kuttl/tests/
 crdDir: ./config/crd/bases/
-timeout: 65
+timeout: 25
 parallel: 1
 namespace: default
 

--- a/tests/kuttl/tests/backup-complete/05-cleanup.yaml
+++ b/tests/kuttl/tests/backup-complete/05-cleanup.yaml
@@ -40,7 +40,7 @@ commands:
     namespaced: true
 
   # Delete the UOCR.
-  - command: oc delete -f ../../../../deploy/upgrades/skip-compliant-policies/skip-compliant-policies.yaml
+  - command: oc delete -f ../../../../deploy/upgrades/backup/backup.yaml
     namespaced: true
 
   - command: ../../../../deploy/upgrades/backup/cleanup.sh 

--- a/tests/kuttl/tests/backup-fail/05-cleanup.yaml
+++ b/tests/kuttl/tests/backup-fail/05-cleanup.yaml
@@ -40,7 +40,7 @@ commands:
     namespaced: true
 
   # Delete the UOCR.
-  - command: oc delete -f ../../../../deploy/upgrades/skip-compliant-policies/skip-compliant-policies.yaml
+  - command: oc delete -f ../../../../deploy/upgrades/backup/backup.yaml
     namespaced: true
 
   - command: ../../../../deploy/upgrades/backup/cleanup.sh 

--- a/tests/kuttl/tests/backup-partial-complete/05-cleanup.yaml
+++ b/tests/kuttl/tests/backup-partial-complete/05-cleanup.yaml
@@ -40,7 +40,7 @@ commands:
     namespaced: true
 
   # Delete the UOCR.
-  - command: oc delete -f ../../../../deploy/upgrades/skip-compliant-policies/skip-compliant-policies.yaml
+  - command: oc delete -f ../../../../deploy/upgrades/backup/backup.yaml
     namespaced: true
 
   - command: ../../../../deploy/upgrades/backup/cleanup.sh 

--- a/tests/kuttl/tests/blocking-mechanisms/03-cleanup-blocking-mechanisms.yaml
+++ b/tests/kuttl/tests/blocking-mechanisms/03-cleanup-blocking-mechanisms.yaml
@@ -2,14 +2,67 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 
 commands:
-  - command: oc delete -f ../../../../deploy/acm/policies/blocking_mechanisms/policy1-common-cluster-version-policy.yaml
+  - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy1-common-cluster-version-policy.yaml
     namespaced: true
-  - command: oc delete -f ../../../../deploy/acm/policies/blocking_mechanisms/policy2-common-pao-sub-policy.yaml
+  - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy2-common-pao-sub-policy.yaml
     namespaced: true
-  - command: oc delete -f ../../../../deploy/acm/policies/blocking_mechanisms/policy3-common-ptp-sub-policy.yaml
+  - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy3-common-ptp-sub-policy.yaml
     namespaced: true
-  - command: oc delete -f ../../../../deploy/acm/policies/blocking_mechanisms/policy4-common-sriov-sub-policy.yaml
+  - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy4-common-sriov-sub-policy.yaml
     namespaced: true
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke3 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke5 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke3 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke5 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke3 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke5 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke3 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke5 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+
+  # Create the UOCRs.
   - command: oc delete -f ../../../../deploy/upgrades/blocking-mechanisms/cgu-a.yaml
     namespaced: true
   - command: oc delete -f ../../../../deploy/upgrades/blocking-mechanisms/cgu-b.yaml

--- a/tests/kuttl/tests/duplicated-managed-policy-name/02-assert.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/02-assert.yaml
@@ -23,7 +23,7 @@ spec:
   preCaching: false
   remediationStrategy:
     maxConcurrency: 2
-    timeout: 240
+    timeout: 241
 status:
   computedMaxConcurrency: 2
   conditions:

--- a/tests/kuttl/tests/duplicated-managed-policy-name/02-remove-duplicated-policies.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/02-remove-duplicated-policies.yaml
@@ -21,3 +21,6 @@ commands:
     namespaced: true
   - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
     namespaced: true
+
+  # Just to wake up the controller sooner
+  - command: oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu --patch '{"spec":{"remediationStrategy":{"timeout":241}}}' --type=merge

--- a/tests/kuttl/tests/duplicated-managed-policy-name/03-cleanup.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/03-cleanup.yaml
@@ -4,9 +4,8 @@ kind: TestStep
 commands:
   # Delete the two namespaces created to hold the managed policies.
   - command: oc delete namespace aaa
-    namespaced: true
   - command: oc delete namespace bbb
-    namespaced: true
+
   # Remove all the managed inform policies
   - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy1-common-cluster-version-policy.yaml
     namespaced: true

--- a/tests/kuttl/tests/pre-caching-complete/06-cleanup.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/06-cleanup.yaml
@@ -40,7 +40,7 @@ commands:
     namespaced: true
 
   # Delete the UOCR.
-  - command: oc delete -f ../../../../deploy/upgrades/skip-compliant-policies/skip-compliant-policies.yaml
+  - command: oc delete -f ../../../../deploy/upgrades/pre-caching/pre-caching.yaml
     namespaced: true
 
   - command: ../../../../deploy/upgrades/pre-caching/cleanup.sh 

--- a/tests/kuttl/tests/pre-caching-missing-sub-policy/06-cleanup.yaml
+++ b/tests/kuttl/tests/pre-caching-missing-sub-policy/06-cleanup.yaml
@@ -40,7 +40,7 @@ commands:
     namespaced: true
 
   # Delete the UOCR.
-  - command: oc delete -f ../../../../deploy/upgrades/skip-compliant-policies/skip-compliant-policies.yaml
+  - command: oc delete -f ../../../../deploy/upgrades/pre-caching-missing-sub-policy/pre-caching.yaml
     namespaced: true
 
   - command: ../../../../deploy/upgrades/pre-caching/cleanup.sh 

--- a/tests/kuttl/tests/pre-caching-partial-complete/07-cleanup.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/07-cleanup.yaml
@@ -40,7 +40,7 @@ commands:
     namespaced: true
 
   # Delete the UOCR.
-  - command: oc delete -f ../../../../deploy/upgrades/skip-compliant-policies/skip-compliant-policies.yaml
+  - command: oc delete -f ../../../../deploy/upgrades/pre-caching/pre-caching.yaml
     namespaced: true
 
   - command: ../../../../deploy/upgrades/pre-caching/cleanup.sh 


### PR DESCRIPTION
Description:
- child policies that are not properly cleaned up cause false failure for other KUTTL tests, so update the cleanup step and make sure everything is cleaned up at the end of each test.