### PR TITLE
Add watch for MCV events to controller

### DIFF
--- a/controllers/utils/multicloud_util_test.go
+++ b/controllers/utils/multicloud_util_test.go
@@ -205,9 +205,10 @@ func TestEnsureManagedClusterView(t *testing.T) {
 		resourceType      string
 		resourceName      string
 		resourceNamespace string
-		label             string
+		cguName           string
+		cguNamespace      string
 		validateFunc      func(t *testing.T, runtimeClient client.Client, safeMcvName, mcvName, mcvNamespace,
-			resourceType, resourceName, resourceNamespace, label string)
+			resourceType, resourceName, resourceNamespace, cguName, cguNamespace string)
 	}{
 		{
 			name:              "ManagedClusterView is successfully created",
@@ -217,18 +218,21 @@ func TestEnsureManagedClusterView(t *testing.T) {
 			resourceType:      "InstallPlan",
 			resourceName:      "installPlan-abcd",
 			resourceNamespace: "installPlan-abcd-namespace",
-			label:             "default-cgu",
+			cguName:           "cgu",
+			cguNamespace:      "default",
 			validateFunc: func(t *testing.T, runtimeClient client.Client, safeMcvName, mcvName, mcvNamespace,
-				resourceType, resourceName, resourceNamespace, label string) {
+				resourceType, resourceName, resourceNamespace, cguName, cguNamespace string) {
 				mcv, err := EnsureManagedClusterView(context.TODO(), runtimeClient, safeMcvName, mcvName, mcvNamespace,
-					resourceType, resourceName, resourceNamespace, label)
+					resourceType, resourceName, resourceNamespace, cguName, cguNamespace)
 				if err != nil {
 					t.Errorf("Error occurred and it wasn't expected")
 				}
 				assert.Equal(t, mcv.ObjectMeta.Name, safeMcvName)
 				assert.Equal(t, mcv.ObjectMeta.Namespace, mcvNamespace)
 				assert.Equal(t, mcv.ObjectMeta.Labels,
-					map[string]string{"openshift-cluster-group-upgrades/clusterGroupUpgrade": label})
+					map[string]string{"openshift-cluster-group-upgrades/clusterGroupUpgrade": cguName,
+						"openshift-cluster-group-upgrades/clusterGroupUpgradeNamespace": cguNamespace,
+					})
 				assert.Equal(t, mcv.Spec.Scope.Resource, resourceType)
 				assert.Equal(t, mcv.Spec.Scope.Name, resourceName)
 				assert.Equal(t, mcv.Spec.Scope.Namespace, resourceNamespace)
@@ -254,18 +258,20 @@ func TestEnsureManagedClusterView(t *testing.T) {
 			resourceType:      "InstallPlan",
 			resourceName:      "installPlan-abcd",
 			resourceNamespace: "installPlan-abcd-namespace",
-			label:             "default-cgu",
+			cguName:           "cgu",
+			cguNamespace:      "default",
 			validateFunc: func(t *testing.T, runtimeClient client.Client, safeMcvName, mcvName, mcvNamespace,
-				resourceType, resourceName, resourceNamespace, label string) {
+				resourceType, resourceName, resourceNamespace, cguName, cguNamespace string) {
 				mcv, err := EnsureManagedClusterView(context.TODO(), runtimeClient, safeMcvName, mcvName, mcvNamespace,
-					resourceType, resourceName, resourceNamespace, label)
+					resourceType, resourceName, resourceNamespace, cguName, cguNamespace)
 				if err != nil {
 					t.Errorf("Error occurred and it wasn't expected")
 				}
 				assert.Equal(t, mcv.ObjectMeta.Name, safeMcvName)
 				assert.Equal(t, mcv.ObjectMeta.Namespace, mcvNamespace)
 				assert.Equal(t, mcv.ObjectMeta.Labels,
-					map[string]string{"openshift-cluster-group-upgrades/clusterGroupUpgrade": label})
+					map[string]string{"openshift-cluster-group-upgrades/clusterGroupUpgrade": cguName,
+						"openshift-cluster-group-upgrades/clusterGroupUpgradeNamespace": cguNamespace})
 				assert.Equal(t, mcv.Spec.Scope.Resource, resourceType)
 				assert.Equal(t, mcv.Spec.Scope.Name, resourceName)
 				assert.Equal(t, mcv.Spec.Scope.Namespace, resourceNamespace)
@@ -286,7 +292,7 @@ func TestEnsureManagedClusterView(t *testing.T) {
 			}
 
 			tc.validateFunc(t, fakeClient, tc.safeMcvName, tc.mcvName, tc.mcvNamespace,
-				tc.resourceType, tc.resourceName, tc.resourceNamespace, tc.label)
+				tc.resourceType, tc.resourceName, tc.resourceNamespace, tc.cguName, tc.cguNamespace)
 		})
 	}
 }
@@ -1205,7 +1211,8 @@ func TestFinalMultiCloudObjectCleanup(t *testing.T) {
 						Name:      "view",
 						Namespace: cluster,
 						Labels: map[string]string{
-							"openshift-cluster-group-upgrades/clusterGroupUpgrade": tc.cgu.Namespace + "-" + tc.cgu.Name,
+							"openshift-cluster-group-upgrades/clusterGroupUpgrade":          tc.cgu.Name,
+							"openshift-cluster-group-upgrades/clusterGroupUpgradeNamespace": tc.cgu.Namespace,
 						},
 					},
 				})

--- a/tests/kuttl/tests/operator-upgrade/02-assert.yaml
+++ b/tests/kuttl/tests/operator-upgrade/02-assert.yaml
@@ -72,7 +72,8 @@ apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
   labels:
-    openshift-cluster-group-upgrades/clusterGroupUpgrade: default-cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgrade: cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgradeNamespace: default
   name: install-aaaa1
   namespace: spoke1
 spec:
@@ -85,7 +86,8 @@ apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
   labels:
-    openshift-cluster-group-upgrades/clusterGroupUpgrade: default-cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgrade: cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgradeNamespace: default
   name: install-aaaa2
   namespace: spoke1
 spec:
@@ -98,7 +100,8 @@ apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
   labels:
-    openshift-cluster-group-upgrades/clusterGroupUpgrade: default-cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgrade: cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgradeNamespace: default
   name: install-aaaa3
   namespace: spoke1
 spec:
@@ -111,7 +114,8 @@ apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
   labels:
-    openshift-cluster-group-upgrades/clusterGroupUpgrade: default-cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgrade: cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgradeNamespace: default
   name: install-aaaa4
   namespace: spoke1
 spec:
@@ -124,7 +128,8 @@ apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
   labels:
-    openshift-cluster-group-upgrades/clusterGroupUpgrade: default-cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgrade: cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgradeNamespace: default
   name: install-aaaa5
   namespace: spoke1
 spec:
@@ -138,7 +143,8 @@ apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
   labels:
-    openshift-cluster-group-upgrades/clusterGroupUpgrade: default-cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgrade: cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgradeNamespace: default
   name: install-bbbb1
   namespace: spoke2
 spec:
@@ -151,7 +157,8 @@ apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
   labels:
-    openshift-cluster-group-upgrades/clusterGroupUpgrade: default-cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgrade: cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgradeNamespace: default
   name: install-bbbb2
   namespace: spoke2
 spec:
@@ -164,7 +171,8 @@ apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
   labels:
-    openshift-cluster-group-upgrades/clusterGroupUpgrade: default-cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgrade: cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgradeNamespace: default
   name: install-bbbb3
   namespace: spoke2
 spec:
@@ -177,7 +185,8 @@ apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
   labels:
-    openshift-cluster-group-upgrades/clusterGroupUpgrade: default-cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgrade: cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgradeNamespace: default
   name: install-bbbb4
   namespace: spoke2
 spec:
@@ -190,7 +199,8 @@ apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
   labels:
-    openshift-cluster-group-upgrades/clusterGroupUpgrade: default-cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgrade: cgu
+    openshift-cluster-group-upgrades/clusterGroupUpgradeNamespace: default
   name: install-bbbb5
   namespace: spoke2
 spec:


### PR DESCRIPTION
- Controller now watches MCV update events and triggers a reconcillation
for the corresponding cgu.
- Add name and namespace of the cgu as labels to created MCVs.
- Controller won't reconcile sooner for MCVs.