### PR TITLE
OCPBUGS-15369: Fix pre-caching issues caused by selective hostPaths

### DIFF
--- a/controllers/managedClusterResources_test.go
+++ b/controllers/managedClusterResources_test.go
@@ -232,9 +232,9 @@ spec:
                       name: host-usr
                       subPath: lib
                       readOnly: true
-                    - mountPath: /host/usr/lib64/python3.6
+                    - mountPath: /host/usr/lib64
                       name: host-usr
-                      subPath: lib64/python3.6
+                      subPath: lib64
                       readOnly: true
                     - mountPath: /host/usr/share/containers
                       name: host-usr

--- a/controllers/templates/precache-templates.go
+++ b/controllers/templates/precache-templates.go
@@ -169,9 +169,9 @@ spec:
                 name: host-usr
                 subPath: lib
                 readOnly: true
-              - mountPath: /host/usr/lib64/python3.6
+              - mountPath: /host/usr/lib64
                 name: host-usr
-                subPath: lib64/python3.6
+                subPath: lib64
                 readOnly: true
               - mountPath: /host/usr/share/containers
                 name: host-usr

--- a/pre-cache/precache.sh
+++ b/pre-cache/precache.sh
@@ -6,7 +6,7 @@ set -e
 mkdir /host/dev
 mknod -m 0666 /host/dev/null c 1 3
 mkdir /host/dev/shm
-/host/usr/bin/mount -t tmpfs -o rw,nosuid,nodev,noexec,relatime tmpfs /host/dev/shm
+chroot /host /usr/bin/mount -t tmpfs -o rw,nosuid,nodev,noexec,relatime tmpfs /dev/shm
 
 ln -s usr/bin /host/bin
 

--- a/tests/kuttl/tests/pre-caching-complete-with-configs/04-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete-with-configs/04-assert.yaml
@@ -164,9 +164,9 @@ spec:
                     name: host-usr
                     subPath: lib
                     readOnly: true
-                  - mountPath: /host/usr/lib64/python3.6
+                  - mountPath: /host/usr/lib64
                     name: host-usr
-                    subPath: lib64/python3.6
+                    subPath: lib64
                     readOnly: true
                   - mountPath: /host/usr/share/containers
                     name: host-usr
@@ -323,9 +323,9 @@ spec:
                     name: host-usr
                     subPath: lib
                     readOnly: true
-                  - mountPath: /host/usr/lib64/python3.6
+                  - mountPath: /host/usr/lib64
                     name: host-usr
-                    subPath: lib64/python3.6
+                    subPath: lib64
                     readOnly: true
                   - mountPath: /host/usr/share/containers
                     name: host-usr
@@ -482,9 +482,9 @@ spec:
                     name: host-usr
                     subPath: lib
                     readOnly: true
-                  - mountPath: /host/usr/lib64/python3.6
+                  - mountPath: /host/usr/lib64
                     name: host-usr
-                    subPath: lib64/python3.6
+                    subPath: lib64
                     readOnly: true
                   - mountPath: /host/usr/share/containers
                     name: host-usr
@@ -641,9 +641,9 @@ spec:
                     name: host-usr
                     subPath: lib
                     readOnly: true
-                  - mountPath: /host/usr/lib64/python3.6
+                  - mountPath: /host/usr/lib64
                     name: host-usr
-                    subPath: lib64/python3.6
+                    subPath: lib64
                     readOnly: true
                   - mountPath: /host/usr/share/containers
                     name: host-usr

--- a/tests/kuttl/tests/pre-caching-complete/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/03-assert.yaml
@@ -154,9 +154,9 @@ spec:
                 name: host-usr
                 subPath: lib
                 readOnly: true
-              - mountPath: /host/usr/lib64/python3.6
+              - mountPath: /host/usr/lib64
                 name: host-usr
-                subPath: lib64/python3.6
+                subPath: lib64
                 readOnly: true
               - mountPath: /host/usr/share/containers
                 name: host-usr
@@ -313,9 +313,9 @@ spec:
                 name: host-usr
                 subPath: lib
                 readOnly: true
-              - mountPath: /host/usr/lib64/python3.6
+              - mountPath: /host/usr/lib64
                 name: host-usr
-                subPath: lib64/python3.6
+                subPath: lib64
                 readOnly: true
               - mountPath: /host/usr/share/containers
                 name: host-usr
@@ -472,9 +472,9 @@ spec:
                 name: host-usr
                 subPath: lib
                 readOnly: true
-              - mountPath: /host/usr/lib64/python3.6
+              - mountPath: /host/usr/lib64
                 name: host-usr
-                subPath: lib64/python3.6
+                subPath: lib64
                 readOnly: true
               - mountPath: /host/usr/share/containers
                 name: host-usr
@@ -631,9 +631,9 @@ spec:
                 name: host-usr
                 subPath: lib
                 readOnly: true
-              - mountPath: /host/usr/lib64/python3.6
+              - mountPath: /host/usr/lib64
                 name: host-usr
-                subPath: lib64/python3.6
+                subPath: lib64
                 readOnly: true
               - mountPath: /host/usr/share/containers
                 name: host-usr

--- a/tests/kuttl/tests/pre-caching-partial-complete/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/03-assert.yaml
@@ -153,9 +153,9 @@ spec:
                 name: host-usr
                 subPath: lib
                 readOnly: true
-              - mountPath: /host/usr/lib64/python3.6
+              - mountPath: /host/usr/lib64
                 name: host-usr
-                subPath: lib64/python3.6
+                subPath: lib64
                 readOnly: true
               - mountPath: /host/usr/share/containers
                 name: host-usr
@@ -312,9 +312,9 @@ spec:
                 name: host-usr
                 subPath: lib
                 readOnly: true
-              - mountPath: /host/usr/lib64/python3.6
+              - mountPath: /host/usr/lib64
                 name: host-usr
-                subPath: lib64/python3.6
+                subPath: lib64
                 readOnly: true
               - mountPath: /host/usr/share/containers
                 name: host-usr
@@ -471,9 +471,9 @@ spec:
                 name: host-usr
                 subPath: lib
                 readOnly: true
-              - mountPath: /host/usr/lib64/python3.6
+              - mountPath: /host/usr/lib64
                 name: host-usr
-                subPath: lib64/python3.6
+                subPath: lib64
                 readOnly: true
               - mountPath: /host/usr/share/containers
                 name: host-usr
@@ -630,9 +630,9 @@ spec:
                 name: host-usr
                 subPath: lib
                 readOnly: true
-              - mountPath: /host/usr/lib64/python3.6
+              - mountPath: /host/usr/lib64
                 name: host-usr
-                subPath: lib64/python3.6
+                subPath: lib64
                 readOnly: true
               - mountPath: /host/usr/share/containers
                 name: host-usr


### PR DESCRIPTION
Description:
- mounting just parts of the host FS has proven too restrictive for the python version, so it's best to mount the full /usr/lib64
- run the mount command for shm within host's chroot jail to make sure all the dependencies are satisfied