### PR TITLE
Add multiple worker threads

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -2130,19 +2130,6 @@ func (r *ClusterGroupUpgradeReconciler) SetupWithManager(mgr ctrl.Manager) error
 		Version: "v1",
 	})
 
-	maxConcurrency, set := os.LookupEnv(utils.CGUControllerWorkerCountEnv)
-	var maxConcurrentReconciles int
-	var err error
-	if set {
-		maxConcurrentReconciles, err = strconv.Atoi(maxConcurrency)
-		if err != nil {
-			r.Log.Info("Invalid value %s for %s, using the default: %i", maxConcurrency, utils.CGUControllerWorkerCountEnv, utils.DefaultCGUControllerWorkerCount)
-			maxConcurrentReconciles = utils.DefaultCGUControllerWorkerCount
-		}
-	} else {
-		maxConcurrentReconciles = utils.DefaultCGUControllerWorkerCount
-	}
-
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&ranv1alpha1.ClusterGroupUpgrade{}, builder.WithPredicates(predicate.Funcs{
 			UpdateFunc: func(e event.UpdateEvent) bool {
@@ -2170,6 +2157,6 @@ func (r *ClusterGroupUpgradeReconciler) SetupWithManager(mgr ctrl.Manager) error
 			GenericFunc: func(ge event.GenericEvent) bool { return false },
 			DeleteFunc:  func(de event.DeleteEvent) bool { return false },
 		})).
-		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.getCGUControllerWorkerCount()}).
 		Complete(r)
 }

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -2115,13 +2115,13 @@ func (r *ClusterGroupUpgradeReconciler) SetupWithManager(mgr ctrl.Manager) error
 		Version: "v1",
 	})
 
-	maxConcurrency, set := os.LookupEnv("TALM_CGU_CTRL_WORKER_COUNT")
+	maxConcurrency, set := os.LookupEnv(utils.CGUCtrllWorkerCountEnv)
 	var maxConcurrentReconciles int
 	var err error
 	if set {
 		maxConcurrentReconciles, err = strconv.Atoi(maxConcurrency)
 		if err != nil {
-			r.Log.Info("Invalid value %s for TALM_CGU_CTRL_WORKER_COUNT, using the default: %i", maxConcurrency, utils.DefaultCGUControllerWorkerCount)
+			r.Log.Info("Invalid value %s for %s, using the default: %i", maxConcurrency, utils.CGUCtrllWorkerCountEnv, utils.DefaultCGUControllerWorkerCount)
 			maxConcurrentReconciles = utils.DefaultCGUControllerWorkerCount
 		}
 	} else {

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -2115,13 +2115,13 @@ func (r *ClusterGroupUpgradeReconciler) SetupWithManager(mgr ctrl.Manager) error
 		Version: "v1",
 	})
 
-	maxConcurrency, set := os.LookupEnv(utils.CGUCtrllWorkerCountEnv)
+	maxConcurrency, set := os.LookupEnv(utils.CGUControllerWorkerCountEnv)
 	var maxConcurrentReconciles int
 	var err error
 	if set {
 		maxConcurrentReconciles, err = strconv.Atoi(maxConcurrency)
 		if err != nil {
-			r.Log.Info("Invalid value %s for %s, using the default: %i", maxConcurrency, utils.CGUCtrllWorkerCountEnv, utils.DefaultCGUControllerWorkerCount)
+			r.Log.Info("Invalid value %s for %s, using the default: %i", maxConcurrency, utils.CGUControllerWorkerCountEnv, utils.DefaultCGUControllerWorkerCount)
 			maxConcurrentReconciles = utils.DefaultCGUControllerWorkerCount
 		}
 	} else {

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -2090,6 +2090,21 @@ func (r *ClusterGroupUpgradeReconciler) handleCguFinalizer(
 	return utils.DontReconcile, nil
 }
 
+func (r *ClusterGroupUpgradeReconciler) getCGUControllerWorkerCount() (count int) {
+	maxConcurrency, isSet := os.LookupEnv(utils.CGUControllerWorkerCountEnv)
+	var err error
+	if isSet {
+		count, err = strconv.Atoi(maxConcurrency)
+		if err != nil || count < 1 {
+			r.Log.Info("Invalid value '%s' for %s, using the default: %i", maxConcurrency, utils.CGUControllerWorkerCountEnv, utils.DefaultCGUControllerWorkerCount)
+			count = utils.DefaultCGUControllerWorkerCount
+		}
+	} else {
+		count = utils.DefaultCGUControllerWorkerCount
+	}
+	return
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterGroupUpgradeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Recorder = mgr.GetEventRecorderFor("ClusterGroupUpgrade")

--- a/controllers/clustergroupupgrade_controller_test.go
+++ b/controllers/clustergroupupgrade_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"os"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -151,6 +152,48 @@ func TestClusterGroupUpgradeReconciler_getClusterComplianceWithPolicy(t *testing
 			}
 			if got := r.getClusterComplianceWithPolicy(tt.args.clusterName, tt.args.policy); got != tt.want {
 				t.Errorf("ClusterGroupUpgradeReconciler.getClusterComplianceWithPolicy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClusterGroupUpgradeReconciler_getCGUControllerWorkerCount(t *testing.T) {
+	tests := []struct {
+		name        string
+		envVarValue string
+		wantCount   int
+	}{
+		{
+			name:        "good value",
+			envVarValue: "10",
+			wantCount:   10,
+		},
+		{
+			name:        "negative value",
+			envVarValue: "-1",
+			wantCount:   5,
+		},
+		{
+			name:        "zero",
+			envVarValue: "0",
+			wantCount:   5,
+		},
+		{
+			name:        "non numeric",
+			envVarValue: "abc",
+			wantCount:   5,
+		},
+	}
+
+	r := &ClusterGroupUpgradeReconciler{
+		Log: logr.Discard(),
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv(utils.CGUControllerWorkerCountEnv, tt.envVarValue)
+			if gotCount := r.getCGUControllerWorkerCount(); gotCount != tt.wantCount {
+				t.Errorf("ClusterGroupUpgradeReconciler.getCGUControllerWorkerCount() = %v, want %v", gotCount, tt.wantCount)
 			}
 		})
 	}

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -2,6 +2,7 @@ package utils
 
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
+// DefaultCGUControllerWorkerCount default number of worker threads for the CGU controller
 const DefaultCGUControllerWorkerCount = 5
 
 // RemediationActionEnforce - Policy remediation for policies.

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -4,7 +4,7 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 
 // CGU controller constants
 const (
-	CGUControllerWorkerCountEnv          = "TALM_CGU_CTRL_WORKER_COUNT"
+	CGUControllerWorkerCountEnv     = "TALM_CGU_CTRL_WORKER_COUNT"
 	DefaultCGUControllerWorkerCount = 5
 )
 

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -2,6 +2,8 @@ package utils
 
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
+const DefaultCGUControllerWorkerCount = 5
+
 // RemediationActionEnforce - Policy remediation for policies.
 const (
 	RemediationActionEnforce = "enforce"

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -9,7 +9,6 @@ const (
 	DefaultCGUControllerWorkerCount = 5
 )
 
-
 // RemediationActionEnforce - Policy remediation for policies.
 const (
 	RemediationActionEnforce = "enforce"

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -2,10 +2,9 @@ package utils
 
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
-// DefaultCGUControllerWorkerCount default number of worker threads for the CGU controller
-// CGUController constants
+// CGU controller constants
 const (
-	CGUCtrllWorkerCountEnv          = "TALM_CGU_CTRL_WORKER_COUNT"
+	CGUControllerWorkerCountEnv          = "TALM_CGU_CTRL_WORKER_COUNT"
 	DefaultCGUControllerWorkerCount = 5
 )
 

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -3,7 +3,12 @@ package utils
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 // DefaultCGUControllerWorkerCount default number of worker threads for the CGU controller
-const DefaultCGUControllerWorkerCount = 5
+// CGUController constants
+const (
+	CGUCtrllWorkerCountEnv          = "TALM_CGU_CTRL_WORKER_COUNT"
+	DefaultCGUControllerWorkerCount = 5
+)
+
 
 // RemediationActionEnforce - Policy remediation for policies.
 const (


### PR DESCRIPTION
Needed for large scale ZTP deployment with higher number of policies and hub side templatization. Peak CPU use goes up to .5 core from .1 core on the hub. Also provides better responsiveness in general when multiple CGUs are being created. 