### PR TITLE
Fix pre-cache scripts not getting checked by shellcheck and bashate

### DIFF
--- a/Dockerfile.precache
+++ b/Dockerfile.precache
@@ -3,10 +3,10 @@ FROM registry.access.redhat.com/ubi8-minimal:latest
 RUN mkdir /opt/precache
 
 COPY pre-cache/release \
-     pre-cache/common \
-     pre-cache/olm \
+     pre-cache/common.sh \
+     pre-cache/olm.sh \
      pre-cache/parse_index.py \
-     pre-cache/pull \
+     pre-cache/pull.sh \
      pre-cache/precache.sh \
-     pre-cache/check_space \
+     pre-cache/check_space.sh \
      /opt/precache/

--- a/Dockerfile.precache
+++ b/Dockerfile.precache
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8-minimal:latest
 
 RUN mkdir /opt/precache
 
-COPY pre-cache/release \
+COPY pre-cache/release.sh \
      pre-cache/common.sh \
      pre-cache/olm.sh \
      pre-cache/parse_index.py \

--- a/pre-cache/check_space
+++ b/pre-cache/check_space
@@ -1,4 +1,4 @@
-./#!/bin/bash
+#!/bin/bash
 
 cwd=$(dirname "$0")
 . $cwd/common
@@ -11,12 +11,20 @@ validate_disk_space() {
     SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
     TOKEN=$(cat ${SERVICEACCOUNT}/token)
     CACERT=${SERVICEACCOUNT}/ca.crt
-    high=$(curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/nodes/${NODE_NAME}/proxy/configz | \
-                chroot /host jq '.kubeletconfig.imageGCHighThresholdPercent')
-    size=$(df /host/var/lib/ | awk '{ print $2 }' | sed -n '2p')
-    used=$(df /host/var/lib/ | awk '{ print $3 }' | sed -n '2p')
 
-    log_debug "highThresholdPercent: $high diskSize:$size used:$used"
+    high=85 # default value for imageGCHighThresholdPercent
+    kubeletconfig=$(with_retries 3 20 curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/nodes/${NODE_NAME}/proxy/configz) 
+    if [ $? -eq 0 ]; then
+        val=$(echo $kubeletconfig | chroot /host jq '.kubeletconfig.imageGCHighThresholdPercent')
+        if [[ $val -gt 0 && $val -lt 100 ]]; then
+           high=$val
+        fi
+    fi
+
+    size=$(df --output=size /host/var/lib/containers | tail -1)
+    used=$(df --output=used /host/var/lib/containers | tail -1)
+
+    log_debug "highThresholdPercent: $high diskSize: $size used: $used"
     log_debug "spaceRequired: ${space_required} GiB"
 
     if [[ $space_required -gt 0 ]]; then

--- a/pre-cache/check_space.sh
+++ b/pre-cache/check_space.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 cwd=$(dirname "$0")
-. $cwd/common
+# shellcheck source=pre-cache/common.sh
+. $cwd/common.sh
 
 validate_disk_space() {
     local space_required=${1:-0}

--- a/pre-cache/check_space.sh
+++ b/pre-cache/check_space.sh
@@ -14,11 +14,11 @@ validate_disk_space() {
     CACERT=${SERVICEACCOUNT}/ca.crt
 
     high=85 # default value for imageGCHighThresholdPercent
-    kubeletconfig=$(with_retries 3 20 curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/nodes/${NODE_NAME}/proxy/configz) 
+    kubeletconfig=$(with_retries 3 20 curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/nodes/${NODE_NAME}/proxy/configz)
     if [ $? -eq 0 ]; then
         val=$(echo $kubeletconfig | chroot /host jq '.kubeletconfig.imageGCHighThresholdPercent')
         if [[ $val -gt 0 && $val -lt 100 ]]; then
-           high=$val
+            high=$val
         fi
     fi
 

--- a/pre-cache/common
+++ b/pre-cache/common
@@ -56,3 +56,34 @@ unmount_index(){
     echo $result
     return $rv
 }
+
+#
+# with_retries:
+# Helper function to run a command with retries on failure
+#
+function with_retries {
+    local max_attempts=$1
+    local delay=$2
+    local cmd=("${@:3}")
+    local attempt=0
+    local rc=0
+
+    while [[ ${attempt} -lt ${max_attempts} ]]; do
+        attempt=$((attempt+=1))
+        if [[ ${attempt} -gt 1 ]]; then
+            log_debug "Retrying after ${delay} seconds, attempt #${attempt}"
+            sleep "${delay}"
+        fi
+
+        "${cmd[@]}"
+        rc=$?
+        if [ $rc -eq 0 ]; then
+            log_debug "Command succeeded:" "${cmd[@]}"
+            break
+        fi
+
+        log_error "Command failed:" "${cmd[@]}"
+    done
+
+    return ${rc}
+}

--- a/pre-cache/common.sh
+++ b/pre-cache/common.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
-container_tool="${container_tool:-podman}"
-pull_secret_path="${pull_secret_path:-/var/lib/kubelet/config.json}"
-pull_spec_file="${pull_spec_file:-/tmp/images.txt}"
-config_volume_path="${config_volume_path:-/tmp/precache/config}"
-rendered_index_path="${rendered_index_path:-/tmp/index.json}"
-additional_images_spec_file="${additional_images_spec_file:-${config_volume_path}/additionalImages}"
+CONTAINER_TOOL="${container_tool:-podman}"
+PULL_SECRET_PATH="${pull_secret_path:-/var/lib/kubelet/config.json}"
+export PULL_SPEC_FILE="${pull_spec_file:-/tmp/images.txt}"
+CONFIG_VOLUME_PATH="${CONFIG_VOLUME_PATH:-/tmp/precache/config}"
+export ADDITIONAL_IMAGES_SPEC_FILE="${additional_images_spec_file:-${CONFIG_VOLUME_PATH}/additionalImages}"
 
-max_pull_threads="${MAX_PULL_THREADS:-10}" # number of simultaneous pulls executed can be modified by setting MAX_PULL_THREADS environment variable
 
 # LOGLEVELS: [0]ERROR, [1]INFO, [2]DEBUG
 LOGLEVEL=${PRE_CACHE_LOG_LEVEL:-2} # set default log level to DEBUG
@@ -33,9 +31,9 @@ log_debug() {
 
 pull_index(){
     local index_pull_spec=$1
-    local pull_secret_path=$2
+    local PULL_SECRET_PATH=$2
     # Pull the image into the cache directory and attain the image ID
-    release_index_id=$($container_tool pull --quiet  $index_pull_spec --authfile=$pull_secret_path)
+    release_index_id=$($CONTAINER_TOOL pull --quiet  $index_pull_spec --authfile=$PULL_SECRET_PATH)
     [[ $? -eq 0 ]] || return 1
     echo $release_index_id
     return 0
@@ -43,7 +41,8 @@ pull_index(){
 
 mount_index(){
     local image_id=$1
-    local image_mount=$($container_tool image mount $image_id)
+    local image_mount
+    image_mount=$($CONTAINER_TOOL image mount $image_id)
     rv=$?
     echo $image_mount
     return $rv
@@ -51,7 +50,8 @@ mount_index(){
 
 unmount_index(){
     local image_id=$1
-    local result=$($container_tool image unmount $image_id)
+    local result
+    result=$($CONTAINER_TOOL image unmount $image_id)
     rv=$?
     echo $result
     return $rv

--- a/pre-cache/common.sh
+++ b/pre-cache/common.sh
@@ -6,6 +6,8 @@ export PULL_SPEC_FILE="${pull_spec_file:-/tmp/images.txt}"
 CONFIG_VOLUME_PATH="${CONFIG_VOLUME_PATH:-/tmp/precache/config}"
 export ADDITIONAL_IMAGES_SPEC_FILE="${additional_images_spec_file:-${CONFIG_VOLUME_PATH}/additionalImages}"
 
+# This fixes process substitution issues in chroot
+ln -snf /proc/self/fd /dev/fd
 
 # LOGLEVELS: [0]ERROR, [1]INFO, [2]DEBUG
 LOGLEVEL=${PRE_CACHE_LOG_LEVEL:-2} # set default log level to DEBUG

--- a/pre-cache/olm.sh
+++ b/pre-cache/olm.sh
@@ -18,7 +18,7 @@ render_index(){
     index=$1
     packages=$2
     image_mount=$3
-    
+
     if [[ -h "$image_mount/bin/opm" ]]; then
         opm_bin=$image_mount$(readlink "$image_mount/bin/opm")
     else
@@ -26,23 +26,21 @@ render_index(){
     fi
 
     if [[ -d "$image_mount/configs" ]]; then
-      log_debug "Rendering file based catalog"
-      $opm_bin render "$image_mount/configs" > $rendered_index_path
+        log_debug "Rendering file based catalog"
+        $opm_bin render "$image_mount/configs" > $rendered_index_path
     else
-      log_debug "Rendering SQLite catalog"
-      $opm_bin render "$image_mount/database/index.db" > $rendered_index_path
+        log_debug "Rendering SQLite catalog"
+        $opm_bin render "$image_mount/database/index.db" > $rendered_index_path
     fi
     if [[ $? -ne 0 ]]; then
         return 1
     fi
-
 }
 
 extract_packages(){
     local packages
     tr -d " " < $CONFIG_VOLUME_PATH/operators.packagesAndChannels > /tmp/packagesAndChannels
     while IFS= read -r item; do
-    # for item in $(sort -u '/tmp/packagesAndChannels'); do
         pkg=$(echo $item |cut -d ':' -f 1)
         packages="$packages$pkg,"
     done < <(sort -u /tmp/packagesAndChannels)
@@ -52,49 +50,49 @@ extract_packages(){
 
 olm_main(){
     if [ -z $(sort -u $CONFIG_VOLUME_PATH/operators.indexes) ]; then
-      log_debug "Operators index is not specified. Operators won't be pre-cached"
-      return 0
+        log_debug "Operators index is not specified. Operators won't be pre-cached"
+        return 0
     fi
     # There could be several indexes, hence the loop
-    sort -u $CONFIG_VOLUME_PATH/operators.indexes | while IFS= read -r index
+    while IFS= read -r index
     do
         image_id=$(pull_index $index $PULL_SECRET_PATH)
         if [[ $? -ne 0 ]]; then
-          log_debug "pull_index failed for index $index"
-          return 1
+            log_debug "pull_index failed for index $index"
+            return 1
         fi
         log_debug "$index image ID is $image_id"
 
         image_mount=$(mount_index $image_id)
         if [[ $? -ne 0 ]]; then
-          log_debug "mount_index failed for index $index"
-          return 1
+            log_debug "mount_index failed for index $index"
+            return 1
         fi
         log_debug "Image mount: $image_mount"
 
         packages=$(extract_packages)
         if [[ -z $packages ]]; then
-          log_debug "operators index is set, but no packages provided - inconsistent configuration"
-          return 1
+            log_debug "operators index is set, but no packages provided - inconsistent configuration"
+            return 1
         fi
 
         render_index $index $packages $image_mount
         if [[ $? -ne 0 ]]; then
-          log_debug "render_index failed: OLM index render failed for index $index, package(s) $packages"
-          return 1
+            log_debug "render_index failed: OLM index render failed for index $index, package(s) $packages"
+            return 1
         fi
         operators_spec_file="$CONFIG_VOLUME_PATH/operators.packagesAndChannels"
         extract_pull_spec $rendered_index_path $operators_spec_file $PULL_SPEC_FILE
         if [[ $? -ne 0 ]]; then
-          log_debug "extract_pull_spec failed"
-          return 1
+            log_debug "extract_pull_spec failed"
+            return 1
         fi
         unmount_index $image_id
-    done
+    done < <(sort -u $CONFIG_VOLUME_PATH/operators.indexes)
     return 0
 }
 
 if [[ "${BASH_SOURCE[0]}" = "${0}" ]]; then
-  olm_main
-  exit $?
+    olm_main
+    exit $?
 fi

--- a/pre-cache/precache.sh
+++ b/pre-cache/precache.sh
@@ -19,14 +19,14 @@ cp -rf /etc/config /host/tmp/precache/config
 # Check the available space for the OCP upgrade case or for pre-caching additional images
 { [ -n "$(cat /etc/config/platform.image)" ] || [ -n "$(cat /etc/config/additionalImages)" ]; } && check_disk_space=1 || check_disk_space=0
 if [[ $check_disk_space == 1 ]]; then
-    /opt/precache/check_space $(cat /etc/config/spaceRequired)
+    /opt/precache/check_space.sh $(cat /etc/config/spaceRequired)
 fi
 
-chroot /host /tmp/precache/release
-chroot /host /tmp/precache/olm
-chroot /host /tmp/precache/pull
+chroot /host /tmp/precache/release.sh
+chroot /host /tmp/precache/olm.sh
+chroot /host /tmp/precache/pull.sh
 
 # Check disk space usage post pre-caching to alert if kubelet Garbage Collection will be triggered
 if [[ $check_disk_space == 1 ]]; then
-    /opt/precache/check_space
+    /opt/precache/check_space.sh
 fi

--- a/pre-cache/pull.sh
+++ b/pre-cache/pull.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 cwd="${cwd:-/tmp/precache}"
-. $cwd/common
+# shellcheck source=pre-cache/common.sh
+. $cwd/common.sh
 
 wait_image(){
     local img=$1
@@ -11,7 +12,7 @@ wait_image(){
     wait $pid # The way wait monitor for each background task (PID). If any error then copy the image in the failed array so it can be retried later
     if [[ $? != 0 ]]; then
         log_error "Pull failed for image: ${img}! Will retry later... "
-        failed_pulls+=(${img}) # Failed, then add the image to be retrieved later
+        failed_pulls+=("${img}") # Failed, then add the image to be retrieved later
     fi
 }
 
@@ -24,42 +25,45 @@ mirror_images() {
         return 1
     fi
 
+    max_pull_threads="${MAX_PULL_THREADS:-10}" # number of simultaneous pulls executed can be modified by setting MAX_PULL_THREADS environment variable
     # definition of vars once the config is provided
     local max_bg=$max_pull_threads
     declare -A pids # Hash that include the images pulled along with their pids to be monitored by wait command
-    local total_pulls=$(sort -u $pull_file | wc -l)  # Required to keep track of the pull task vs total
+    local total_pulls
+    total_pulls=$(sort -u $pull_file | wc -l)  # Required to keep track of the pull task vs total
     local current_pull=1
 
-    for line in $(sort -u $pull_file) ; do
+    # for line in $(sort -u $pull_file); do
+    while IFS= read -r line; do
         # Strip double quotes
         img="${line%\"}"
         img="${img#\"}"
         log_debug "Pulling ${img} [${current_pull}/${total_pulls}]"
         # If image is on disk, then skip. This improves the global performance
-        $container_tool image exists $img
+        $CONTAINER_TOOL image exists $img
         if [[ $? == 0 ]]; then
             log_debug "Skipping existing image $img"
             current_pull=$((current_pull + 1))
             continue
         fi
-        $container_tool pull $img --authfile=$pull_secret_path -q > /dev/null &
-        #$container_tool copy docker://${img} --authfile=/var/lib/kubelet/config.json containers-storage:${img} -q & # SKOPEO 
+        $CONTAINER_TOOL pull $img --authfile=$PULL_SECRET_PATH -q > /dev/null &
+        #$CONTAINER_TOOL copy docker://${img} --authfile=/var/lib/kubelet/config.json containers-storage:${img} -q & # SKOPEO 
         pids[${img}]=$! # Keeping track of the PID and container image in case the pull fails
         max_bg=$((max_bg - 1)) # Batch size adapted 
         current_pull=$((current_pull + 1)) 
         if [[ $max_bg == 0 ]] # If the batch is done, then monitor the status of all pulls before moving to the next batch
         then
-          for pid in ${!pids[@]}; do
+          for pid in "${!pids[@]}"; do
             wait_image $pid ${pids[$pid]}
           done
           # Once the batch is processed, reset the new batch size and clear the processes hash for the next one
           max_bg=$max_pull_threads
           pids=()
         fi
-    done
+    done < $pull_file
 
     # Make sure that all pull-threads have been processed
-    for pid in ${!pids[@]}; do
+    for pid in "${!pids[@]}"; do
         wait_image $pid ${pids[$pid]}
     done
 }
@@ -70,13 +74,13 @@ retry_images() {
     local iterations
     local rv=0
 
-    for failed_pull in ${failed_pulls[@]}; do
+    for failed_pull in "${failed_pulls[@]}"; do
       success=0
       iterations=10
       until [[ $success -eq 1 ]] || [[ $iterations -eq 0 ]]
       do
         log_info "Retrying failed image pull: ${failed_pull}"
-        $container_tool pull $failed_pull --authfile=$pull_secret_path
+        $CONTAINER_TOOL pull $failed_pull --authfile=$PULL_SECRET_PATH
         if [[ $? == 0 ]]; then
           success=1
         fi
@@ -112,12 +116,12 @@ pre_cache_images(){
 
 if [[ "${BASH_SOURCE[0]}" = "${0}" ]]; then
     declare -A pull_types
-    pull_types["platform-images"]=${pull_spec_file}
-    pull_types["additional-images"]=${additional_images_spec_file}
+    pull_types["platform-images"]=${PULL_SPEC_FILE}
+    pull_types["additional-images"]=${ADDITIONAL_IMAGES_SPEC_FILE}
 
     failed_pulls=() # Array that will include all the images that failed to be pulled
 
-    for pull_type in ${!pull_types[@]}; do
+    for pull_type in "${!pull_types[@]}"; do
         pull_file=${pull_types[$pull_type]}
         # Check if the spec_file exists before executing pull statements
         if [ -n "$(cat $pull_file)" ]; then

--- a/pre-cache/release.sh
+++ b/pre-cache/release.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
 
 cwd=$(dirname "$0")
-. $cwd/common
+# shellcheck source=pre-cache/common.sh
+. $cwd/common.sh
 
 extract_pull_spec(){
     local rel_img_mount=$1
 
     # remove empty lines
-    sed -i '/^[[:space:]]*$/d' $config_volume_path/excludePrecachePatterns
+    sed -i '/^[[:space:]]*$/d' $CONFIG_VOLUME_PATH/excludePrecachePatterns
     # remove trailing and leading whitespace
-    sed -i 's/^[ \t]*//;s/[ \t]*$//' $config_volume_path/excludePrecachePatterns
+    sed -i 's/^[ \t]*//;s/[ \t]*$//' $CONFIG_VOLUME_PATH/excludePrecachePatterns
     
-    cat ${rel_img_mount}/release-manifests/image-references | \
-      jq  '.spec.tags[] | .name as $name |.from.name as $pull |[$name,$pull] |join("$")' | \
-       grep -vG -f $config_volume_path/excludePrecachePatterns | \
+    jq  '.spec.tags[] | .name as $name |.from.name as $pull |[$name,$pull] |join("$")' < ${rel_img_mount}/release-manifests/image-references | \
+       grep -vG -f $CONFIG_VOLUME_PATH/excludePrecachePatterns | \
        cut -d "$" -f2 | \
-       sed 's/^/"/' >> $pull_spec_file
+       sed 's/^/"/' >> $PULL_SPEC_FILE
     log_debug "Release index image processing done"
 }
 
 release_main(){
-    rel_img=$(cat $config_volume_path/platform.image)
-    if ! [[ -n $rel_img ]]; then
+    rel_img=$(cat $CONFIG_VOLUME_PATH/platform.image)
+    if [[ -z $rel_img ]]; then
       log_debug "Release index is not specified. Release images will not be pre-cached"
       return 0
     fi
-    release_index_id=$(pull_index $rel_img $pull_secret_path)
+    release_index_id=$(pull_index $rel_img $PULL_SECRET_PATH)
     [[ $? -eq 0 ]] || return 1
     rel_img_mount=$(mount_index $release_index_id)
     [[ $? -eq 0 ]] || return 1

--- a/pre-cache/release.sh
+++ b/pre-cache/release.sh
@@ -11,19 +11,19 @@ extract_pull_spec(){
     sed -i '/^[[:space:]]*$/d' $CONFIG_VOLUME_PATH/excludePrecachePatterns
     # remove trailing and leading whitespace
     sed -i 's/^[ \t]*//;s/[ \t]*$//' $CONFIG_VOLUME_PATH/excludePrecachePatterns
-    
+
     jq  '.spec.tags[] | .name as $name |.from.name as $pull |[$name,$pull] |join("$")' < ${rel_img_mount}/release-manifests/image-references | \
-       grep -vG -f $CONFIG_VOLUME_PATH/excludePrecachePatterns | \
-       cut -d "$" -f2 | \
-       sed 's/^/"/' >> $PULL_SPEC_FILE
+        grep -vG -f $CONFIG_VOLUME_PATH/excludePrecachePatterns | \
+        cut -d "$" -f2 | \
+        sed 's/^/"/' >> $PULL_SPEC_FILE
     log_debug "Release index image processing done"
 }
 
 release_main(){
     rel_img=$(cat $CONFIG_VOLUME_PATH/platform.image)
     if [[ -z $rel_img ]]; then
-      log_debug "Release index is not specified. Release images will not be pre-cached"
-      return 0
+        log_debug "Release index is not specified. Release images will not be pre-cached"
+        return 0
     fi
     release_index_id=$(pull_index $rel_img $PULL_SECRET_PATH)
     [[ $? -eq 0 ]] || return 1
@@ -37,6 +37,6 @@ release_main(){
 }
 
 if [[ "${BASH_SOURCE[0]}" = "${0}" ]]; then
-  release_main
-  exit $?
+    release_main
+    exit $?
 fi

--- a/pre-cache/test.sh
+++ b/pre-cache/test.sh
@@ -7,7 +7,7 @@ fatal() {
     exit 1
 }
 
-for f in common olm release pull; do
+for f in common.sh olm.sh release.sh pull.sh; do
     echo "Testing import of $f"
     # shellcheck disable=1090,2154
     . $cwd/$f
@@ -47,20 +47,20 @@ cat <<EOF > /tmp/release-manifests/image-references
 EOF
 
 # shellcheck disable=SC2154
-(rm $pull_spec_file || true) &> /dev/null
+(rm $PULL_SPEC_FILE || true) &> /dev/null
 
 # shellcheck disable=SC2034
-container_tool=/usr/bin/echo
+CONTAINER_TOOL=/usr/bin/echo
 # shellcheck disable=SC2034
-config_volume_path=/tmp
+CONFIG_VOLUME_PATH=/tmp
 
 # Test common
 echo "Testing common functions:"
 
 # shellcheck disable=SC2154
-result=$(pull_index "temp" $pull_secret_path)
+result=$(pull_index "temp" $PULL_SECRET_PATH)
 [[ $? -eq 0 ]] || fatal "pull_index unexpected exit code"
-[[ $result == "pull --quiet temp --authfile=$pull_secret_path" ]] || fatal "Index pull failure"
+[[ $result == "pull --quiet temp --authfile=$PULL_SECRET_PATH" ]] || fatal "Index pull failure"
 echo " Index pull pass"
 
 result=$(mount_index test)
@@ -83,8 +83,8 @@ echo " extract_packages - pass"
 echo "Testing release unit:"
 result=$(extract_pull_spec "/tmp")
 [[ $? -eq 0 ]] || fatal "release_image extract unexpected exit code"
-[[ $(cat $pull_spec_file) == "\"quay.io/1\"" ]] || fatal "release pull spec extract failure"
+[[ $(cat $PULL_SPEC_FILE) == "\"quay.io/1\"" ]] || fatal "release pull spec extract failure"
 echo " release extract_pull_spec pass"
 
 # Clean
-rm -rf /tmp/operators.indexes /tmp/release-manifests $pull_spec_file /tmp/operators.packagesAndChannels
+rm -rf /tmp/operators.indexes /tmp/release-manifests $PULL_SPEC_FILE /tmp/operators.packagesAndChannels


### PR DESCRIPTION
Add `.sh` extension to pre-caching scripts.
Fix bashate warnings.
Fix shellcheck warnings.