### PR TITLE
Revert "[release-4.13] OCPBUGS-17726: Use a more specific label for TALM pod selectors"

### DIFF
--- a/bundle/manifests/cluster-group-upgrades-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/cluster-group-upgrades-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -2,8 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app.kubernetes.io/component: talm
-    app.kubernetes.io/name: talm-operator
     control-plane: controller-manager
   name: cluster-group-upgrades-controller-manager-metrics-monitor
 spec:
@@ -16,6 +14,4 @@ spec:
       insecureSkipVerify: true
   selector:
     matchLabels:
-      app.kubernetes.io/component: talm
-      app.kubernetes.io/name: talm-operator
       control-plane: controller-manager

--- a/bundle/manifests/cluster-group-upgrades-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/cluster-group-upgrades-controller-manager-metrics-service_v1_service.yaml
@@ -3,8 +3,6 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/component: talm
-    app.kubernetes.io/name: talm-operator
     control-plane: controller-manager
   name: cluster-group-upgrades-controller-manager-metrics-service
 spec:
@@ -13,8 +11,6 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    app.kubernetes.io/component: talm
-    app.kubernetes.io/name: talm-operator
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/cluster-group-upgrades-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator-controller-manager-metrics-service_v1_service.yaml
@@ -3,8 +3,6 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/name: talm-operator
-    app.kubernetes.io/component: talm
     control-plane: controller-manager
   name: cluster-group-upgrades-operator-controller-manager-metrics-svc
 spec:
@@ -13,8 +11,6 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    app.kubernetes.io/name: talm-operator
-    app.kubernetes.io/component: talm
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -331,15 +331,11 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              app.kubernetes.io/component: talm
-              app.kubernetes.io/name: talm-operator
               control-plane: controller-manager
           strategy: {}
           template:
             metadata:
               labels:
-                app.kubernetes.io/component: talm
-                app.kubernetes.io/name: talm-operator
                 control-plane: controller-manager
             spec:
               containers:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    app.kubernetes.io/name: talm-operator
-    app.kubernetes.io/component: talm
     control-plane: controller-manager
   name: system
 ---
@@ -13,21 +11,15 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    app.kubernetes.io/name: talm-operator
-    app.kubernetes.io/component: talm
     control-plane: controller-manager
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: talm-operator
-      app.kubernetes.io/component: talm
       control-plane: controller-manager
   replicas: 1
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: talm-operator
-        app.kubernetes.io/component: talm
         control-plane: controller-manager
     spec:
       securityContext:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,8 +4,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app.kubernetes.io/name: talm-operator
-    app.kubernetes.io/component: talm
     control-plane: controller-manager
   name: controller-manager-metrics-monitor
   namespace: system
@@ -19,8 +17,6 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      app.kubernetes.io/name: talm-operator
-      app.kubernetes.io/component: talm
       control-plane: controller-manager
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: talm-operator
-    app.kubernetes.io/component: talm
     control-plane: controller-manager
   name: controller-manager-metrics-service
   namespace: system
@@ -13,6 +11,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    app.kubernetes.io/name: talm-operator
-    app.kubernetes.io/component: talm
     control-plane: controller-manager


### PR DESCRIPTION
Reverts openshift-kni/cluster-group-upgrades-operator#638