### PR TITLE
CNF-8675: Update kuttl tests for quick reconciles for resource constrained environments

### DIFF
--- a/tests/kuttl/tests/pre-caching-complete-with-configs/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete-with-configs/03-assert.yaml
@@ -22,7 +22,7 @@ spec:
     namespace: default
   remediationStrategy:
     maxConcurrency: 4
-    timeout: 241
+    timeout: 240
 status:
   computedMaxConcurrency: 4
   conditions:

--- a/tests/kuttl/tests/pre-caching-complete-with-configs/03-pre-caching-starting-deps-ready.yaml
+++ b/tests/kuttl/tests/pre-caching-complete-with-configs/03-pre-caching-starting-deps-ready.yaml
@@ -8,4 +8,4 @@ commands:
   # Force a quick reconcile
   - command: >
       oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu
-        --patch '{"spec":{"remediationStrategy":{"timeout":241}}}' --type=merge
+        --patch '{"spec":{"actions":{"beforeEnable":{"addClusterLabels":{"dummy1":""}}}}}' --type=merge

--- a/tests/kuttl/tests/pre-caching-complete-with-configs/04-pre-caching-starting-job-view.yaml
+++ b/tests/kuttl/tests/pre-caching-complete-with-configs/04-pre-caching-starting-job-view.yaml
@@ -8,4 +8,4 @@ commands:
   # Force a quick reconcile
   - command: >
       oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu 
-        --patch '{"spec":{"remediationStrategy":{"timeout":240}}}' --type=merge
+        --patch '{"spec":{"actions":{"beforeEnable":{"addClusterLabels":{"dummy2":""}}}}}' --type=merge

--- a/tests/kuttl/tests/pre-caching-complete/02-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/02-assert.yaml
@@ -19,7 +19,7 @@ spec:
   preCaching: true
   remediationStrategy:
     maxConcurrency: 4
-    timeout: 241
+    timeout: 240
 status:
   computedMaxConcurrency: 4
   conditions:

--- a/tests/kuttl/tests/pre-caching-complete/02-pre-caching-starting-deps-ready.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/02-pre-caching-starting-deps-ready.yaml
@@ -8,4 +8,4 @@ commands:
   # Force a quick reconcile
   - command: >
       oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu
-        --patch '{"spec":{"remediationStrategy":{"timeout":241}}}' --type=merge
+        --patch '{"spec":{"actions":{"beforeEnable":{"addClusterLabels":{"dummy1":""}}}}}' --type=merge

--- a/tests/kuttl/tests/pre-caching-complete/03-pre-caching-starting-job-view.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/03-pre-caching-starting-job-view.yaml
@@ -8,4 +8,4 @@ commands:
   # Force a quick reconcile
   - command: >
       oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu 
-        --patch '{"spec":{"remediationStrategy":{"timeout":240}}}' --type=merge
+        --patch '{"spec":{"actions":{"beforeEnable":{"addClusterLabels":{"dummy2":""}}}}}' --type=merge

--- a/tests/kuttl/tests/pre-caching-partial-complete/02-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/02-assert.yaml
@@ -19,7 +19,7 @@ spec:
   preCaching: true
   remediationStrategy:
     maxConcurrency: 4
-    timeout: 241
+    timeout: 240
 status:
   computedMaxConcurrency: 4
   conditions:

--- a/tests/kuttl/tests/pre-caching-partial-complete/02-pre-caching-starting-deps-ready.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/02-pre-caching-starting-deps-ready.yaml
@@ -8,4 +8,4 @@ commands:
   # Force a quick reconcile
   - command: >
       oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu
-        --patch '{"spec":{"remediationStrategy":{"timeout":241}}}' --type=merge
+        --patch '{"spec":{"actions":{"beforeEnable":{"addClusterLabels":{"dummy1":""}}}}}' --type=merge

--- a/tests/kuttl/tests/pre-caching-partial-complete/03-pre-caching-starting-job-view.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/03-pre-caching-starting-job-view.yaml
@@ -8,4 +8,4 @@ commands:
   # Force a quick reconcile
   - command: >
       oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu 
-        --patch '{"spec":{"remediationStrategy":{"timeout":240}}}' --type=merge
+        --patch '{"spec":{"actions":{"beforeEnable":{"addClusterLabels":{"dummy2":""}}}}}' --type=merge


### PR DESCRIPTION
This PR provides a simple fix to the kuttl tests which force quick reconciliation in TALM in resource constrained environments. 

The original behaviour comprised of patching the test CGU `.spec.remediationStrategy.timeout` field. However, since this field is used to create the pre-caching job, there are situations wherein the patch command is delayed in execution due to a slow kube-apiserver.

An example of a failed kuttl test run is shown below:
```
    case.go:366: --- ManagedClusterAction:spoke5/precache-job-create
        +++ ManagedClusterAction:spoke5/precache-job-create
        @@ -1,6 +1,53 @@
         apiVersion: action.open-cluster-management.io/v1beta1
         kind: ManagedClusterAction
         metadata:
... <output omitted>
           name: precache-job-create
           namespace: spoke5
         spec:
        @@ -17,7 +64,7 @@
                 name: pre-cache
                 namespace: openshift-talo-pre-cache
               spec:
        -        activeDeadlineSeconds: 14400
        +        activeDeadlineSeconds: 14460
                 backoffLimit: 0
                 template:
                   metadata:

    case.go:366: resource ManagedClusterAction:spoke5/precache-job-create: .spec.kube.template.spec.activeDeadlineSeconds: value mismatch, expected: 14400 != actual: 14460
```

**Proposed fix:** Instead of patching the `timeout` field, the `.spec.actions` field is used.

The updated kuttl tests have been executed numerous times on such a resource limited platform and each test run was successful. 

/cc @jc-rh @sudomakeinstall2 