### PR TITLE
OCPBUGS-17037: Use a more specific label for TALM pod selectors

### DIFF
--- a/bundle/manifests/cluster-group-upgrades-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/cluster-group-upgrades-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -2,6 +2,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
+    app.kuberenetes.io/component: talm
+    app.kubernetes.io/name: talm-operator
     control-plane: controller-manager
   name: cluster-group-upgrades-controller-manager-metrics-monitor
 spec:
@@ -14,4 +16,6 @@ spec:
       insecureSkipVerify: true
   selector:
     matchLabels:
+      app.kuberenetes.io/component: talm
+      app.kubernetes.io/name: talm-operator
       control-plane: controller-manager

--- a/bundle/manifests/cluster-group-upgrades-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/cluster-group-upgrades-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app.kuberenetes.io/component: talm
+    app.kubernetes.io/component: talm
     app.kubernetes.io/name: talm-operator
     control-plane: controller-manager
   name: cluster-group-upgrades-controller-manager-metrics-monitor
@@ -16,6 +16,6 @@ spec:
       insecureSkipVerify: true
   selector:
     matchLabels:
-      app.kuberenetes.io/component: talm
+      app.kubernetes.io/component: talm
       app.kubernetes.io/name: talm-operator
       control-plane: controller-manager

--- a/bundle/manifests/cluster-group-upgrades-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/cluster-group-upgrades-controller-manager-metrics-service_v1_service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
+    app.kuberenetes.io/component: talm
+    app.kubernetes.io/name: talm-operator
     control-plane: controller-manager
   name: cluster-group-upgrades-controller-manager-metrics-service
 spec:
@@ -11,6 +13,8 @@ spec:
     port: 8443
     targetPort: https
   selector:
+    app.kuberenetes.io/component: talm
+    app.kubernetes.io/name: talm-operator
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/cluster-group-upgrades-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/cluster-group-upgrades-controller-manager-metrics-service_v1_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    app.kuberenetes.io/component: talm
+    app.kubernetes.io/component: talm
     app.kubernetes.io/name: talm-operator
     control-plane: controller-manager
   name: cluster-group-upgrades-controller-manager-metrics-service
@@ -13,7 +13,7 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    app.kuberenetes.io/component: talm
+    app.kubernetes.io/component: talm
     app.kubernetes.io/name: talm-operator
     control-plane: controller-manager
 status:

--- a/bundle/manifests/cluster-group-upgrades-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator-controller-manager-metrics-service_v1_service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
+    app.kubernetes.io/name: talm-operator
+    app.kuberenetes.io/component: talm
     control-plane: controller-manager
   name: cluster-group-upgrades-operator-controller-manager-metrics-svc
 spec:
@@ -11,6 +13,8 @@ spec:
     port: 8443
     targetPort: https
   selector:
+    app.kubernetes.io/name: talm-operator
+    app.kuberenetes.io/component: talm
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/cluster-group-upgrades-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator-controller-manager-metrics-service_v1_service.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/name: talm-operator
-    app.kuberenetes.io/component: talm
+    app.kubernetes.io/component: talm
     control-plane: controller-manager
   name: cluster-group-upgrades-operator-controller-manager-metrics-svc
 spec:
@@ -14,7 +14,7 @@ spec:
     targetPort: https
   selector:
     app.kubernetes.io/name: talm-operator
-    app.kuberenetes.io/component: talm
+    app.kubernetes.io/component: talm
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -366,11 +366,15 @@ spec:
           replicas: 1
           selector:
             matchLabels:
+              app.kuberenetes.io/component: talm
+              app.kubernetes.io/name: talm-operator
               control-plane: controller-manager
           strategy: {}
           template:
             metadata:
               labels:
+                app.kuberenetes.io/component: talm
+                app.kubernetes.io/name: talm-operator
                 control-plane: controller-manager
             spec:
               containers:

--- a/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -366,14 +366,14 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              app.kuberenetes.io/component: talm
+              app.kubernetes.io/component: talm
               app.kubernetes.io/name: talm-operator
               control-plane: controller-manager
           strategy: {}
           template:
             metadata:
               labels:
-                app.kuberenetes.io/component: talm
+                app.kubernetes.io/component: talm
                 app.kubernetes.io/name: talm-operator
                 control-plane: controller-manager
             spec:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    app.kubernetes.io/name: talm-operator
+    app.kuberenetes.io/component: talm
     control-plane: controller-manager
   name: system
 ---
@@ -11,15 +13,21 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
+    app.kubernetes.io/name: talm-operator
+    app.kuberenetes.io/component: talm
     control-plane: controller-manager
 spec:
   selector:
     matchLabels:
+      app.kubernetes.io/name: talm-operator
+      app.kuberenetes.io/component: talm
       control-plane: controller-manager
   replicas: 1
   template:
     metadata:
       labels:
+        app.kubernetes.io/name: talm-operator
+        app.kuberenetes.io/component: talm
         control-plane: controller-manager
     spec:
       securityContext:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     app.kubernetes.io/name: talm-operator
-    app.kuberenetes.io/component: talm
+    app.kubernetes.io/component: talm
     control-plane: controller-manager
   name: system
 ---
@@ -14,20 +14,20 @@ metadata:
   namespace: system
   labels:
     app.kubernetes.io/name: talm-operator
-    app.kuberenetes.io/component: talm
+    app.kubernetes.io/component: talm
     control-plane: controller-manager
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: talm-operator
-      app.kuberenetes.io/component: talm
+      app.kubernetes.io/component: talm
       control-plane: controller-manager
   replicas: 1
   template:
     metadata:
       labels:
         app.kubernetes.io/name: talm-operator
-        app.kuberenetes.io/component: talm
+        app.kubernetes.io/component: talm
         control-plane: controller-manager
     spec:
       securityContext:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -5,7 +5,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/name: talm-operator
-    app.kuberenetes.io/component: talm
+    app.kubernetes.io/component: talm
     control-plane: controller-manager
   name: controller-manager-metrics-monitor
   namespace: system
@@ -20,7 +20,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: talm-operator
-      app.kuberenetes.io/component: talm
+      app.kubernetes.io/component: talm
       control-plane: controller-manager
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,6 +4,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
+    app.kubernetes.io/name: talm-operator
+    app.kuberenetes.io/component: talm
     control-plane: controller-manager
   name: controller-manager-metrics-monitor
   namespace: system
@@ -17,6 +19,8 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
+      app.kubernetes.io/name: talm-operator
+      app.kuberenetes.io/component: talm
       control-plane: controller-manager
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app.kubernetes.io/name: talm-operator
+    app.kuberenetes.io/component: talm
     control-plane: controller-manager
   name: controller-manager-metrics-service
   namespace: system
@@ -11,4 +13,6 @@ spec:
     port: 8443
     targetPort: https
   selector:
+    app.kubernetes.io/name: talm-operator
+    app.kuberenetes.io/component: talm
     control-plane: controller-manager

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: talm-operator
-    app.kuberenetes.io/component: talm
+    app.kubernetes.io/component: talm
     control-plane: controller-manager
   name: controller-manager-metrics-service
   namespace: system
@@ -14,5 +14,5 @@ spec:
     targetPort: https
   selector:
     app.kubernetes.io/name: talm-operator
-    app.kuberenetes.io/component: talm
+    app.kubernetes.io/component: talm
     control-plane: controller-manager


### PR DESCRIPTION
- Add more specific labels to the TALM resources
- This should prevent seeing resources from other operators that also use the same default label in unintended places

