### PR TITLE
OCPBUGS-19723: Add PreCachingConfig to owned CRDs under csv

### DIFF
--- a/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -151,8 +151,14 @@ spec:
       - displayName: Status
         path: status
       version: v1alpha1
-    - kind: PreCachingConfig
+    - description: PreCachingConfig is the Schema for the precachingconfigs API
+      displayName: Pre-caching Config
+      kind: PreCachingConfig
       name: precachingconfigs.ran.openshift.io
+      resources:
+      - kind: Namespace
+        name: “”
+        version: v1
       version: v1alpha1
   description: cluster-group-upgrades-operator is an operator that facilitates platform
     upgrades of group of clusters

--- a/config/manifests/bases/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -12,6 +12,15 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: PreCachingConfig is the Schema for the precachingconfigs API
+      displayName: Pre-caching Config
+      kind: PreCachingConfig
+      name: precachingconfigs.ran.openshift.io
+      resources:
+      - kind: Namespace
+        name: “”
+        version: v1
+      version: v1alpha1
     - description: ClusterGroupUpgrade is the Schema for the ClusterGroupUpgrades
         API
       displayName: Cluster Group Upgrade


### PR DESCRIPTION
This commit adds the PreCachingConfig CRD to the list of CRDs owned by the cluster-group-upgrades operator under the ClusterServiceVersion manifest.

/cc @jc-rh @sudomakeinstall2 