### PR TITLE
OCPBUGS-17037: Fix upgrade failure due to immutable label selectors

### DIFF
--- a/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -361,7 +361,7 @@ spec:
           - create
         serviceAccountName: cluster-group-upgrades-controller-manager
       deployments:
-      - name: cluster-group-upgrades-controller-manager
+      - name: cluster-group-upgrades-controller-manager-v2
         spec:
           replicas: 1
           selector:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller-manager-v2
   namespace: system
 spec:
   template:

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller-manager-v2
   namespace: system
 spec:
   template:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -10,7 +10,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller-manager-v2
   namespace: system
   labels:
     app.kubernetes.io/name: talm-operator

--- a/config/manager/related-images/in.yaml
+++ b/config/manager/related-images/in.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller-manager-v2
   namespace: system
 spec:
   template:


### PR DESCRIPTION
This fixes upgrade due to immutable selector labels by adding a -v2 suffix to the controller manager deployment.

This is the intended solution for when you need to make changes to an immutable field as per OLM: https://github.com/operator-framework/operator-lifecycle-manager/issues/952#issuecomment-639657949

If we need to make another immutable change in the future then we can just increment v2 to v3 and so on.
