### PR TITLE
CNF-8527: Update pre-cache scripts to pull additional images

### DIFF
--- a/controllers/managedClusterResources_test.go
+++ b/controllers/managedClusterResources_test.go
@@ -62,7 +62,7 @@ spec:
         operators.indexes: ""
         operators.packagesAndChannels: ""
         platform.image:
-        spaceRequired: 45
+        spaceRequired: "45"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec

--- a/controllers/templates/precache-templates.go
+++ b/controllers/templates/precache-templates.go
@@ -60,7 +60,7 @@ spec:
         additionalImages: |{{ range .AdditionalImages }}
           {{ . }} {{ end }}
         platform.image: {{ .PlatformImage }}
-        spaceRequired: {{ .SpaceRequired }}
+        spaceRequired: "{{ .SpaceRequired }}"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec

--- a/pre-cache/common
+++ b/pre-cache/common
@@ -5,11 +5,30 @@ pull_secret_path="${pull_secret_path:-/var/lib/kubelet/config.json}"
 pull_spec_file="${pull_spec_file:-/tmp/images.txt}"
 config_volume_path="${config_volume_path:-/tmp/precache/config}"
 rendered_index_path="${rendered_index_path:-/tmp/index.json}"
+additional_images_spec_file="${additional_images_spec_file:-${config_volume_path}/additionalImages}"
 
 max_pull_threads="${MAX_PULL_THREADS:-10}" # number of simultaneous pulls executed can be modified by setting MAX_PULL_THREADS environment variable
 
+# LOGLEVELS: [0]ERROR, [1]INFO, [2]DEBUG
+LOGLEVEL=${PRE_CACHE_LOG_LEVEL:-2} # set default log level to DEBUG
+
+_log() {
+    local level=$1; shift
+    if [[ $level -le $LOGLEVEL ]]; then
+        echo "upgrades.pre-cache $(date -Iseconds) $*" >&2
+    fi
+}
+
+log_error() {
+    _log 0 "[ERROR]: $*"
+}
+
+log_info() {
+    _log 1 "[INFO]: $*"
+}
+
 log_debug() {
-  echo "upgrades.pre-cache $(date -Iseconds) DEBUG $@"
+    _log 2 "[DEBUG]: $*"
 }
 
 pull_index(){

--- a/pre-cache/pull
+++ b/pre-cache/pull
@@ -3,19 +3,34 @@
 cwd="${cwd:-/tmp/precache}"
 . $cwd/common
 
-mirror_images() {
+wait_image(){
+    local img=$1
+    local pid=$2
 
-    if ! [[ -f $pull_spec_file ]]; then
-        log_debug "no pull spec provided - misconfiguration error"
+    log_debug "Waiting to finish pulling image: ${img}"
+    wait $pid # The way wait monitor for each background task (PID). If any error then copy the image in the failed array so it can be retried later
+    if [[ $? != 0 ]]; then
+        log_error "Pull failed for image: ${img}! Will retry later... "
+        failed_pulls+=(${img}) # Failed, then add the image to be retrieved later
+    fi
+}
+
+mirror_images() {
+    local pull_file=$1
+    local pull_type=$2
+
+    if ! [[ -f $pull_file ]]; then
+        log_error "No pull spec provided for ${pull_type}"
         return 1
     fi
+
     # definition of vars once the config is provided
     local max_bg=$max_pull_threads
     declare -A pids # Hash that include the images pulled along with their pids to be monitored by wait command
-    local total_pulls=$(sort -u $pull_spec_file | wc -l)  # Required to keep track of the pull task vs total
+    local total_pulls=$(sort -u $pull_file | wc -l)  # Required to keep track of the pull task vs total
     local current_pull=1
 
-    for line in $(sort -u $pull_spec_file) ; do
+    for line in $(sort -u $pull_file) ; do
         # Strip double quotes
         img="${line%\"}"
         img="${img#\"}"
@@ -27,7 +42,7 @@ mirror_images() {
             current_pull=$((current_pull + 1))
             continue
         fi
-        $container_tool pull $img --authfile=/var/lib/kubelet/config.json -q > /dev/null &
+        $container_tool pull $img --authfile=$pull_secret_path -q > /dev/null &
         #$container_tool copy docker://${img} --authfile=/var/lib/kubelet/config.json containers-storage:${img} -q & # SKOPEO 
         pids[${img}]=$! # Keeping track of the PID and container image in case the pull fails
         max_bg=$((max_bg - 1)) # Batch size adapted 
@@ -35,51 +50,80 @@ mirror_images() {
         if [[ $max_bg == 0 ]] # If the batch is done, then monitor the status of all pulls before moving to the next batch
         then
           for pid in ${!pids[@]}; do
-            wait ${pids[$pid]} # The way wait monitor for each background task (PID). If any error then copy the image in the failed array so it can be retried later
-            if [[ $? != 0 ]]; then
-              log_debug "Pull failed for container image: ${pid} . Retrying later... "
-              failed_pulls+=(${pid}) # Failed, then add the image to be retrieved later
-            fi
+            wait_image $pid ${pids[$pid]}
           done
           # Once the batch is processed, reset the new batch size and clear the processes hash for the next one
           max_bg=$max_pull_threads
           pids=()
         fi
     done
+
+    # Make sure that all pull-threads have been processed
+    for pid in ${!pids[@]}; do
+        wait_image $pid ${pids[$pid]}
+    done
 }
 
 retry_images() {
+    local pull_type=$1
     local success
     local iterations
     local rv=0
+
     for failed_pull in ${failed_pulls[@]}; do
       success=0
       iterations=10
       until [[ $success -eq 1 ]] || [[ $iterations -eq 0 ]]
       do
-        log_debug "Retrying failed image pull: ${failed_pull}"
-        $container_tool pull $failed_pull --authfile=/var/lib/kubelet/config.json
+        log_info "Retrying failed image pull: ${failed_pull}"
+        $container_tool pull $failed_pull --authfile=$pull_secret_path
         if [[ $? == 0 ]]; then
           success=1
         fi
           iterations=$((iterations - 1))
       done
       if [[ $success == 0 ]]; then
-       log_debug "Limit number of retries reached. The image could not be pulled: ${failed_pull}"
+       log_error "Limit number of retries reached. The image  ${failed_pull} could not be pulled."
        rv=1
       fi
     done
-    log_debug "Image pre-cache done"
     return $rv
 }
 
+pre_cache_images(){
+    local pull_file=$1
+    local pull_type=$2
+
+    log_info "Image pre-caching starting for ${pull_type}"
+
+    failed_pulls=() # Clear the failed_pull array
+    mirror_images $pull_file $pull_type
+    [[ $? -eq 0 ]] || return 1
+
+    retry_images $pull_type # Return 1 if max.retries reached
+    if [[ $? -ne 0 ]]; then
+        log_error "One or more images were not pre-cached successfully for ${pull_type}"
+        return 1
+    fi
+
+    log_info "Image pre-caching complete for ${pull_type}"
+    return 0
+}
+
 if [[ "${BASH_SOURCE[0]}" = "${0}" ]]; then
-  failed_pulls=() # Array that will include all the images that failed to be pulled
-  mirror_images
-  retry_images # Return 1 if max.retries reached
-  if [[ $? -ne 0 ]]; then
-    log_debug "[FAIL] One or more images were not precached successfully"
-    exit 1
-  fi
-  exit 0
+    declare -A pull_types
+    pull_types["platform-images"]=${pull_spec_file}
+    pull_types["additional-images"]=${additional_images_spec_file}
+
+    failed_pulls=() # Array that will include all the images that failed to be pulled
+
+    for pull_type in ${!pull_types[@]}; do
+        pull_file=${pull_types[$pull_type]}
+        # Check if the spec_file exists before executing pull statements
+        if [ -n "$(cat $pull_file)" ]; then
+                pre_cache_images $pull_file $pull_type
+                [[ $? -eq 0 ]] || exit 1
+        fi
+    done
+    exit 0
 fi

--- a/tests/kuttl/tests/pre-caching-complete-with-configs/02-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete-with-configs/02-assert.yaml
@@ -175,7 +175,7 @@ spec:
         platform.image: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
         excludePrecachePatterns: "aws  \nazure \n"
         additionalImages: "image1:latest \nimage2:latest \n"
-        spaceRequired: 40
+        spaceRequired: "40"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -256,7 +256,7 @@ spec:
         platform.image: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
         excludePrecachePatterns: "aws  \nazure \n"
         additionalImages: "image1:latest \nimage2:latest \n"
-        spaceRequired: 40
+        spaceRequired: "40"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -337,7 +337,7 @@ spec:
         platform.image: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
         excludePrecachePatterns: "aws  \nazure \n"
         additionalImages: "image1:latest \nimage2:latest \n"
-        spaceRequired: 40
+        spaceRequired: "40"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -418,7 +418,7 @@ spec:
         platform.image: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
         excludePrecachePatterns: "aws  \nazure \n"
         additionalImages: "image1:latest \nimage2:latest \n"
-        spaceRequired: 40
+        spaceRequired: "40"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec

--- a/tests/kuttl/tests/pre-caching-complete/01-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/01-assert.yaml
@@ -163,7 +163,7 @@ spec:
         operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11 \n"
         operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9  \nperformance-addon-operator:4.9 \n"
         platform.image: null
-        spaceRequired: 35
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -242,7 +242,7 @@ spec:
         operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11 \n"
         operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9  \nperformance-addon-operator:4.9 \n"
         platform.image: null
-        spaceRequired: 35
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -321,7 +321,7 @@ spec:
         operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11 \n"
         operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9  \nperformance-addon-operator:4.9 \n"
         platform.image: null
-        spaceRequired: 35
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -400,7 +400,7 @@ spec:
         operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11 \n"
         operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9  \nperformance-addon-operator:4.9 \n"
         platform.image: null
-        spaceRequired: 35
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec


### PR DESCRIPTION
This commit contains the following changes:
- refactor pre-cache/common script with more logging options.
- refactor pre-cache/pull script to pull platform images and additional user-specified images.
- updated the "spaceRequired" field in controllers/templates/precache-templates.go to reflect string output.
- updated the expected spaceRequired fields in the associated kuttl tests as string values.