### PR TITLE
OCPBUGS-20057: Create /var/recovery directory if it does not exist

### DIFF
--- a/controllers/templates/backup-templates.go
+++ b/controllers/templates/backup-templates.go
@@ -166,7 +166,7 @@ spec:
                 name: host-etc
               - hostPath:
                   path: /var/recovery
-                  type: Directory
+                  type: DirectoryOrCreate
                 name: host-var-recovery
               - hostPath:
                   path: /var/lib/

--- a/tests/kuttl/tests/backup-complete/02-assert.yaml
+++ b/tests/kuttl/tests/backup-complete/02-assert.yaml
@@ -224,7 +224,7 @@ spec:
               name: host-etc
             - hostPath:
                 path: /var/recovery
-                type: Directory
+                type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
                 path: /var/lib/
@@ -350,7 +350,7 @@ spec:
               name: host-etc
             - hostPath:
                 path: /var/recovery
-                type: Directory
+                type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
                 path: /var/lib/
@@ -476,7 +476,7 @@ spec:
               name: host-etc
             - hostPath:
                 path: /var/recovery
-                type: Directory
+                type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
                 path: /var/lib/
@@ -602,7 +602,7 @@ spec:
               name: host-etc
             - hostPath:
                 path: /var/recovery
-                type: Directory
+                type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
                 path: /var/lib/

--- a/tests/kuttl/tests/backup-fail/02-assert.yaml
+++ b/tests/kuttl/tests/backup-fail/02-assert.yaml
@@ -224,7 +224,7 @@ spec:
               name: host-etc
             - hostPath:
                 path: /var/recovery
-                type: Directory
+                type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
                 path: /var/lib/
@@ -350,7 +350,7 @@ spec:
               name: host-etc
             - hostPath:
                 path: /var/recovery
-                type: Directory
+                type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
                 path: /var/lib/
@@ -476,7 +476,7 @@ spec:
               name: host-etc
             - hostPath:
                 path: /var/recovery
-                type: Directory
+                type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
                 path: /var/lib/
@@ -602,7 +602,7 @@ spec:
               name: host-etc
             - hostPath:
                 path: /var/recovery
-                type: Directory
+                type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
                 path: /var/lib/

--- a/tests/kuttl/tests/backup-partial-complete/02-assert.yaml
+++ b/tests/kuttl/tests/backup-partial-complete/02-assert.yaml
@@ -224,7 +224,7 @@ spec:
               name: host-etc
             - hostPath:
                 path: /var/recovery
-                type: Directory
+                type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
                 path: /var/lib/
@@ -350,7 +350,7 @@ spec:
               name: host-etc
             - hostPath:
                 path: /var/recovery
-                type: Directory
+                type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
                 path: /var/lib/
@@ -476,7 +476,7 @@ spec:
               name: host-etc
             - hostPath:
                 path: /var/recovery
-                type: Directory
+                type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
                 path: /var/lib/
@@ -602,7 +602,7 @@ spec:
               name: host-etc
             - hostPath:
                 path: /var/recovery
-                type: Directory
+                type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
                 path: /var/lib/


### PR DESCRIPTION
This PR introduces the ability to create the /var/recovery directory if it does not exist upon pod creation for the backup job.

/cc @jc-rh @donpenney 