### PR TITLE
OCPBUGS-11769: Identify managed policies with ambiguous names (#556)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A full table of the conditions and their appropriate reasons and types are:
   | |False | ClusterNotFound | Unable to select clusters: error message |
   `Validated` | True | ValidationCompleted| Completed validation |
   | | False | NotAllManagedPoliciesExist| Missing managed policies: policyList,  invalid managed policies: policyList |
+  | | False | AmbiguousManagedPoliciesNames | Managed policy name should be unique, but was found in multiple namespaces: {"policy":["namespace1","namespace2"]} |
   | | False | InvalidPlatformImage | Error related to platform image |
   `PrecacheSpecValid` | True | PrecacheSpecIsWellFormed | Precaching spec is valid and consistent |
   | | False | InvalidPlatformImage| Precaching spec is incomplete |

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -55,10 +56,11 @@ type ClusterGroupUpgradeReconciler struct {
 }
 
 type policiesInfo struct {
-	invalidPolicies   []string
-	missingPolicies   []string
-	presentPolicies   []*unstructured.Unstructured
-	compliantPolicies []*unstructured.Unstructured
+	invalidPolicies      []string
+	missingPolicies      []string
+	presentPolicies      []*unstructured.Unstructured
+	compliantPolicies    []*unstructured.Unstructured
+	duplicatedPoliciesNs map[string][]string
 }
 
 const statusUpdateWaitInMilliSeconds = 100
@@ -250,6 +252,9 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 
 			// If not all managedPolicies exist or invalid, update the Status accordingly.
 			var statusMessage string
+			var conditionReason utils.ConditionReason
+
+			conditionReason = utils.ConditionReasons.NotAllManagedPoliciesExist
 			if len(managedPoliciesInfo.missingPolicies) != 0 {
 				statusMessage = fmt.Sprintf("Missing managed policies: %s ", managedPoliciesInfo.missingPolicies)
 			}
@@ -258,11 +263,17 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 				statusMessage = fmt.Sprintf("Invalid managed policies: %s ", managedPoliciesInfo.invalidPolicies)
 			}
 
-			// If not all managedPolicies exist, update the Status accordingly.
+			if len(managedPoliciesInfo.duplicatedPoliciesNs) != 0 {
+				jsonData, _ := json.Marshal(managedPoliciesInfo.duplicatedPoliciesNs)
+				statusMessage = fmt.Sprintf(
+					"Managed policy name should be unique, but was found in multiple namespaces: %s ", jsonData)
+				conditionReason = utils.ConditionReasons.AmbiguousManagedPoliciesNames
+			}
+			// If there are errors regarding the managedPolicies, update the Status accordingly.
 			utils.SetStatusCondition(
 				&clusterGroupUpgrade.Status.Conditions,
 				utils.ConditionTypes.Validated,
-				utils.ConditionReasons.NotAllManagedPoliciesExist,
+				conditionReason,
 				metav1.ConditionFalse,
 				statusMessage,
 			)
@@ -903,6 +914,16 @@ func (r *ClusterGroupUpgradeReconciler) getPolicyByName(ctx context.Context, pol
 	return foundPolicy, r.Client.Get(ctx, types.NamespacedName{Name: policyName, Namespace: namespace}, foundPolicy)
 }
 
+func updateDuplicatedManagedPoliciesInfo(managedPoliciesInfo *policiesInfo, policiesNs map[string][]string) {
+	managedPoliciesInfo.duplicatedPoliciesNs = make(map[string][]string)
+	for crtPolicy, crtNs := range policiesNs {
+		if len(crtNs) > 1 {
+			managedPoliciesInfo.duplicatedPoliciesNs[crtPolicy] = crtNs
+			sort.Strings(managedPoliciesInfo.duplicatedPoliciesNs[crtPolicy])
+		}
+	}
+}
+
 /*
 	 doManagedPoliciesExist checks that all the managedPolicies specified in the CR exist.
 	   returns: true/false                   if all the policies exist or not
@@ -919,10 +940,14 @@ func (r *ClusterGroupUpgradeReconciler) doManagedPoliciesExist(
 		return false, policiesInfo{}, err
 	}
 
+	var managedPoliciesInfo policiesInfo
 	// Go through all the child policies and split the namespace from the policy name.
 	// A child policy name has the name format parent_policy_namespace.parent_policy_name
 	// The policy map we are creating will be of format {"policy_name": "policy_namespace"}
 	policyMap := make(map[string]string)
+	// Keep inventory of all the namespaces a managed policy appears in with policyNs which
+	// is of format {"policy_name": []string of policy namespaces}
+	policiesNs := make(map[string][]string)
 	policyEnforce := make(map[string]bool)
 	policyInvalidHubTmpl := make(map[string]bool)
 	for _, childPolicy := range childPoliciesList {
@@ -948,12 +973,18 @@ func (r *ClusterGroupUpgradeReconciler) doManagedPoliciesExist(
 		}
 
 		policyMap[policyNameArr[1]] = policyNameArr[0]
+		utils.UpdateManagedPolicyNamespaceList(policiesNs, policyNameArr)
 	}
-	r.Log.Info("[doManagedPoliciesExist]", "policyMap", policyMap)
+
+	// If a managed policy is present in more than one namespace, raise an error and advice user to
+	// fix the duplicated name.
+	updateDuplicatedManagedPoliciesInfo(&managedPoliciesInfo, policiesNs)
+	if len(managedPoliciesInfo.duplicatedPoliciesNs) != 0 {
+		return false, managedPoliciesInfo, nil
+	}
 
 	// Go through the managedPolicies in the CR, make sure they exist and save them to the upgrade's status together with
 	// their namespace.
-	var managedPoliciesInfo policiesInfo
 	var managedPoliciesForUpgrade []ranv1alpha1.ManagedPolicyForUpgrade
 	var managedPoliciesCompliantBeforeUpgrade []string
 	clusterGroupUpgrade.Status.ManagedPoliciesNs = make(map[string]string)

--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -32,43 +32,45 @@ type ConditionReason string
 
 // ConditionReasons define the different reasons that conditions will be set for
 var ConditionReasons = struct {
-	Completed                  ConditionReason
-	ClusterSelectionCompleted  ConditionReason
-	ValidationCompleted        ConditionReason
-	BackupCompleted            ConditionReason
-	PrecachingCompleted        ConditionReason
-	Failed                     ConditionReason
-	IncompleteBlockingCR       ConditionReason
-	InProgress                 ConditionReason
-	InvalidPlatformImage       ConditionReason
-	MissingBlockingCR          ConditionReason
-	NotAllManagedPoliciesExist ConditionReason
-	NotEnabled                 ConditionReason
-	NotStarted                 ConditionReason
-	ClusterNotFound            ConditionReason
-	NotPresent                 ConditionReason
-	PartiallyDone              ConditionReason
-	PrecacheSpecIsWellFormed   ConditionReason
-	TimedOut                   ConditionReason
+	Completed                     ConditionReason
+	ClusterSelectionCompleted     ConditionReason
+	ValidationCompleted           ConditionReason
+	BackupCompleted               ConditionReason
+	PrecachingCompleted           ConditionReason
+	Failed                        ConditionReason
+	IncompleteBlockingCR          ConditionReason
+	InProgress                    ConditionReason
+	InvalidPlatformImage          ConditionReason
+	MissingBlockingCR             ConditionReason
+	NotAllManagedPoliciesExist    ConditionReason
+	AmbiguousManagedPoliciesNames ConditionReason
+	NotEnabled                    ConditionReason
+	NotStarted                    ConditionReason
+	ClusterNotFound               ConditionReason
+	NotPresent                    ConditionReason
+	PartiallyDone                 ConditionReason
+	PrecacheSpecIsWellFormed      ConditionReason
+	TimedOut                      ConditionReason
 }{
-	Completed:                  "Completed",
-	ClusterSelectionCompleted:  "ClusterSelectionCompleted",
-	ValidationCompleted:        "ValidationCompleted",
-	BackupCompleted:            "BackupCompleted",
-	PrecachingCompleted:        "PrecachingCompleted",
-	Failed:                     "Failed",
-	IncompleteBlockingCR:       "IncompleteBlockingCR",
-	InProgress:                 "InProgress",
-	InvalidPlatformImage:       "InvalidPlatformImage",
-	MissingBlockingCR:          "MissingBlockingCR",
-	NotAllManagedPoliciesExist: "NotAllManagedPoliciesExist",
-	NotEnabled:                 "NotEnabled",
-	NotStarted:                 "NotStarted",
-	ClusterNotFound:            "ClusterNotFound",
-	NotPresent:                 "NotPresent",
-	PartiallyDone:              "PartiallyDone",
-	PrecacheSpecIsWellFormed:   "PrecacheSpecIsWellFormed",
-	TimedOut:                   "TimedOut",
+	Completed:                     "Completed",
+	ClusterSelectionCompleted:     "ClusterSelectionCompleted",
+	ValidationCompleted:           "ValidationCompleted",
+	BackupCompleted:               "BackupCompleted",
+	PrecachingCompleted:           "PrecachingCompleted",
+	Failed:                        "Failed",
+	IncompleteBlockingCR:          "IncompleteBlockingCR",
+	InProgress:                    "InProgress",
+	InvalidPlatformImage:          "InvalidPlatformImage",
+	MissingBlockingCR:             "MissingBlockingCR",
+	NotAllManagedPoliciesExist:    "NotAllManagedPoliciesExist",
+	AmbiguousManagedPoliciesNames: "AmbiguousManagedPoliciesNames",
+	NotEnabled:                    "NotEnabled",
+	NotStarted:                    "NotStarted",
+	ClusterNotFound:               "ClusterNotFound",
+	NotPresent:                    "NotPresent",
+	PartiallyDone:                 "PartiallyDone",
+	PrecacheSpecIsWellFormed:      "PrecacheSpecIsWellFormed",
+	TimedOut:                      "TimedOut",
 }
 
 // SetStatusCondition is a convenience wrapper for meta.SetStatusCondition that takes in the types defined here and converts them to strings

--- a/controllers/utils/policy_util.go
+++ b/controllers/utils/policy_util.go
@@ -211,3 +211,22 @@ func ShouldSoak(policy *unstructured.Unstructured, firstCompliantAt metav1.Time)
 	}
 	return true, nil
 }
+
+// UpdateManagedPolicyNamespaceList updates policyNs with the corresponding namespaces of a managed policy
+// as contained in the policyNameArr parameter.
+func UpdateManagedPolicyNamespaceList(policyNs map[string][]string, policyNameArr []string) {
+	crtPolicyName := policyNameArr[1]
+	crtPolicyNs := policyNameArr[0]
+
+	// If the current managed policy namespace doesn't exist in the namespace list, add it.
+	nsFound := false
+	for _, nsEntry := range policyNs[crtPolicyName] {
+		if crtPolicyNs == nsEntry {
+			nsFound = true
+			break
+		}
+	}
+	if nsFound == false {
+		policyNs[crtPolicyName] = append(policyNs[crtPolicyName], crtPolicyNs)
+	}
+}

--- a/controllers/utils/policy_util_test.go
+++ b/controllers/utils/policy_util_test.go
@@ -55,3 +55,46 @@ func TestShouldSoak(t *testing.T) {
 	_, err = ShouldSoak(policy, v1.Now())
 	assert.Error(t, err)
 }
+
+func TestUpdateManagedPolicyNamespaceList(t *testing.T) {
+	testcases := []struct {
+		policiesNs     map[string][]string
+		policyNameArr  []string
+		expectedResult map[string][]string
+	}{
+		{
+			policiesNs: map[string][]string{
+				"policy1": {"aaa", "bbb"},
+				"policy2": {"aaa"},
+			},
+			policyNameArr: []string{"bbb", "policy2"},
+			expectedResult: map[string][]string{
+				"policy1": {"aaa", "bbb"},
+				"policy2": {"aaa", "bbb"},
+			},
+		},
+		{
+			policiesNs:    map[string][]string{},
+			policyNameArr: []string{"bbb", "policy2"},
+			expectedResult: map[string][]string{
+				"policy2": {"bbb"},
+			},
+		},
+		{
+			policiesNs: map[string][]string{
+				"policy1": {"aaa", "bbb"},
+				"policy2": {"aaa"},
+			},
+			policyNameArr: []string{"aaa", "policy1"},
+			expectedResult: map[string][]string{
+				"policy1": {"aaa", "bbb"},
+				"policy2": {"aaa"},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		UpdateManagedPolicyNamespaceList(tc.policiesNs, tc.policyNameArr)
+		assert.Equal(t, tc.policiesNs, tc.expectedResult)
+	}
+}

--- a/deploy/acm/policies/all_policies/child-aaa-ns-policy2-common-pao-sub-policy.yaml
+++ b/deploy/acm/policies/all_policies/child-aaa-ns-policy2-common-pao-sub-policy.yaml
@@ -1,0 +1,57 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  labels:
+    policy.open-cluster-management.io/root-policy: policy2-common-pao-sub-policy
+  name: aaa.policy2-common-pao-sub-policy
+spec:
+  disabled: false
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: common-pao-sub-policy-config
+      spec:
+        namespaceselector:
+          exclude:
+          - kube-*
+          include:
+          - '*'
+        object-templates:
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: Subscription
+            metadata:
+              name: performance-addon-operator
+              namespace: openshift-performance-addon-operator
+            spec:
+              channel: "4.9"
+              name: performance-addon-operator
+              source: redhat-operators
+              sourceNamespace: openshift-marketplace
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+              annotations:
+                workload.openshift.io/allowed: management
+              labels:
+                openshift.io/cluster-monitoring: "true"
+              name: openshift-performance-addon-operator
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1
+            kind: OperatorGroup
+            metadata:
+              name: performance-addon-operator
+              namespace: openshift-performance-addon-operator
+        remediationAction: inform
+        severity: low
+  remediationAction: inform

--- a/deploy/acm/policies/all_policies/child-aaa-ns-policy3-common-ptp-sub-policy.yaml
+++ b/deploy/acm/policies/all_policies/child-aaa-ns-policy3-common-ptp-sub-policy.yaml
@@ -1,0 +1,60 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  labels:
+    policy.open-cluster-management.io/root-policy: policy3-common-ptp-sub-policy
+  name: aaa.policy3-common-ptp-sub-policy
+spec:
+  disabled: false
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: common-ptp-sub-policy-config
+      spec:
+        namespaceselector:
+          exclude:
+          - kube-*
+          include:
+          - '*'
+        object-templates:
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: Subscription
+            metadata:
+              name: ptp-operator-subscription
+              namespace: openshift-ptp
+            spec:
+              channel: "4.9"
+              name: ptp-operator
+              source: redhat-operators
+              sourceNamespace: openshift-marketplace
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+              annotations:
+                workload.openshift.io/allowed: management
+              labels:
+                openshift.io/cluster-monitoring: "true"
+              name: openshift-ptp
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1
+            kind: OperatorGroup
+            metadata:
+              name: ptp-operators
+              namespace: openshift-ptp
+            spec:
+              targetNamespaces:
+              - openshift-ptp
+        remediationAction: inform
+        severity: low
+  remediationAction: inform

--- a/deploy/acm/policies/all_policies/child-bbb-ns-policy2-common-pao-sub-policy.yaml
+++ b/deploy/acm/policies/all_policies/child-bbb-ns-policy2-common-pao-sub-policy.yaml
@@ -1,0 +1,57 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  labels:
+    policy.open-cluster-management.io/root-policy: policy2-common-pao-sub-policy
+  name: bbb.policy2-common-pao-sub-policy
+spec:
+  disabled: false
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: common-pao-sub-policy-config
+      spec:
+        namespaceselector:
+          exclude:
+          - kube-*
+          include:
+          - '*'
+        object-templates:
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: Subscription
+            metadata:
+              name: performance-addon-operator
+              namespace: openshift-performance-addon-operator
+            spec:
+              channel: "4.9"
+              name: performance-addon-operator
+              source: redhat-operators
+              sourceNamespace: openshift-marketplace
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+              annotations:
+                workload.openshift.io/allowed: management
+              labels:
+                openshift.io/cluster-monitoring: "true"
+              name: openshift-performance-addon-operator
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1
+            kind: OperatorGroup
+            metadata:
+              name: performance-addon-operator
+              namespace: openshift-performance-addon-operator
+        remediationAction: inform
+        severity: low
+  remediationAction: inform

--- a/deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+++ b/deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
@@ -1,0 +1,60 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  labels:
+    policy.open-cluster-management.io/root-policy: policy3-common-ptp-sub-policy
+  name: bbb.policy3-common-ptp-sub-policy
+spec:
+  disabled: false
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: common-ptp-sub-policy-config
+      spec:
+        namespaceselector:
+          exclude:
+          - kube-*
+          include:
+          - '*'
+        object-templates:
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1alpha1
+            kind: Subscription
+            metadata:
+              name: ptp-operator-subscription
+              namespace: openshift-ptp
+            spec:
+              channel: "4.9"
+              name: ptp-operator
+              source: redhat-operators
+              sourceNamespace: openshift-marketplace
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+              annotations:
+                workload.openshift.io/allowed: management
+              labels:
+                openshift.io/cluster-monitoring: "true"
+              name: openshift-ptp
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: operators.coreos.com/v1
+            kind: OperatorGroup
+            metadata:
+              name: ptp-operators
+              namespace: openshift-ptp
+            spec:
+              targetNamespaces:
+              - openshift-ptp
+        remediationAction: inform
+        severity: low
+  remediationAction: inform

--- a/deploy/upgrades/duplicated-managed-policy-name/cgu-duplicated-managed-policy-name.yaml
+++ b/deploy/upgrades/duplicated-managed-policy-name/cgu-duplicated-managed-policy-name.yaml
@@ -1,0 +1,21 @@
+apiVersion: ran.openshift.io/v1alpha1
+kind: ClusterGroupUpgrade
+metadata:
+  name: cgu
+  namespace: default
+  annotations:
+    cluster-group-upgrades-operator/name-suffix: kuttl      
+spec:
+  managedPolicies:
+    - policy1-common-cluster-version-policy
+    - policy2-common-pao-sub-policy
+    - policy3-common-ptp-sub-policy
+    - policy4-common-sriov-sub-policy
+  enable: false
+  clusters:
+  - spoke1
+  - spoke2
+  - spoke4
+  - spoke6
+  remediationStrategy:
+    maxConcurrency: 2

--- a/deploy/upgrades/duplicated-managed-policy-name/patch-policies-status.sh
+++ b/deploy/upgrades/duplicated-managed-policy-name/patch-policies-status.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ -n "$1" ]; then
+    curl -k -s -X PATCH -H "Accept: application/json, */*" \
+    -H "Content-Type: application/merge-patch+json" \
+    http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$1/policies/policy1-common-cluster-version-policy/status \
+    --data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"}]}}'
+fi
+
+if [ -n "$2" ]; then
+    curl -k -s -X PATCH -H "Accept: application/json, */*" \
+    -H "Content-Type: application/merge-patch+json" \
+    http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$2/policies/policy2-common-pao-sub-policy/status \
+    --data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"}, {"clustername":"spoke2","clusternamespace":"spoke2","compliant":"NonCompliant"}, {"clustername":"spoke6","clusternamespace":"spoke6","compliant":"NonCompliant"}]}}'
+fi
+
+if [ -n "$3" ]; then
+    curl -k -s -X PATCH -H "Accept: application/json, */*" \
+    -H "Content-Type: application/merge-patch+json" \
+    http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$3/policies/policy3-common-ptp-sub-policy/status \
+    --data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"},{"clustername":"spoke2","clusternamespace":"spoke2","compliant":"NonCompliant"} {"clustername":"spoke4","clusternamespace":"spoke4","compliant":"NonCompliant"},{"clustername":"spoke6","clusternamespace":"spoke6","compliant":"NonCompliant"}]}}'
+fi
+
+if [ -n "$4" ]; then
+    curl -k -s -X PATCH -H "Accept: application/json, */*" \
+    -H "Content-Type: application/merge-patch+json" \
+    http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$4/policies/policy4-common-sriov-sub-policy/status \
+    --data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"}, {"clustername":"spoke4","clusternamespace":"spoke4","compliant":"NonCompliant"}, {"clustername":"spoke6","clusternamespace":"spoke6","compliant":"NonCompliant"}]}}'
+fi
+

--- a/tests/kuttl/tests/blocking-mechanisms/03-cleanup-blocking-mechanisms.yaml
+++ b/tests/kuttl/tests/blocking-mechanisms/03-cleanup-blocking-mechanisms.yaml
@@ -2,14 +2,67 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 
 commands:
-  - command: oc delete -f ../../../../deploy/acm/policies/blocking_mechanisms/policy1-common-cluster-version-policy.yaml
+  - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy1-common-cluster-version-policy.yaml
     namespaced: true
-  - command: oc delete -f ../../../../deploy/acm/policies/blocking_mechanisms/policy2-common-pao-sub-policy.yaml
+  - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy2-common-pao-sub-policy.yaml
     namespaced: true
-  - command: oc delete -f ../../../../deploy/acm/policies/blocking_mechanisms/policy3-common-ptp-sub-policy.yaml
+  - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy3-common-ptp-sub-policy.yaml
     namespaced: true
-  - command: oc delete -f ../../../../deploy/acm/policies/blocking_mechanisms/policy4-common-sriov-sub-policy.yaml
+  - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy4-common-sriov-sub-policy.yaml
     namespaced: true
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke3 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke5 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke3 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke5 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke3 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke5 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke3 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke5 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+
+  # Create the UOCRs.
   - command: oc delete -f ../../../../deploy/upgrades/blocking-mechanisms/cgu-a.yaml
     namespaced: true
   - command: oc delete -f ../../../../deploy/upgrades/blocking-mechanisms/cgu-b.yaml

--- a/tests/kuttl/tests/duplicated-managed-policy-name/00-assert.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/00-assert.yaml
@@ -1,0 +1,39 @@
+apiVersion: ran.openshift.io/v1alpha1
+kind: ClusterGroupUpgrade
+metadata:
+  name: cgu
+  namespace: default
+spec:
+  actions:
+    afterCompletion:
+      deleteObjects: true
+    beforeEnable: {}
+  backup: false
+  clusters:
+  - spoke1
+  - spoke2
+  - spoke4
+  - spoke6
+  enable: false
+  managedPolicies:
+  - policy1-common-cluster-version-policy
+  - policy2-common-pao-sub-policy
+  - policy3-common-ptp-sub-policy
+  - policy4-common-sriov-sub-policy
+  preCaching: false
+  remediationStrategy:
+    maxConcurrency: 2
+    timeout: 240
+status:
+  computedMaxConcurrency: 2
+  conditions:
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: "True"
+    type: ClustersSelected
+  - message: 'Managed policy name should be unique, but was found in multiple namespaces: {"policy2-common-pao-sub-policy":["aaa","bbb"],"policy3-common-ptp-sub-policy":["aaa","bbb","default"]} '
+    reason: AmbiguousManagedPoliciesNames
+    status: "False"
+    type: Validated
+  status: {}
+

--- a/tests/kuttl/tests/duplicated-managed-policy-name/00-setup.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/00-setup.yaml
@@ -1,0 +1,74 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+
+commands:
+  # Create the two namespaces to hold the managed policies with the same name.
+  - command: oc create namespace aaa
+    namespaced: true
+  - command: oc create namespace bbb
+    namespaced: true
+
+  # Create all the managed inform policies
+  - command: oc apply -f ../../../../deploy/acm/policies/all_policies/policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=aaa -f ../../../../deploy/acm/policies/all_policies/policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=bbb -f ../../../../deploy/acm/policies/all_policies/policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=aaa -f ../../../../deploy/acm/policies/all_policies/policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=bbb -f ../../../../deploy/acm/policies/all_policies/policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=default -f ../../../../deploy/acm/policies/all_policies/policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply -f ../../../../deploy/acm/policies/all_policies/policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+
+  # Patch the inform policies to reflect the compliance status.
+  - command: ../../../../deploy/acm/policies/patch-policies-status.sh default "" default default
+    ignoreFailure: false
+  - command: ../../../../deploy/acm/policies/patch-policies-status.sh "" aaa aaa ""
+    ignoreFailure: false
+  - command: ../../../../deploy/acm/policies/patch-policies-status.sh "" bbb bbb ""
+    ignoreFailure: false
+
+  # Create all the child policies to map the inform policies above.
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+
+  # Apply the CGU.
+  - command: oc apply -f ../../../../deploy/upgrades/duplicated-managed-policy-name/cgu-duplicated-managed-policy-name.yaml
+    namespaced: true

--- a/tests/kuttl/tests/duplicated-managed-policy-name/01-assert.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/01-assert.yaml
@@ -1,0 +1,39 @@
+apiVersion: ran.openshift.io/v1alpha1
+kind: ClusterGroupUpgrade
+metadata:
+  name: cgu
+  namespace: default
+spec:
+  actions:
+    afterCompletion:
+      deleteObjects: true
+    beforeEnable: {}
+  backup: false
+  clusters:
+  - spoke1
+  - spoke2
+  - spoke4
+  - spoke6
+  enable: true
+  managedPolicies:
+  - policy1-common-cluster-version-policy
+  - policy2-common-pao-sub-policy
+  - policy3-common-ptp-sub-policy
+  - policy4-common-sriov-sub-policy
+  preCaching: false
+  remediationStrategy:
+    maxConcurrency: 2
+    timeout: 240
+status:
+  computedMaxConcurrency: 2
+  conditions:
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: "True"
+    type: ClustersSelected
+  - message: 'Managed policy name should be unique, but was found in multiple namespaces: {"policy2-common-pao-sub-policy":["aaa","bbb"],"policy3-common-ptp-sub-policy":["aaa","bbb","default"]} '
+    reason: AmbiguousManagedPoliciesNames
+    status: "False"
+    type: Validated
+  status: {}
+

--- a/tests/kuttl/tests/duplicated-managed-policy-name/01-start-upgrade.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/01-start-upgrade.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+
+commands:
+  # Start the upgrade by enabling the CGU.
+  - command: oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu --patch '{"spec":{"enable":true}}' --type=merge
+    ignoreFailure: false

--- a/tests/kuttl/tests/duplicated-managed-policy-name/02-assert.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/02-assert.yaml
@@ -1,0 +1,102 @@
+apiVersion: ran.openshift.io/v1alpha1
+kind: ClusterGroupUpgrade
+metadata:
+  name: cgu
+  namespace: default
+spec:
+  actions:
+    afterCompletion:
+      deleteObjects: true
+    beforeEnable: {}
+  backup: false
+  clusters:
+  - spoke1
+  - spoke2
+  - spoke4
+  - spoke6
+  enable: true
+  managedPolicies:
+  - policy1-common-cluster-version-policy
+  - policy2-common-pao-sub-policy
+  - policy3-common-ptp-sub-policy
+  - policy4-common-sriov-sub-policy
+  preCaching: false
+  remediationStrategy:
+    maxConcurrency: 2
+    timeout: 241
+status:
+  computedMaxConcurrency: 2
+  conditions:
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: "True"
+    type: ClustersSelected
+  - message: Completed validation
+    reason: ValidationCompleted
+    status: "True"
+    type: Validated
+  - message: Remediating non-compliant policies
+    reason: InProgress
+    status: "True"
+    type: Progressing
+  copiedPolicies:
+  - cgu-policy1-common-cluster-version-policy-kuttl
+  - cgu-policy2-common-pao-sub-policy-kuttl
+  - cgu-policy3-common-ptp-sub-policy-kuttl
+  - cgu-policy4-common-sriov-sub-policy-kuttl
+  managedPoliciesContent:
+    policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-performance-addon-operator"}]'
+    policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'
+    policy4-common-sriov-sub-policy: '[{"kind":"Subscription","name":"sriov-network-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-sriov-network-operator"}]'
+  managedPoliciesForUpgrade:
+  - name: policy1-common-cluster-version-policy
+    namespace: default
+  - name: policy2-common-pao-sub-policy
+    namespace: aaa
+  - name: policy3-common-ptp-sub-policy
+    namespace: bbb
+  - name: policy4-common-sriov-sub-policy
+    namespace: default
+  managedPoliciesNs:
+    policy1-common-cluster-version-policy: default
+    policy2-common-pao-sub-policy: aaa
+    policy3-common-ptp-sub-policy: bbb
+    policy4-common-sriov-sub-policy: default
+  placementBindings:
+  - cgu-policy1-common-cluster-version-policy-placement-kuttl
+  - cgu-policy2-common-pao-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  placementRules:
+  - cgu-policy1-common-cluster-version-policy-placement-kuttl
+  - cgu-policy2-common-pao-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  remediationPlan:
+  - - spoke1
+    - spoke2
+  - - spoke4
+    - spoke6
+  safeResourceNames:
+    cgu-common-cluster-version-policy-config: cgu-common-cluster-version-policy-config-kuttl
+    cgu-common-pao-sub-policy-config: cgu-common-pao-sub-policy-config-kuttl
+    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    cgu-default-subscription-performance-addon-operator: cgu-default-subscription-performance-addon-operator-kuttl
+    cgu-policy1-common-cluster-version-policy: cgu-policy1-common-cluster-version-policy-kuttl
+    cgu-policy1-common-cluster-version-policy-placement: cgu-policy1-common-cluster-version-policy-placement-kuttl
+    cgu-policy2-common-pao-sub-policy: cgu-policy2-common-pao-sub-policy-kuttl
+    cgu-policy2-common-pao-sub-policy-placement: cgu-policy2-common-pao-sub-policy-placement-kuttl
+    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  status:
+    currentBatch: 1
+    currentBatchRemediationProgress:
+      spoke1:
+        policyIndex: 0
+        state: InProgress
+      spoke2:
+        policyIndex: 1
+        state: InProgress

--- a/tests/kuttl/tests/duplicated-managed-policy-name/02-remove-duplicated-policies.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/02-remove-duplicated-policies.yaml
@@ -1,0 +1,26 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+
+commands:
+  # Remove all the conflicting managed and child policies.
+  - command: oc delete --namespace=bbb -f ../../../../deploy/acm/policies/all_policies/policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=aaa -f ../../../../deploy/acm/policies/all_policies/policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=default -f ../../../../deploy/acm/policies/all_policies/policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+
+  # Just to wake up the controller sooner
+  - command: oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu --patch '{"spec":{"remediationStrategy":{"timeout":241}}}' --type=merge

--- a/tests/kuttl/tests/duplicated-managed-policy-name/03-cleanup.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/03-cleanup.yaml
@@ -1,0 +1,44 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+
+commands:
+  # Delete the two namespaces created to hold the managed policies.
+  - command: oc delete namespace aaa
+  - command: oc delete namespace bbb
+
+  # Remove all the managed inform policies
+  - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+
+  # Remove all the child policies.
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-aaa-ns-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-bbb-ns-policy3-common-ptp-sub-policy.yaml
+    namespaced: true
+
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy4-common-sriov-sub-policy.yaml
+    namespaced: true
+
+  # Delete the CGU.
+  - command: oc delete -f ../../../../deploy/upgrades/duplicated-managed-policy-name/cgu-duplicated-managed-policy-name.yaml
+    namespaced: true

--- a/tests/kuttl/tests/pre-caching/06-cleanup.yaml
+++ b/tests/kuttl/tests/pre-caching/06-cleanup.yaml
@@ -40,7 +40,7 @@ commands:
     namespaced: true
 
   # Delete the UOCR.
-  - command: oc delete -f ../../../../deploy/upgrades/skip-compliant-policies/skip-compliant-policies.yaml
+  - command: oc delete -f ../../../../deploy/upgrades/pre-caching/pre-caching.yaml
     namespaced: true
 
   - command: ../../../../deploy/upgrades/pre-caching/cleanup.sh 


### PR DESCRIPTION
Differentiate between managed policies with the same name in different namespaces:
- determine all the namespaces where we can find managed policies
- if there is at least one managed policy name that can be found in more than one namespace fail the CGU validation and include a condition message that contains the conflicting policy names and namespaces

Cleanup KUTTL child policies (#560)

Description:
- child policies that are not properly cleaned up cause false failure for other KUTTL tests