### PR TITLE
OCPBUGS-7389: pre-cache container mounts host's root

### DIFF
--- a/controllers/managedClusterResources_test.go
+++ b/controllers/managedClusterResources_test.go
@@ -219,10 +219,69 @@ spec:
                     terminationMessagePath: /dev/termination-log
                     terminationMessagePolicy: File
                     volumeMounts:
-                    - mountPath: /host
-                      name: host 
                     - mountPath: /etc/config
                       name: config-volume
+                      readOnly: true
+                    - mountPath: /host
+                      name: host
+                    - mountPath: /host/tmp
+                      name: host-tmp
+                    - mountPath: /host/usr/bin
+                      name: host-usr
+                      subPath: bin
+                      readOnly: true
+                    - mountPath: /host/usr/lib
+                      name: host-usr
+                      subPath: lib
+                      readOnly: true
+                    - mountPath: /host/usr/lib64/python3.6
+                      name: host-usr
+                      subPath: lib64/python3.6
+                      readOnly: true
+                    - mountPath: /host/usr/share/containers
+                      name: host-usr
+                      subPath: share/containers
+                      readOnly: true
+                    - mountPath: /host/usr/libexec
+                      name: host-usr
+                      subPath: libexec
+                      readOnly: true
+                    - mountPath: /host/var/lib/containers
+                      name: host-var
+                      subPath: lib/containers
+                    - mountPath: /host/var/lib/cni
+                      name: host-var
+                      subPath: lib/cni
+                      readOnly: true
+                    - mountPath: /host/var/lib/kubelet
+                      name: host-var
+                      subPath: lib/kubelet
+                      readOnly: true
+                    - mountPath: /host/var/tmp
+                      name: host-var
+                      subPath: tmp
+                    - mountPath: /host/lib64
+                      name: host-lib64
+                      readOnly: true
+                    - mountPath: /host/run
+                      name: host-run
+                    - mountPath: /host/proc
+                      name: host-proc
+                      readOnly: true
+                    - mountPath: /host/sys/fs/cgroup
+                      name: sys-fs-cgroup
+                      readOnly: true
+                    - mountPath: /host/etc/containers
+                      name: host-etc
+                      subPath: containers
+                      readOnly: true
+                    - mountPath: /host/etc/pki/ca-trust
+                      name: host-etc
+                      subPath: pki/ca-trust
+                      readOnly: true
+                    - mountPath: /host/etc/resolv.conf
+                      name: host-etc
+                      subPath: resolv.conf
                       readOnly: true
                   dnsPolicy: ClusterFirst
                   restartPolicy: Never
@@ -231,14 +290,44 @@ spec:
                   serviceAccountName: pre-cache-agent
                   priorityClassName: system-cluster-critical
                   volumes:
+                  - name: host
+                    emptyDir: {}
                   - configMap:
                       defaultMode: 420
                       name: pre-cache-spec
                     name: config-volume
                   - hostPath:
-                      path: /
+                      path: /usr
                       type: Directory
-                    name: host
+                    name: host-usr
+                  - hostPath:
+                      path: /var
+                      type: Directory
+                    name: host-var
+                  - hostPath:
+                      path: /tmp
+                      type: Directory
+                    name: host-tmp
+                  - hostPath:
+                      path: /lib64
+                      type: Directory
+                    name: host-lib64
+                  - hostPath:
+                      path: /proc
+                      type: Directory
+                    name: host-proc
+                  - hostPath:
+                      path: /run
+                      type: Directory
+                    name: host-run
+                  - hostPath:
+                      path: /sys/fs/cgroup
+                      type: Directory
+                    name: sys-fs-cgroup
+                  - hostPath:
+                      path: /etc
+                      type: Directory
+                    name: host-etc
 `,
 		},
 		{

--- a/controllers/templates/precache-templates.go
+++ b/controllers/templates/precache-templates.go
@@ -156,10 +156,69 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-              - mountPath: /host
-                name: host 
               - mountPath: /etc/config
                 name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr
+                subPath: bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr
+                subPath: lib
+                readOnly: true
+              - mountPath: /host/usr/lib64/python3.6
+                name: host-usr
+                subPath: lib64/python3.6
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr
+                subPath: libexec
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/kubelet
+                name: host-var
+                subPath: lib/kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
+              - mountPath: /host/etc/containers
+                name: host-etc
+                subPath: containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc
+                subPath: pki/ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc
+                subPath: resolv.conf
                 readOnly: true
             dnsPolicy: ClusterFirst
             restartPolicy: Never
@@ -168,15 +227,44 @@ spec:
             serviceAccountName: pre-cache-agent
             priorityClassName: system-cluster-critical
             volumes:
+            - name: host
+              emptyDir: {}
             - configMap:
                 defaultMode: 420
                 name: pre-cache-spec
               name: config-volume
             - hostPath:
-                path: /
+                path: /usr
                 type: Directory
-              name: host
-
+              name: host-usr
+            - hostPath:
+                path: /var
+                type: Directory
+              name: host-var
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
 `
 
 // MngClusterViewJob creates mcv to monitor precaching k8s job

--- a/pre-cache/check_space
+++ b/pre-cache/check_space
@@ -7,8 +7,8 @@ TOKEN=$(cat ${SERVICEACCOUNT}/token)
 CACERT=${SERVICEACCOUNT}/ca.crt
 high=$(curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/nodes/${NODE_NAME}/proxy/configz | \
             chroot /host jq '.kubeletconfig.imageGCHighThresholdPercent')
-size=$(df /var/lib/ | awk '{ print $2 }' | sed -n '2p')
-used=$(df /var/lib/ | awk '{ print $3 }' | sed -n '2p')
+size=$(df /host/var/lib/ | awk '{ print $2 }' | sed -n '2p')
+used=$(df /host/var/lib/ | awk '{ print $3 }' | sed -n '2p')
 echo "highThresholdPercent: $high diskSize:$size used:$used"
 rc=$(awk "BEGIN {avail=${size}/100.0*${high}-${used} ; print avail<${SPACE_REQUIRED}*1024*1024}")
 [ $rc -ne 0 ] && echo "ERROR: not enough space for precaching"

--- a/pre-cache/olm
+++ b/pre-cache/olm
@@ -16,12 +16,6 @@ render_index(){
     packages=$2
     image_mount=$3
     
-    capath="/host/etc/docker/certs.d/${index%/*}/ca.crt"
-    # opm doesn't accept cacert as an arg
-    if [[ -f "$capath" ]]; then
-        cp $capath /etc/pki/ca-trust/source/anchors/ 
-        update-ca-trust
-    fi
     if [[ -h "$image_mount/bin/opm" ]]; then
         opm_bin=$image_mount$(readlink "$image_mount/bin/opm")
     else
@@ -66,17 +60,20 @@ olm_main(){
           return 1
         fi
         log_debug "$index image ID is $image_id"
+
         image_mount=$(mount_index $image_id)
         if [[ $? -ne 0 ]]; then
           log_debug "mount_index failed for index $index"
           return 1
         fi
         log_debug "Image mount: $image_mount"
+
         packages=$(extract_packages)
         if ! [[ -n $packages ]]; then
           log_debug "operators index is set, but no packages provided - inconsistent configuration"
           return 1
         fi
+
         render_index $index $packages $image_mount
         if [[ $? -ne 0 ]]; then
           log_debug "render_index failed: OLM index render failed for index $index, package(s) $packages"

--- a/pre-cache/precache.sh
+++ b/pre-cache/precache.sh
@@ -1,12 +1,22 @@
-#!/bin/bash
+#!/usr/bin/bash
 
 set -e
 
+# Setup the environment for running podman.
+mkdir /host/dev
+mknod -m 0666 /host/dev/null c 1 3
+mkdir /host/dev/shm
+/host/usr/bin/mount -t tmpfs -o rw,nosuid,nodev,noexec,relatime tmpfs /host/dev/shm
+
+ln -s usr/bin /host/bin
+
+# Setup the environment for precaching.
 rm -rf /host/tmp/precache
 rm -f /host/tmp/images.txt
 cp -a /opt/precache /host/tmp/
 cp -rf /etc/config /host/tmp/precache/config
-# only check space for OCP upgrade
+
+# Check the available space for the OCP upgrade case.
 if [ -n "$(cat /etc/config/platform.image)" ]; then
     /opt/precache/check_space
 fi

--- a/tests/kuttl/tests/pre-caching-complete-with-configs/04-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete-with-configs/04-assert.yaml
@@ -151,10 +151,69 @@ spec:
                 terminationMessagePath: /dev/termination-log
                 terminationMessagePolicy: File
                 volumeMounts:
-                  - mountPath: /host
-                    name: host
                   - mountPath: /etc/config
                     name: config-volume
+                    readOnly: true
+                  - mountPath: /host
+                    name: host
+                  - mountPath: /host/tmp
+                    name: host-tmp
+                  - mountPath: /host/usr/bin
+                    name: host-usr
+                    subPath: bin
+                    readOnly: true
+                  - mountPath: /host/usr/lib
+                    name: host-usr
+                    subPath: lib
+                    readOnly: true
+                  - mountPath: /host/usr/lib64/python3.6
+                    name: host-usr
+                    subPath: lib64/python3.6
+                    readOnly: true
+                  - mountPath: /host/usr/share/containers
+                    name: host-usr
+                    subPath: share/containers
+                    readOnly: true
+                  - mountPath: /host/usr/libexec
+                    name: host-usr
+                    subPath: libexec
+                    readOnly: true
+                  - mountPath: /host/var/lib/containers
+                    name: host-var
+                    subPath: lib/containers
+                  - mountPath: /host/var/lib/cni
+                    name: host-var
+                    subPath: lib/cni
+                    readOnly: true
+                  - mountPath: /host/var/lib/kubelet
+                    name: host-var
+                    subPath: lib/kubelet
+                    readOnly: true
+                  - mountPath: /host/var/tmp
+                    name: host-var
+                    subPath: tmp
+                  - mountPath: /host/lib64
+                    name: host-lib64
+                    readOnly: true
+                  - mountPath: /host/run
+                    name: host-run
+                  - mountPath: /host/proc
+                    name: host-proc
+                    readOnly: true
+                  - mountPath: /host/sys/fs/cgroup
+                    name: sys-fs-cgroup
+                    readOnly: true
+                  - mountPath: /host/etc/containers
+                    name: host-etc
+                    subPath: containers
+                    readOnly: true
+                  - mountPath: /host/etc/pki/ca-trust
+                    name: host-etc
+                    subPath: pki/ca-trust
+                    readOnly: true
+                  - mountPath: /host/etc/resolv.conf
+                    name: host-etc
+                    subPath: resolv.conf
                     readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
@@ -163,14 +222,44 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
+              - name: host
+                emptyDir: {}
               - configMap:
                   defaultMode: 420
                   name: pre-cache-spec
                 name: config-volume
               - hostPath:
-                  path: /
+                  path: /usr
                   type: Directory
-                name: host
+                name: host-usr
+              - hostPath:
+                  path: /var
+                  type: Directory
+                name: host-var
+              - hostPath:
+                  path: /tmp
+                  type: Directory
+                name: host-tmp
+              - hostPath:
+                  path: /lib64
+                  type: Directory
+                name: host-lib64
+              - hostPath:
+                  path: /proc
+                  type: Directory
+                name: host-proc
+              - hostPath:
+                  path: /run
+                  type: Directory
+                name: host-run
+              - hostPath:
+                  path: /sys/fs/cgroup
+                  type: Directory
+                name: sys-fs-cgroup
+              - hostPath:
+                  path: /etc
+                  type: Directory
+                name: host-etc
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -223,10 +312,69 @@ spec:
                 terminationMessagePath: /dev/termination-log
                 terminationMessagePolicy: File
                 volumeMounts:
-                  - mountPath: /host
-                    name: host
                   - mountPath: /etc/config
                     name: config-volume
+                    readOnly: true
+                  - mountPath: /host
+                    name: host
+                  - mountPath: /host/tmp
+                    name: host-tmp
+                  - mountPath: /host/usr/bin
+                    name: host-usr
+                    subPath: bin
+                    readOnly: true
+                  - mountPath: /host/usr/lib
+                    name: host-usr
+                    subPath: lib
+                    readOnly: true
+                  - mountPath: /host/usr/lib64/python3.6
+                    name: host-usr
+                    subPath: lib64/python3.6
+                    readOnly: true
+                  - mountPath: /host/usr/share/containers
+                    name: host-usr
+                    subPath: share/containers
+                    readOnly: true
+                  - mountPath: /host/usr/libexec
+                    name: host-usr
+                    subPath: libexec
+                    readOnly: true
+                  - mountPath: /host/var/lib/containers
+                    name: host-var
+                    subPath: lib/containers
+                  - mountPath: /host/var/lib/cni
+                    name: host-var
+                    subPath: lib/cni
+                    readOnly: true
+                  - mountPath: /host/var/lib/kubelet
+                    name: host-var
+                    subPath: lib/kubelet
+                    readOnly: true
+                  - mountPath: /host/var/tmp
+                    name: host-var
+                    subPath: tmp
+                  - mountPath: /host/lib64
+                    name: host-lib64
+                    readOnly: true
+                  - mountPath: /host/run
+                    name: host-run
+                  - mountPath: /host/proc
+                    name: host-proc
+                    readOnly: true
+                  - mountPath: /host/sys/fs/cgroup
+                    name: sys-fs-cgroup
+                    readOnly: true
+                  - mountPath: /host/etc/containers
+                    name: host-etc
+                    subPath: containers
+                    readOnly: true
+                  - mountPath: /host/etc/pki/ca-trust
+                    name: host-etc
+                    subPath: pki/ca-trust
+                    readOnly: true
+                  - mountPath: /host/etc/resolv.conf
+                    name: host-etc
+                    subPath: resolv.conf
                     readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
@@ -235,14 +383,44 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
+              - name: host
+                emptyDir: {}
               - configMap:
                   defaultMode: 420
                   name: pre-cache-spec
                 name: config-volume
               - hostPath:
-                  path: /
+                  path: /usr
                   type: Directory
-                name: host
+                name: host-usr
+              - hostPath:
+                  path: /var
+                  type: Directory
+                name: host-var
+              - hostPath:
+                  path: /tmp
+                  type: Directory
+                name: host-tmp
+              - hostPath:
+                  path: /lib64
+                  type: Directory
+                name: host-lib64
+              - hostPath:
+                  path: /proc
+                  type: Directory
+                name: host-proc
+              - hostPath:
+                  path: /run
+                  type: Directory
+                name: host-run
+              - hostPath:
+                  path: /sys/fs/cgroup
+                  type: Directory
+                name: sys-fs-cgroup
+              - hostPath:
+                  path: /etc
+                  type: Directory
+                name: host-etc
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -295,10 +473,69 @@ spec:
                 terminationMessagePath: /dev/termination-log
                 terminationMessagePolicy: File
                 volumeMounts:
-                  - mountPath: /host
-                    name: host
                   - mountPath: /etc/config
                     name: config-volume
+                    readOnly: true
+                  - mountPath: /host
+                    name: host
+                  - mountPath: /host/tmp
+                    name: host-tmp
+                  - mountPath: /host/usr/bin
+                    name: host-usr
+                    subPath: bin
+                    readOnly: true
+                  - mountPath: /host/usr/lib
+                    name: host-usr
+                    subPath: lib
+                    readOnly: true
+                  - mountPath: /host/usr/lib64/python3.6
+                    name: host-usr
+                    subPath: lib64/python3.6
+                    readOnly: true
+                  - mountPath: /host/usr/share/containers
+                    name: host-usr
+                    subPath: share/containers
+                    readOnly: true
+                  - mountPath: /host/usr/libexec
+                    name: host-usr
+                    subPath: libexec
+                    readOnly: true
+                  - mountPath: /host/var/lib/containers
+                    name: host-var
+                    subPath: lib/containers
+                  - mountPath: /host/var/lib/cni
+                    name: host-var
+                    subPath: lib/cni
+                    readOnly: true
+                  - mountPath: /host/var/lib/kubelet
+                    name: host-var
+                    subPath: lib/kubelet
+                    readOnly: true
+                  - mountPath: /host/var/tmp
+                    name: host-var
+                    subPath: tmp
+                  - mountPath: /host/lib64
+                    name: host-lib64
+                    readOnly: true
+                  - mountPath: /host/run
+                    name: host-run
+                  - mountPath: /host/proc
+                    name: host-proc
+                    readOnly: true
+                  - mountPath: /host/sys/fs/cgroup
+                    name: sys-fs-cgroup
+                    readOnly: true
+                  - mountPath: /host/etc/containers
+                    name: host-etc
+                    subPath: containers
+                    readOnly: true
+                  - mountPath: /host/etc/pki/ca-trust
+                    name: host-etc
+                    subPath: pki/ca-trust
+                    readOnly: true
+                  - mountPath: /host/etc/resolv.conf
+                    name: host-etc
+                    subPath: resolv.conf
                     readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
@@ -307,14 +544,44 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
+              - name: host
+                emptyDir: {}
               - configMap:
                   defaultMode: 420
                   name: pre-cache-spec
                 name: config-volume
               - hostPath:
-                  path: /
+                  path: /usr
                   type: Directory
-                name: host
+                name: host-usr
+              - hostPath:
+                  path: /var
+                  type: Directory
+                name: host-var
+              - hostPath:
+                  path: /tmp
+                  type: Directory
+                name: host-tmp
+              - hostPath:
+                  path: /lib64
+                  type: Directory
+                name: host-lib64
+              - hostPath:
+                  path: /proc
+                  type: Directory
+                name: host-proc
+              - hostPath:
+                  path: /run
+                  type: Directory
+                name: host-run
+              - hostPath:
+                  path: /sys/fs/cgroup
+                  type: Directory
+                name: sys-fs-cgroup
+              - hostPath:
+                  path: /etc
+                  type: Directory
+                name: host-etc
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -367,10 +634,69 @@ spec:
                 terminationMessagePath: /dev/termination-log
                 terminationMessagePolicy: File
                 volumeMounts:
-                  - mountPath: /host
-                    name: host
                   - mountPath: /etc/config
                     name: config-volume
+                    readOnly: true
+                  - mountPath: /host
+                    name: host
+                  - mountPath: /host/tmp
+                    name: host-tmp
+                  - mountPath: /host/usr/bin
+                    name: host-usr
+                    subPath: bin
+                    readOnly: true
+                  - mountPath: /host/usr/lib
+                    name: host-usr
+                    subPath: lib
+                    readOnly: true
+                  - mountPath: /host/usr/lib64/python3.6
+                    name: host-usr
+                    subPath: lib64/python3.6
+                    readOnly: true
+                  - mountPath: /host/usr/share/containers
+                    name: host-usr
+                    subPath: share/containers
+                    readOnly: true
+                  - mountPath: /host/usr/libexec
+                    name: host-usr
+                    subPath: libexec
+                    readOnly: true
+                  - mountPath: /host/var/lib/containers
+                    name: host-var
+                    subPath: lib/containers
+                  - mountPath: /host/var/lib/cni
+                    name: host-var
+                    subPath: lib/cni
+                    readOnly: true
+                  - mountPath: /host/var/lib/kubelet
+                    name: host-var
+                    subPath: lib/kubelet
+                    readOnly: true
+                  - mountPath: /host/var/tmp
+                    name: host-var
+                    subPath: tmp
+                  - mountPath: /host/lib64
+                    name: host-lib64
+                    readOnly: true
+                  - mountPath: /host/run
+                    name: host-run
+                  - mountPath: /host/proc
+                    name: host-proc
+                    readOnly: true
+                  - mountPath: /host/sys/fs/cgroup
+                    name: sys-fs-cgroup
+                    readOnly: true
+                  - mountPath: /host/etc/containers
+                    name: host-etc
+                    subPath: containers
+                    readOnly: true
+                  - mountPath: /host/etc/pki/ca-trust
+                    name: host-etc
+                    subPath: pki/ca-trust
+                    readOnly: true
+                  - mountPath: /host/etc/resolv.conf
+                    name: host-etc
+                    subPath: resolv.conf
                     readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
@@ -379,12 +705,42 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
+              - name: host
+                emptyDir: {}
               - configMap:
                   defaultMode: 420
                   name: pre-cache-spec
                 name: config-volume
               - hostPath:
-                  path: /
+                  path: /usr
                   type: Directory
-                name: host
+                name: host-usr
+              - hostPath:
+                  path: /var
+                  type: Directory
+                name: host-var
+              - hostPath:
+                  path: /tmp
+                  type: Directory
+                name: host-tmp
+              - hostPath:
+                  path: /lib64
+                  type: Directory
+                name: host-lib64
+              - hostPath:
+                  path: /proc
+                  type: Directory
+                name: host-proc
+              - hostPath:
+                  path: /run
+                  type: Directory
+                name: host-run
+              - hostPath:
+                  path: /sys/fs/cgroup
+                  type: Directory
+                name: sys-fs-cgroup
+              - hostPath:
+                  path: /etc
+                  type: Directory
+                name: host-etc
 

--- a/tests/kuttl/tests/pre-caching-complete/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/03-assert.yaml
@@ -142,10 +142,69 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-              - mountPath: /host
-                name: host
               - mountPath: /etc/config
                 name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr
+                subPath: bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr
+                subPath: lib
+                readOnly: true
+              - mountPath: /host/usr/lib64/python3.6
+                name: host-usr
+                subPath: lib64/python3.6
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr
+                subPath: libexec
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/kubelet
+                name: host-var
+                subPath: lib/kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
+              - mountPath: /host/etc/containers
+                name: host-etc
+                subPath: containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc
+                subPath: pki/ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc
+                subPath: resolv.conf
                 readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
@@ -154,14 +213,44 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
+            - name: host
+              emptyDir: {}
             - configMap:
                 defaultMode: 420
                 name: pre-cache-spec
               name: config-volume
             - hostPath:
-                path: /
+                path: /usr
                 type: Directory
-              name: host
+              name: host-usr
+            - hostPath:
+                path: /var
+                type: Directory
+              name: host-var
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
 ---              
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -214,10 +303,69 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-              - mountPath: /host
-                name: host
               - mountPath: /etc/config
                 name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr
+                subPath: bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr
+                subPath: lib
+                readOnly: true
+              - mountPath: /host/usr/lib64/python3.6
+                name: host-usr
+                subPath: lib64/python3.6
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr
+                subPath: libexec
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/kubelet
+                name: host-var
+                subPath: lib/kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
+              - mountPath: /host/etc/containers
+                name: host-etc
+                subPath: containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc
+                subPath: pki/ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc
+                subPath: resolv.conf
                 readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
@@ -226,14 +374,44 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
+            - name: host
+              emptyDir: {}
             - configMap:
                 defaultMode: 420
                 name: pre-cache-spec
               name: config-volume
             - hostPath:
-                path: /
+                path: /usr
                 type: Directory
-              name: host
+              name: host-usr
+            - hostPath:
+                path: /var
+                type: Directory
+              name: host-var
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
 ---              
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -286,10 +464,69 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-              - mountPath: /host
-                name: host
               - mountPath: /etc/config
                 name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr
+                subPath: bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr
+                subPath: lib
+                readOnly: true
+              - mountPath: /host/usr/lib64/python3.6
+                name: host-usr
+                subPath: lib64/python3.6
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr
+                subPath: libexec
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/kubelet
+                name: host-var
+                subPath: lib/kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
+              - mountPath: /host/etc/containers
+                name: host-etc
+                subPath: containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc
+                subPath: pki/ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc
+                subPath: resolv.conf
                 readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
@@ -298,14 +535,44 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
+            - name: host
+              emptyDir: {}
             - configMap:
                 defaultMode: 420
                 name: pre-cache-spec
               name: config-volume
             - hostPath:
-                path: /
+                path: /usr
                 type: Directory
-              name: host
+              name: host-usr
+            - hostPath:
+                path: /var
+                type: Directory
+              name: host-var
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
 ---              
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -358,10 +625,69 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-              - mountPath: /host
-                name: host
               - mountPath: /etc/config
                 name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr
+                subPath: bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr
+                subPath: lib
+                readOnly: true
+              - mountPath: /host/usr/lib64/python3.6
+                name: host-usr
+                subPath: lib64/python3.6
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr
+                subPath: libexec
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/kubelet
+                name: host-var
+                subPath: lib/kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
+              - mountPath: /host/etc/containers
+                name: host-etc
+                subPath: containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc
+                subPath: pki/ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc
+                subPath: resolv.conf
                 readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
@@ -370,12 +696,42 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
+            - name: host
+              emptyDir: {}
             - configMap:
                 defaultMode: 420
                 name: pre-cache-spec
               name: config-volume
             - hostPath:
-                path: /
+                path: /usr
                 type: Directory
-              name: host
+              name: host-usr
+            - hostPath:
+                path: /var
+                type: Directory
+              name: host-var
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
 

--- a/tests/kuttl/tests/pre-caching-partial-complete/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/03-assert.yaml
@@ -140,10 +140,69 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-              - mountPath: /host
-                name: host
               - mountPath: /etc/config
                 name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr
+                subPath: bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr
+                subPath: lib
+                readOnly: true
+              - mountPath: /host/usr/lib64/python3.6
+                name: host-usr
+                subPath: lib64/python3.6
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr
+                subPath: libexec
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/kubelet
+                name: host-var
+                subPath: lib/kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
+              - mountPath: /host/etc/containers
+                name: host-etc
+                subPath: containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc
+                subPath: pki/ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc
+                subPath: resolv.conf
                 readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
@@ -152,14 +211,44 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
+            - name: host
+              emptyDir: {}
             - configMap:
                 defaultMode: 420
                 name: pre-cache-spec
               name: config-volume
             - hostPath:
-                path: /
+                path: /usr
                 type: Directory
-              name: host
+              name: host-usr
+            - hostPath:
+                path: /var
+                type: Directory
+              name: host-var
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
 ---              
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -212,10 +301,69 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-              - mountPath: /host
-                name: host
               - mountPath: /etc/config
                 name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr
+                subPath: bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr
+                subPath: lib
+                readOnly: true
+              - mountPath: /host/usr/lib64/python3.6
+                name: host-usr
+                subPath: lib64/python3.6
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr
+                subPath: libexec
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/kubelet
+                name: host-var
+                subPath: lib/kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
+              - mountPath: /host/etc/containers
+                name: host-etc
+                subPath: containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc
+                subPath: pki/ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc
+                subPath: resolv.conf
                 readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
@@ -224,14 +372,44 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
+            - name: host
+              emptyDir: {}
             - configMap:
                 defaultMode: 420
                 name: pre-cache-spec
               name: config-volume
             - hostPath:
-                path: /
+                path: /usr
                 type: Directory
-              name: host
+              name: host-usr
+            - hostPath:
+                path: /var
+                type: Directory
+              name: host-var
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
 ---              
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -284,10 +462,69 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-              - mountPath: /host
-                name: host
               - mountPath: /etc/config
                 name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr
+                subPath: bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr
+                subPath: lib
+                readOnly: true
+              - mountPath: /host/usr/lib64/python3.6
+                name: host-usr
+                subPath: lib64/python3.6
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr
+                subPath: libexec
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/kubelet
+                name: host-var
+                subPath: lib/kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
+              - mountPath: /host/etc/containers
+                name: host-etc
+                subPath: containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc
+                subPath: pki/ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc
+                subPath: resolv.conf
                 readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
@@ -296,14 +533,44 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
+            - name: host
+              emptyDir: {}
             - configMap:
                 defaultMode: 420
                 name: pre-cache-spec
               name: config-volume
             - hostPath:
-                path: /
+                path: /usr
                 type: Directory
-              name: host
+              name: host-usr
+            - hostPath:
+                path: /var
+                type: Directory
+              name: host-var
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
 ---              
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -356,10 +623,69 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-              - mountPath: /host
-                name: host
               - mountPath: /etc/config
                 name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr
+                subPath: bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr
+                subPath: lib
+                readOnly: true
+              - mountPath: /host/usr/lib64/python3.6
+                name: host-usr
+                subPath: lib64/python3.6
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr
+                subPath: libexec
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/kubelet
+                name: host-var
+                subPath: lib/kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
+              - mountPath: /host/etc/containers
+                name: host-etc
+                subPath: containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc
+                subPath: pki/ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc
+                subPath: resolv.conf
                 readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
@@ -368,12 +694,42 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
+            - name: host
+              emptyDir: {}
             - configMap:
                 defaultMode: 420
                 name: pre-cache-spec
               name: config-volume
             - hostPath:
-                path: /
+                path: /usr
                 type: Directory
-              name: host
+              name: host-usr
+            - hostPath:
+                path: /var
+                type: Directory
+              name: host-var
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
 


### PR DESCRIPTION
Description:
- mount only the needed host paths for the pre-cache container with the needed privilege access
- change the check_space script to make the check for host instead of the pre-cache container
- update tests