### PR TITLE
CNF-8528: Add post pre-caching disk usage check

### DIFF
--- a/controllers/managedClusterResources.go
+++ b/controllers/managedClusterResources.go
@@ -634,12 +634,7 @@ func (r *ClusterGroupUpgradeReconciler) getPrecacheJobTemplateData(
 	if err != nil {
 		return rv, err
 	}
-	spaceRequired, err := r.getPrecacheSpaceRequiredSpec(ctx, clusterGroupUpgrade)
-	if err != nil {
-		return rv, err
-	}
 	rv.WorkloadImage = image
-	rv.SpaceRequired = spaceRequired
 	return rv, nil
 }
 

--- a/controllers/managedClusterResources_test.go
+++ b/controllers/managedClusterResources_test.go
@@ -204,8 +204,6 @@ spec:
                     env:
                     - name: config_volume_path
                       value: /tmp/precache/config
-                    - name: SPACE_REQUIRED
-                      value: "15"
                     - name: NODE_NAME
                       valueFrom:
                         fieldRef:

--- a/controllers/templates/precache-templates.go
+++ b/controllers/templates/precache-templates.go
@@ -141,8 +141,6 @@ spec:
               env:
               - name: config_volume_path
                 value: /tmp/precache/config
-              - name: SPACE_REQUIRED
-                value: "{{ .SpaceRequired }}"
               - name: NODE_NAME
                 valueFrom:
                   fieldRef:

--- a/pre-cache/check_space
+++ b/pre-cache/check_space
@@ -1,15 +1,34 @@
-#!/bin/bash
-set -e
+./#!/bin/bash
 
-APISERVER=https://kubernetes.default.svc
-SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
-TOKEN=$(cat ${SERVICEACCOUNT}/token)
-CACERT=${SERVICEACCOUNT}/ca.crt
-high=$(curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/nodes/${NODE_NAME}/proxy/configz | \
-            chroot /host jq '.kubeletconfig.imageGCHighThresholdPercent')
-size=$(df /host/var/lib/ | awk '{ print $2 }' | sed -n '2p')
-used=$(df /host/var/lib/ | awk '{ print $3 }' | sed -n '2p')
-echo "highThresholdPercent: $high diskSize:$size used:$used"
-rc=$(awk "BEGIN {avail=${size}/100.0*${high}-${used} ; print avail<${SPACE_REQUIRED}*1024*1024}")
-[ $rc -ne 0 ] && echo "ERROR: not enough space for precaching"
-exit $rc
+cwd=$(dirname "$0")
+. $cwd/common
+
+validate_disk_space() {
+    local space_required=${1:-0}
+    local rv=1
+
+    APISERVER=https://kubernetes.default.svc
+    SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
+    TOKEN=$(cat ${SERVICEACCOUNT}/token)
+    CACERT=${SERVICEACCOUNT}/ca.crt
+    high=$(curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/nodes/${NODE_NAME}/proxy/configz | \
+                chroot /host jq '.kubeletconfig.imageGCHighThresholdPercent')
+    size=$(df /host/var/lib/ | awk '{ print $2 }' | sed -n '2p')
+    used=$(df /host/var/lib/ | awk '{ print $3 }' | sed -n '2p')
+
+    log_debug "highThresholdPercent: $high diskSize:$size used:$used"
+    log_debug "spaceRequired: ${space_required} GiB"
+
+    if [[ $space_required -gt 0 ]]; then
+        rv=$(awk "BEGIN {avail=${high}/100.0*${size}-${used} ; print (avail<${space_required}*1024*1024)}")
+    else
+        rv=$(awk "BEGIN {avail=${high}/100.0*${size}-${used} ; print (avail<=0)}")
+    fi
+    [ $rv -ne 0 ] && log_error "not enough space for precaching"
+    return $rv
+}
+
+if [[ "${BASH_SOURCE[0]}" = "${0}" ]]; then
+    validate_disk_space ${1:-0}
+    exit $?
+fi

--- a/pre-cache/precache.sh
+++ b/pre-cache/precache.sh
@@ -16,10 +16,17 @@ rm -f /host/tmp/images.txt
 cp -a /opt/precache /host/tmp/
 cp -rf /etc/config /host/tmp/precache/config
 
-# Check the available space for the OCP upgrade case.
-if [ -n "$(cat /etc/config/platform.image)" ]; then
-    /opt/precache/check_space
+# Check the available space for the OCP upgrade case or for pre-caching additional images
+{ [ -n "$(cat /etc/config/platform.image)" ] || [ -n "$(cat /etc/config/additionalImages)" ]; } && check_disk_space=1 || check_disk_space=0
+if [[ $check_disk_space == 1 ]]; then
+    /opt/precache/check_space $(cat /etc/config/spaceRequired)
 fi
+
 chroot /host /tmp/precache/release
 chroot /host /tmp/precache/olm
 chroot /host /tmp/precache/pull
+
+# Check disk space usage post pre-caching to alert if kubelet Garbage Collection will be triggered
+if [[ $check_disk_space == 1 ]]; then
+    /opt/precache/check_space
+fi

--- a/tests/kuttl/tests/pre-caching-complete-with-configs/04-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete-with-configs/04-assert.yaml
@@ -136,8 +136,6 @@ spec:
                 env:
                   - name: config_volume_path
                     value: /tmp/precache/config
-                  - name: SPACE_REQUIRED
-                    value: "40"
                   - name: NODE_NAME
                     valueFrom:
                       fieldRef:
@@ -297,8 +295,6 @@ spec:
                 env:
                   - name: config_volume_path
                     value: /tmp/precache/config
-                  - name: SPACE_REQUIRED
-                    value: "40"
                   - name: NODE_NAME
                     valueFrom:
                       fieldRef:
@@ -458,8 +454,6 @@ spec:
                 env:
                   - name: config_volume_path
                     value: /tmp/precache/config
-                  - name: SPACE_REQUIRED
-                    value: "40"
                   - name: NODE_NAME
                     valueFrom:
                       fieldRef:
@@ -619,8 +613,6 @@ spec:
                 env:
                   - name: config_volume_path
                     value: /tmp/precache/config
-                  - name: SPACE_REQUIRED
-                    value: "40"
                   - name: NODE_NAME
                     valueFrom:
                       fieldRef:

--- a/tests/kuttl/tests/pre-caching-complete/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/03-assert.yaml
@@ -126,9 +126,6 @@ spec:
               env:
               - name: config_volume_path
                 value: /tmp/precache/config
-
-              - name: SPACE_REQUIRED
-                value: "35"
               - name: NODE_NAME
                 valueFrom:
                   fieldRef:
@@ -288,8 +285,6 @@ spec:
               env:
               - name: config_volume_path
                 value: /tmp/precache/config
-              - name: SPACE_REQUIRED
-                value: "35"
               - name: NODE_NAME
                 valueFrom:
                   fieldRef:
@@ -449,8 +444,6 @@ spec:
               env:
               - name: config_volume_path
                 value: /tmp/precache/config
-              - name: SPACE_REQUIRED
-                value: "35"
               - name: NODE_NAME
                 valueFrom:
                   fieldRef:
@@ -610,8 +603,6 @@ spec:
               env:
               - name: config_volume_path
                 value: /tmp/precache/config
-              - name: SPACE_REQUIRED
-                value: "35"
               - name: NODE_NAME
                 valueFrom:
                   fieldRef:

--- a/tests/kuttl/tests/pre-caching-partial-complete/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/03-assert.yaml
@@ -125,8 +125,6 @@ spec:
               env:
               - name: config_volume_path
                 value: /tmp/precache/config
-              - name: SPACE_REQUIRED
-                value: "35"
               - name: NODE_NAME
                 valueFrom:
                   fieldRef:
@@ -286,8 +284,6 @@ spec:
               env:
               - name: config_volume_path
                 value: /tmp/precache/config
-              - name: SPACE_REQUIRED
-                value: "35"
               - name: NODE_NAME
                 valueFrom:
                   fieldRef:
@@ -447,8 +443,6 @@ spec:
               env:
               - name: config_volume_path
                 value: /tmp/precache/config
-              - name: SPACE_REQUIRED
-                value: "35"
               - name: NODE_NAME
                 valueFrom:
                   fieldRef:
@@ -608,8 +602,6 @@ spec:
               env:
               - name: config_volume_path
                 value: /tmp/precache/config
-              - name: SPACE_REQUIRED
-                value: "35"
               - name: NODE_NAME
                 valueFrom:
                   fieldRef:


### PR DESCRIPTION
This PR consists of checking for disk space usage after pre-caching is completed successfully to address the potential kubelet garbage collection problem that can result in the deletion of the pre-cached images (thus nullifying the entire pre-caching job).

The commit contains the following changes:
- refactor pre-cache/check_space script to check disk space for both pre and post pre-caching.
- update the pre-cache/precache.sh script to include post pre-caching disk usage.
- refactor controllers/precache.go and controllers/templates/precache-templates.go source files to remove the spaceRequired environment variable references and assignments. The spaceRequired parameter has been added to the pre-cache-spec ConfigMap previously.
- update unit and kuttl tests accordingly to remove spaceRequired environment variable references.