### PR TITLE
OCPBUGS-17480: precaching - do not use subPath for /var/lib/kubelet

### DIFF
--- a/controllers/managedClusterResources_test.go
+++ b/controllers/managedClusterResources_test.go
@@ -252,8 +252,7 @@ spec:
                       subPath: lib/cni
                       readOnly: true
                     - mountPath: /host/var/lib/kubelet
-                      name: host-var
-                      subPath: lib/kubelet
+                      name: host-var-lib-kubelet
                       readOnly: true
                     - mountPath: /host/var/tmp
                       name: host-var
@@ -302,6 +301,10 @@ spec:
                       path: /var
                       type: Directory
                     name: host-var
+                  - hostPath:
+                      path: /var/lib/kubelet
+                      type: Directory
+                    name: host-var-lib-kubelet
                   - hostPath:
                       path: /tmp
                       type: Directory

--- a/controllers/templates/precache-templates.go
+++ b/controllers/templates/precache-templates.go
@@ -189,8 +189,7 @@ spec:
                 subPath: lib/cni
                 readOnly: true
               - mountPath: /host/var/lib/kubelet
-                name: host-var
-                subPath: lib/kubelet
+                name: host-var-lib-kubelet
                 readOnly: true
               - mountPath: /host/var/tmp
                 name: host-var
@@ -239,6 +238,10 @@ spec:
                 path: /var
                 type: Directory
               name: host-var
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
             - hostPath:
                 path: /tmp
                 type: Directory

--- a/tests/kuttl/tests/pre-caching-complete/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/03-assert.yaml
@@ -174,8 +174,7 @@ spec:
                 subPath: lib/cni
                 readOnly: true
               - mountPath: /host/var/lib/kubelet
-                name: host-var
-                subPath: lib/kubelet
+                name: host-var-lib-kubelet
                 readOnly: true
               - mountPath: /host/var/tmp
                 name: host-var
@@ -224,6 +223,10 @@ spec:
                 path: /var
                 type: Directory
               name: host-var
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
             - hostPath:
                 path: /tmp
                 type: Directory
@@ -333,8 +336,7 @@ spec:
                 subPath: lib/cni
                 readOnly: true
               - mountPath: /host/var/lib/kubelet
-                name: host-var
-                subPath: lib/kubelet
+                name: host-var-lib-kubelet
                 readOnly: true
               - mountPath: /host/var/tmp
                 name: host-var
@@ -383,6 +385,10 @@ spec:
                 path: /var
                 type: Directory
               name: host-var
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
             - hostPath:
                 path: /tmp
                 type: Directory
@@ -492,8 +498,7 @@ spec:
                 subPath: lib/cni
                 readOnly: true
               - mountPath: /host/var/lib/kubelet
-                name: host-var
-                subPath: lib/kubelet
+                name: host-var-lib-kubelet
                 readOnly: true
               - mountPath: /host/var/tmp
                 name: host-var
@@ -542,6 +547,10 @@ spec:
                 path: /var
                 type: Directory
               name: host-var
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
             - hostPath:
                 path: /tmp
                 type: Directory
@@ -651,8 +660,7 @@ spec:
                 subPath: lib/cni
                 readOnly: true
               - mountPath: /host/var/lib/kubelet
-                name: host-var
-                subPath: lib/kubelet
+                name: host-var-lib-kubelet
                 readOnly: true
               - mountPath: /host/var/tmp
                 name: host-var
@@ -701,6 +709,10 @@ spec:
                 path: /var
                 type: Directory
               name: host-var
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
             - hostPath:
                 path: /tmp
                 type: Directory

--- a/tests/kuttl/tests/pre-caching-partial-complete/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/03-assert.yaml
@@ -173,8 +173,7 @@ spec:
                 subPath: lib/cni
                 readOnly: true
               - mountPath: /host/var/lib/kubelet
-                name: host-var
-                subPath: lib/kubelet
+                name: host-var-lib-kubelet
                 readOnly: true
               - mountPath: /host/var/tmp
                 name: host-var
@@ -223,6 +222,10 @@ spec:
                 path: /var
                 type: Directory
               name: host-var
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
             - hostPath:
                 path: /tmp
                 type: Directory
@@ -332,8 +335,7 @@ spec:
                 subPath: lib/cni
                 readOnly: true
               - mountPath: /host/var/lib/kubelet
-                name: host-var
-                subPath: lib/kubelet
+                name: host-var-lib-kubelet
                 readOnly: true
               - mountPath: /host/var/tmp
                 name: host-var
@@ -382,6 +384,10 @@ spec:
                 path: /var
                 type: Directory
               name: host-var
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
             - hostPath:
                 path: /tmp
                 type: Directory
@@ -491,8 +497,7 @@ spec:
                 subPath: lib/cni
                 readOnly: true
               - mountPath: /host/var/lib/kubelet
-                name: host-var
-                subPath: lib/kubelet
+                name: host-var-lib-kubelet
                 readOnly: true
               - mountPath: /host/var/tmp
                 name: host-var
@@ -541,6 +546,10 @@ spec:
                 path: /var
                 type: Directory
               name: host-var
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
             - hostPath:
                 path: /tmp
                 type: Directory
@@ -650,8 +659,7 @@ spec:
                 subPath: lib/cni
                 readOnly: true
               - mountPath: /host/var/lib/kubelet
-                name: host-var
-                subPath: lib/kubelet
+                name: host-var-lib-kubelet
                 readOnly: true
               - mountPath: /host/var/tmp
                 name: host-var
@@ -700,6 +708,10 @@ spec:
                 path: /var
                 type: Directory
               name: host-var
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
             - hostPath:
                 path: /tmp
                 type: Directory

--- a/tests/kuttl/tests/pre-caching-with-configs/04-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-with-configs/04-assert.yaml
@@ -184,8 +184,7 @@ spec:
                     subPath: lib/cni
                     readOnly: true
                   - mountPath: /host/var/lib/kubelet
-                    name: host-var
-                    subPath: lib/kubelet
+                    name: host-var-lib-kubelet
                     readOnly: true
                   - mountPath: /host/var/tmp
                     name: host-var
@@ -234,6 +233,10 @@ spec:
                   path: /var
                   type: Directory
                 name: host-var
+              - hostPath:
+                  path: /var/lib/kubelet
+                  type: Directory
+                name: host-var-lib-kubelet
               - hostPath:
                   path: /tmp
                   type: Directory
@@ -343,8 +346,7 @@ spec:
                     subPath: lib/cni
                     readOnly: true
                   - mountPath: /host/var/lib/kubelet
-                    name: host-var
-                    subPath: lib/kubelet
+                    name: host-var-lib-kubelet
                     readOnly: true
                   - mountPath: /host/var/tmp
                     name: host-var
@@ -393,6 +395,10 @@ spec:
                   path: /var
                   type: Directory
                 name: host-var
+              - hostPath:
+                  path: /var/lib/kubelet
+                  type: Directory
+                name: host-var-lib-kubelet
               - hostPath:
                   path: /tmp
                   type: Directory
@@ -502,8 +508,7 @@ spec:
                     subPath: lib/cni
                     readOnly: true
                   - mountPath: /host/var/lib/kubelet
-                    name: host-var
-                    subPath: lib/kubelet
+                    name: host-var-lib-kubelet
                     readOnly: true
                   - mountPath: /host/var/tmp
                     name: host-var
@@ -552,6 +557,10 @@ spec:
                   path: /var
                   type: Directory
                 name: host-var
+              - hostPath:
+                  path: /var/lib/kubelet
+                  type: Directory
+                name: host-var-lib-kubelet
               - hostPath:
                   path: /tmp
                   type: Directory
@@ -661,8 +670,7 @@ spec:
                     subPath: lib/cni
                     readOnly: true
                   - mountPath: /host/var/lib/kubelet
-                    name: host-var
-                    subPath: lib/kubelet
+                    name: host-var-lib-kubelet
                     readOnly: true
                   - mountPath: /host/var/tmp
                     name: host-var
@@ -711,6 +719,10 @@ spec:
                   path: /var
                   type: Directory
                 name: host-var
+              - hostPath:
+                  path: /var/lib/kubelet
+                  type: Directory
+                name: host-var-lib-kubelet
               - hostPath:
                   path: /tmp
                   type: Directory


### PR DESCRIPTION
Description:
- due to a bug in k8s around subPaths, we are left with volume-subpaths in /var/lib/kubelet - https://github.com/kubernetes/kubernetes/issues/89181
- remove the use of subPath