### PR TITLE
Revert "Use system:basic-user cluster role for precaching (#619)"

### DIFF
--- a/controllers/managedClusterResources_test.go
+++ b/controllers/managedClusterResources_test.go
@@ -150,7 +150,7 @@ spec:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: system:basic-user
+        name: cluster-admin
       subjects:
       - kind: ServiceAccount
         name: pre-cache-agent

--- a/controllers/templates/precache-templates.go
+++ b/controllers/templates/precache-templates.go
@@ -99,7 +99,7 @@ spec:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: system:basic-user
+        name: cluster-admin
       subjects:
         - kind: ServiceAccount
           name: pre-cache-agent

--- a/tests/kuttl/tests/pre-caching-complete-with-configs/02-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete-with-configs/02-assert.yaml
@@ -117,7 +117,7 @@ spec:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: system:basic-user
+        name: cluster-admin
       subjects:
         - kind: ServiceAccount
           name: pre-cache-agent
@@ -198,7 +198,7 @@ spec:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: system:basic-user
+        name: cluster-admin
       subjects:
         - kind: ServiceAccount
           name: pre-cache-agent
@@ -279,7 +279,7 @@ spec:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: system:basic-user
+        name: cluster-admin
       subjects:
         - kind: ServiceAccount
           name: pre-cache-agent
@@ -360,7 +360,7 @@ spec:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: system:basic-user
+        name: cluster-admin
       subjects:
         - kind: ServiceAccount
           name: pre-cache-agent

--- a/tests/kuttl/tests/pre-caching-complete/01-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/01-assert.yaml
@@ -107,7 +107,7 @@ spec:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: system:basic-user
+        name: cluster-admin
       subjects:
       - kind: ServiceAccount
         name: pre-cache-agent
@@ -186,7 +186,7 @@ spec:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: system:basic-user
+        name: cluster-admin
       subjects:
       - kind: ServiceAccount
         name: pre-cache-agent
@@ -265,7 +265,7 @@ spec:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: system:basic-user
+        name: cluster-admin
       subjects:
       - kind: ServiceAccount
         name: pre-cache-agent
@@ -344,7 +344,7 @@ spec:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: system:basic-user
+        name: cluster-admin
       subjects:
       - kind: ServiceAccount
         name: pre-cache-agent

--- a/tests/kuttl/tests/pre-caching-partial-complete/01-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/01-assert.yaml
@@ -106,7 +106,7 @@ spec:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: system:basic-user
+        name: cluster-admin
       subjects:
       - kind: ServiceAccount
         name: pre-cache-agent
@@ -184,7 +184,7 @@ spec:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: system:basic-user
+        name: cluster-admin
       subjects:
       - kind: ServiceAccount
         name: pre-cache-agent
@@ -262,7 +262,7 @@ spec:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: system:basic-user
+        name: cluster-admin
       subjects:
       - kind: ServiceAccount
         name: pre-cache-agent
@@ -340,7 +340,7 @@ spec:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: system:basic-user
+        name: cluster-admin
       subjects:
       - kind: ServiceAccount
         name: pre-cache-agent


### PR DESCRIPTION
This reverts commit c04f175771a7ebcfb8ff59d6b50b8533c15a5883.

It was not properly tested due to https://issues.redhat.com/browse/OCPBUGS-16757