### PR TITLE
OCPBUGS-19555: Add ovn-ic volumeMount to backup job template

### DIFF
--- a/controllers/templates/backup-templates.go
+++ b/controllers/templates/backup-templates.go
@@ -136,6 +136,10 @@ spec:
                     name: host-var-lib
                     subPath: etcd
                     readOnly: true
+                  - mountPath: /host/var/lib/ovn-ic
+                    name: host-var-lib
+                    subPath: ovn-ic
+                    readOnly: true
                   - mountPath: /host/boot
                     name: host-boot
                     readOnly: true

--- a/tests/kuttl/tests/backup-complete/02-assert.yaml
+++ b/tests/kuttl/tests/backup-complete/02-assert.yaml
@@ -194,6 +194,10 @@ spec:
                 name: host-var-lib
                 subPath: etcd
                 readOnly: true
+              - mountPath: /host/var/lib/ovn-ic
+                name: host-var-lib
+                subPath: ovn-ic
+                readOnly: true
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
@@ -315,6 +319,10 @@ spec:
               - mountPath: /host/var/lib/etcd
                 name: host-var-lib
                 subPath: etcd
+                readOnly: true
+              - mountPath: /host/var/lib/ovn-ic
+                name: host-var-lib
+                subPath: ovn-ic
                 readOnly: true
               - mountPath: /host/boot
                 name: host-boot
@@ -438,6 +446,10 @@ spec:
                 name: host-var-lib
                 subPath: etcd
                 readOnly: true
+              - mountPath: /host/var/lib/ovn-ic
+                name: host-var-lib
+                subPath: ovn-ic
+                readOnly: true
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
@@ -559,6 +571,10 @@ spec:
               - mountPath: /host/var/lib/etcd
                 name: host-var-lib
                 subPath: etcd
+                readOnly: true
+              - mountPath: /host/var/lib/ovn-ic
+                name: host-var-lib
+                subPath: ovn-ic
                 readOnly: true
               - mountPath: /host/boot
                 name: host-boot

--- a/tests/kuttl/tests/backup-fail/02-assert.yaml
+++ b/tests/kuttl/tests/backup-fail/02-assert.yaml
@@ -194,6 +194,10 @@ spec:
                 name: host-var-lib
                 subPath: etcd
                 readOnly: true
+              - mountPath: /host/var/lib/ovn-ic
+                name: host-var-lib
+                subPath: ovn-ic
+                readOnly: true
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
@@ -315,6 +319,10 @@ spec:
               - mountPath: /host/var/lib/etcd
                 name: host-var-lib
                 subPath: etcd
+                readOnly: true
+              - mountPath: /host/var/lib/ovn-ic
+                name: host-var-lib
+                subPath: ovn-ic
                 readOnly: true
               - mountPath: /host/boot
                 name: host-boot
@@ -438,6 +446,10 @@ spec:
                 name: host-var-lib
                 subPath: etcd
                 readOnly: true
+              - mountPath: /host/var/lib/ovn-ic
+                name: host-var-lib
+                subPath: ovn-ic
+                readOnly: true
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
@@ -559,6 +571,10 @@ spec:
               - mountPath: /host/var/lib/etcd
                 name: host-var-lib
                 subPath: etcd
+                readOnly: true
+              - mountPath: /host/var/lib/ovn-ic
+                name: host-var-lib
+                subPath: ovn-ic
                 readOnly: true
               - mountPath: /host/boot
                 name: host-boot

--- a/tests/kuttl/tests/backup-partial-complete/02-assert.yaml
+++ b/tests/kuttl/tests/backup-partial-complete/02-assert.yaml
@@ -194,6 +194,10 @@ spec:
                 name: host-var-lib
                 subPath: etcd
                 readOnly: true
+              - mountPath: /host/var/lib/ovn-ic
+                name: host-var-lib
+                subPath: ovn-ic
+                readOnly: true
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
@@ -315,6 +319,10 @@ spec:
               - mountPath: /host/var/lib/etcd
                 name: host-var-lib
                 subPath: etcd
+                readOnly: true
+              - mountPath: /host/var/lib/ovn-ic
+                name: host-var-lib
+                subPath: ovn-ic
                 readOnly: true
               - mountPath: /host/boot
                 name: host-boot
@@ -438,6 +446,10 @@ spec:
                 name: host-var-lib
                 subPath: etcd
                 readOnly: true
+              - mountPath: /host/var/lib/ovn-ic
+                name: host-var-lib
+                subPath: ovn-ic
+                readOnly: true
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
@@ -559,6 +571,10 @@ spec:
               - mountPath: /host/var/lib/etcd
                 name: host-var-lib
                 subPath: etcd
+                readOnly: true
+              - mountPath: /host/var/lib/ovn-ic
+                name: host-var-lib
+                subPath: ovn-ic
                 readOnly: true
               - mountPath: /host/boot
                 name: host-boot


### PR DESCRIPTION
This commit adds a read-only ovn-ic volumeMount to the backup job template.

The expected kuttl test outputs have been updated accordingly.

/cc @jc-rh @sudomakeinstall2 