### PR TITLE
OCPBUGS-16032: Remove target directory in backup function of upgrade-recovery script

### DIFF
--- a/recovery/bindata/upgrade-recovery.sh
+++ b/recovery/bindata/upgrade-recovery.sh
@@ -245,17 +245,17 @@ function take_backup {
     cat /etc/tmpfiles.d/* | sed 's/#.*//' | awk '{print $2}' | grep '^/etc/' | sed 's#^/etc/##' > ${BACKUP_DIR}/etc.exclude.list
     echo '.updated' >> ${BACKUP_DIR}/etc.exclude.list
     echo 'kubernetes/manifests' >> ${BACKUP_DIR}/etc.exclude.list
-    with_retries 3 1 cp -Ra /etc/ ${BACKUP_DIR}/etc/
+    with_retries 3 1 cp -Ra /etc/ ${BACKUP_DIR}/
     if [ $? -ne 0 ]; then
         fatal "Failed to backup /etc"
     fi
 
-    with_retries 3 1 cp -Ra /usr/local/ ${BACKUP_DIR}/usrlocal/
+    with_retries 3 1 cp -Ra /usr/local/ ${BACKUP_DIR}/
     if [ $? -ne 0 ]; then
         fatal "Failed to backup /usr/local"
     fi
 
-    with_retries 3 1 cp -Ra /var/lib/kubelet/ ${BACKUP_DIR}/kubelet/
+    with_retries 3 1 cp -Ra /var/lib/kubelet/ ${BACKUP_DIR}/
     if [ $? -ne 0 ]; then
         fatal "Failed to backup /var/lib/kubelet"
     fi
@@ -323,7 +323,7 @@ function restore_files {
     # Restore /usr/local content
     #
     log_info "Restoring /usr/local content"
-    time with_retries 3 1 rsync -aAXvc --delete --no-t ${BACKUP_DIR}/usrlocal/ /usr/local/
+    time with_retries 3 1 rsync -aAXvc --delete --no-t ${BACKUP_DIR}/local/ /usr/local/
     if [ $? -ne 0 ]; then
         fatal "Failed to restore /usr/local content"
     fi
@@ -533,7 +533,7 @@ fi
 #
 if [ ! -d "${BACKUP_DIR}/cluster" ] || \
         [ ! -d "${BACKUP_DIR}/etc" ] || \
-        [ ! -d "${BACKUP_DIR}/usrlocal" ] || \
+        [ ! -d "${BACKUP_DIR}/local" ] || \
         [ ! -d "${BACKUP_DIR}/kubelet" ]; then
     echo "Required backup content not found in ${BACKUP_DIR}" >&2
     exit 1

--- a/recovery/generated/zz_generated.bindata.go
+++ b/recovery/generated/zz_generated.bindata.go
@@ -301,17 +301,17 @@ function take_backup {
     cat /etc/tmpfiles.d/* | sed 's/#.*//' | awk '{print $2}' | grep '^/etc/' | sed 's#^/etc/##' > ${BACKUP_DIR}/etc.exclude.list
     echo '.updated' >> ${BACKUP_DIR}/etc.exclude.list
     echo 'kubernetes/manifests' >> ${BACKUP_DIR}/etc.exclude.list
-    with_retries 3 1 cp -Ra /etc/ ${BACKUP_DIR}/etc/
+    with_retries 3 1 cp -Ra /etc/ ${BACKUP_DIR}/
     if [ $? -ne 0 ]; then
         fatal "Failed to backup /etc"
     fi
 
-    with_retries 3 1 cp -Ra /usr/local/ ${BACKUP_DIR}/usrlocal/
+    with_retries 3 1 cp -Ra /usr/local/ ${BACKUP_DIR}/
     if [ $? -ne 0 ]; then
         fatal "Failed to backup /usr/local"
     fi
 
-    with_retries 3 1 cp -Ra /var/lib/kubelet/ ${BACKUP_DIR}/kubelet/
+    with_retries 3 1 cp -Ra /var/lib/kubelet/ ${BACKUP_DIR}/
     if [ $? -ne 0 ]; then
         fatal "Failed to backup /var/lib/kubelet"
     fi
@@ -379,7 +379,7 @@ function restore_files {
     # Restore /usr/local content
     #
     log_info "Restoring /usr/local content"
-    time with_retries 3 1 rsync -aAXvc --delete --no-t ${BACKUP_DIR}/usrlocal/ /usr/local/
+    time with_retries 3 1 rsync -aAXvc --delete --no-t ${BACKUP_DIR}/local/ /usr/local/
     if [ $? -ne 0 ]; then
         fatal "Failed to restore /usr/local content"
     fi
@@ -589,7 +589,7 @@ fi
 #
 if [ ! -d "${BACKUP_DIR}/cluster" ] || \
         [ ! -d "${BACKUP_DIR}/etc" ] || \
-        [ ! -d "${BACKUP_DIR}/usrlocal" ] || \
+        [ ! -d "${BACKUP_DIR}/local" ] || \
         [ ! -d "${BACKUP_DIR}/kubelet" ]; then
     echo "Required backup content not found in ${BACKUP_DIR}" >&2
     exit 1


### PR DESCRIPTION
On a failed copy attempt, a retry will result in the source directory being copied under a partially copied target directory. This results in a nested directory structure in which the nested directory holds the most recent copied contents.

This PR removes the target directory specification from the copy command cp -Ra.

/cc @donpenney @jc-rh 