### PR TITLE
OCPBUGS-17382: Fix for CGU not being autocreated

### DIFF
--- a/controllers/managedclusterForCGU_controller.go
+++ b/controllers/managedclusterForCGU_controller.go
@@ -289,7 +289,15 @@ func (r *ManagedClusterForCguReconciler) SetupWithManager(mgr ctrl.Manager) erro
 				GenericFunc: func(e event.GenericEvent) bool { return false },
 				CreateFunc:  func(e event.CreateEvent) bool { return true },
 				DeleteFunc:  func(e event.DeleteEvent) bool { return false },
-				UpdateFunc:  func(e event.UpdateEvent) bool { return false },
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					// Check if the event was deleting the label "ztp-done"
+					// We want to return true for that event only, and false for everything else
+					const labelName = "ztp-done"
+					_, labelExistsInOld := e.ObjectOld.GetLabels()[labelName]
+					_, labelExistsInNew := e.ObjectNew.GetLabels()[labelName]
+
+					return labelExistsInOld && !labelExistsInNew
+				},
 			})).
 		Owns(&ranv1alpha1.ClusterGroupUpgrade{},
 			// watch for delete event for owned ClusterGroupUpgrade

--- a/controllers/managedclusterForCGU_controller.go
+++ b/controllers/managedclusterForCGU_controller.go
@@ -292,9 +292,8 @@ func (r *ManagedClusterForCguReconciler) SetupWithManager(mgr ctrl.Manager) erro
 				UpdateFunc: func(e event.UpdateEvent) bool {
 					// Check if the event was deleting the label "ztp-done"
 					// We want to return true for that event only, and false for everything else
-					const labelName = "ztp-done"
-					_, labelExistsInOld := e.ObjectOld.GetLabels()[labelName]
-					_, labelExistsInNew := e.ObjectNew.GetLabels()[labelName]
+					_, labelExistsInOld := e.ObjectOld.GetLabels()[ztpDoneLabel]
+					_, labelExistsInNew := e.ObjectNew.GetLabels()[ztpDoneLabel]
 
 					return labelExistsInOld && !labelExistsInNew
 				},


### PR DESCRIPTION
- If you were to delete the CGU and then remove ztp-done from a node, then the CGU would previously not be auto-created again
- This fixes that behaviour so that it does not matter which operation you do first, the auto-creation should now run again regardless