### PR TITLE
OCPBUGS-21749: Fix failing upgrade-recovery backup job 

### DIFF
--- a/controllers/templates/backup-templates.go
+++ b/controllers/templates/backup-templates.go
@@ -121,32 +121,52 @@ spec:
                   - mountPath: /host/usr/local
                     name: host-usrlocal
                     readOnly: true
+                  - mountPath: /host/usr/share/containers
+                    name: host-usr
+                    subPath: share/containers
+                    readOnly: true
                   - mountPath: /host/proc
                     name: host-proc
                     readOnly: true
                   - mountPath: /host/etc
                     name: host-etc
-                    readOnly: true
                   - mountPath: /host/var/recovery
                     name: host-var-recovery
+                  - mountPath: /host/var/lib/containers
+                    name: host-var
+                    subPath: lib/containers
+                  - mountPath: /host/var/lib/cni
+                    name: host-var
+                    subPath: lib/cni
+                    readOnly: true
+                  - mountPath: /host/var/lib/etcd
+                    name: host-var
+                    subPath: lib/etcd
+                    readOnly: true
                   - mountPath: /host/var/lib/kubelet
                     name: host-var-lib-kubelet
                     readOnly: true
-                  - mountPath: /host/var/lib/etcd
-                    name: host-var-lib
-                    subPath: etcd
-                    readOnly: true
                   - mountPath: /host/var/lib/ovn-ic
-                    name: host-var-lib
-                    subPath: ovn-ic
+                    name: host-var
+                    subPath: lib/ovn-ic
                     readOnly: true
+                  - mountPath: /host/var/tmp
+                    name: host-var
+                    subPath: tmp
                   - mountPath: /host/boot
                     name: host-boot
                     readOnly: true
+                  - mountPath: /host/run
+                    name: host-run
                   - mountPath: /host/sysroot
                     name: host-sysroot
+                  - mountPath: /host/sys/fs/cgroup
+                    name: sys-fs-cgroup
+                    readOnly: true
                   - mountPath: /host/dev/log
                     name: host-dev-log
+                  - mountPath: /host/tmp
+                    name: host-tmp
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
@@ -169,9 +189,9 @@ spec:
                   type: DirectoryOrCreate
                 name: host-var-recovery
               - hostPath:
-                  path: /var/lib/
+                  path: /var/
                   type: Directory
-                name: host-var-lib
+                name: host-var
               - hostPath:
                   path: /var/lib/kubelet
                   type: Directory
@@ -189,9 +209,21 @@ spec:
                   type: Directory
                 name: host-sysroot
               - hostPath:
+                  path: /run
+                  type: Directory
+                name: host-run
+              - hostPath:
+                  path: /sys/fs/cgroup
+                  type: Directory
+                name: sys-fs-cgroup
+              - hostPath:
                   path: /dev/log
                   type: Socket
                 name: host-dev-log
+              - hostPath:
+                  path: /tmp
+                  type: Directory
+                name: host-tmp
 `
 
 // MngClusterActDeleteBackupNS deletes namespace

--- a/tests/kuttl/tests/backup-complete/02-assert.yaml
+++ b/tests/kuttl/tests/backup-complete/02-assert.yaml
@@ -179,32 +179,52 @@ spec:
               - mountPath: /host/usr/local
                 name: host-usrlocal
                 readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
               - mountPath: /host/proc
                 name: host-proc
                 readOnly: true
               - mountPath: /host/etc
                 name: host-etc
-                readOnly: true
               - mountPath: /host/var/recovery
                 name: host-var-recovery
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/etcd
+                name: host-var
+                subPath: lib/etcd
+                readOnly: true
               - mountPath: /host/var/lib/kubelet
                 name: host-var-lib-kubelet
                 readOnly: true
-              - mountPath: /host/var/lib/etcd
-                name: host-var-lib
-                subPath: etcd
-                readOnly: true
               - mountPath: /host/var/lib/ovn-ic
-                name: host-var-lib
-                subPath: ovn-ic
+                name: host-var
+                subPath: lib/ovn-ic
                 readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
+              - mountPath: /host/run
+                name: host-run
               - mountPath: /host/sysroot
                 name: host-sysroot
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
               - mountPath: /host/dev/log
                 name: host-dev-log
+              - mountPath: /host/tmp
+                name: host-tmp
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
@@ -227,9 +247,9 @@ spec:
                 type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
-                path: /var/lib/
+                path: /var/
                 type: Directory
-              name: host-var-lib
+              name: host-var
             - hostPath:
                 path: /var/lib/kubelet
                 type: Directory
@@ -247,9 +267,21 @@ spec:
                 type: Directory
               name: host-sysroot
             - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
                 path: /dev/log
                 type: Socket
               name: host-dev-log
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -305,32 +337,52 @@ spec:
               - mountPath: /host/usr/local
                 name: host-usrlocal
                 readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
               - mountPath: /host/proc
                 name: host-proc
                 readOnly: true
               - mountPath: /host/etc
                 name: host-etc
-                readOnly: true
               - mountPath: /host/var/recovery
                 name: host-var-recovery
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/etcd
+                name: host-var
+                subPath: lib/etcd
+                readOnly: true
               - mountPath: /host/var/lib/kubelet
                 name: host-var-lib-kubelet
                 readOnly: true
-              - mountPath: /host/var/lib/etcd
-                name: host-var-lib
-                subPath: etcd
-                readOnly: true
               - mountPath: /host/var/lib/ovn-ic
-                name: host-var-lib
-                subPath: ovn-ic
+                name: host-var
+                subPath: lib/ovn-ic
                 readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
+              - mountPath: /host/run
+                name: host-run
               - mountPath: /host/sysroot
                 name: host-sysroot
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
               - mountPath: /host/dev/log
                 name: host-dev-log
+              - mountPath: /host/tmp
+                name: host-tmp
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
@@ -353,9 +405,9 @@ spec:
                 type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
-                path: /var/lib/
+                path: /var/
                 type: Directory
-              name: host-var-lib
+              name: host-var
             - hostPath:
                 path: /var/lib/kubelet
                 type: Directory
@@ -373,9 +425,21 @@ spec:
                 type: Directory
               name: host-sysroot
             - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
                 path: /dev/log
                 type: Socket
               name: host-dev-log
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -431,32 +495,52 @@ spec:
               - mountPath: /host/usr/local
                 name: host-usrlocal
                 readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
               - mountPath: /host/proc
                 name: host-proc
                 readOnly: true
               - mountPath: /host/etc
                 name: host-etc
-                readOnly: true
               - mountPath: /host/var/recovery
                 name: host-var-recovery
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/etcd
+                name: host-var
+                subPath: lib/etcd
+                readOnly: true
               - mountPath: /host/var/lib/kubelet
                 name: host-var-lib-kubelet
                 readOnly: true
-              - mountPath: /host/var/lib/etcd
-                name: host-var-lib
-                subPath: etcd
-                readOnly: true
               - mountPath: /host/var/lib/ovn-ic
-                name: host-var-lib
-                subPath: ovn-ic
+                name: host-var
+                subPath: lib/ovn-ic
                 readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
+              - mountPath: /host/run
+                name: host-run
               - mountPath: /host/sysroot
                 name: host-sysroot
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
               - mountPath: /host/dev/log
                 name: host-dev-log
+              - mountPath: /host/tmp
+                name: host-tmp
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
@@ -479,9 +563,9 @@ spec:
                 type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
-                path: /var/lib/
+                path: /var/
                 type: Directory
-              name: host-var-lib
+              name: host-var
             - hostPath:
                 path: /var/lib/kubelet
                 type: Directory
@@ -499,9 +583,21 @@ spec:
                 type: Directory
               name: host-sysroot
             - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
                 path: /dev/log
                 type: Socket
               name: host-dev-log
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -557,32 +653,52 @@ spec:
               - mountPath: /host/usr/local
                 name: host-usrlocal
                 readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
               - mountPath: /host/proc
                 name: host-proc
                 readOnly: true
               - mountPath: /host/etc
                 name: host-etc
-                readOnly: true
               - mountPath: /host/var/recovery
                 name: host-var-recovery
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/etcd
+                name: host-var
+                subPath: lib/etcd
+                readOnly: true
               - mountPath: /host/var/lib/kubelet
                 name: host-var-lib-kubelet
                 readOnly: true
-              - mountPath: /host/var/lib/etcd
-                name: host-var-lib
-                subPath: etcd
-                readOnly: true
               - mountPath: /host/var/lib/ovn-ic
-                name: host-var-lib
-                subPath: ovn-ic
+                name: host-var
+                subPath: lib/ovn-ic
                 readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
+              - mountPath: /host/run
+                name: host-run
               - mountPath: /host/sysroot
                 name: host-sysroot
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
               - mountPath: /host/dev/log
                 name: host-dev-log
+              - mountPath: /host/tmp
+                name: host-tmp
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
@@ -605,9 +721,9 @@ spec:
                 type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
-                path: /var/lib/
+                path: /var/
                 type: Directory
-              name: host-var-lib
+              name: host-var
             - hostPath:
                 path: /var/lib/kubelet
                 type: Directory
@@ -625,9 +741,21 @@ spec:
                 type: Directory
               name: host-sysroot
             - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
                 path: /dev/log
                 type: Socket
               name: host-dev-log
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
 ---
 
 

--- a/tests/kuttl/tests/backup-fail/02-assert.yaml
+++ b/tests/kuttl/tests/backup-fail/02-assert.yaml
@@ -179,32 +179,52 @@ spec:
               - mountPath: /host/usr/local
                 name: host-usrlocal
                 readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
               - mountPath: /host/proc
                 name: host-proc
                 readOnly: true
               - mountPath: /host/etc
                 name: host-etc
-                readOnly: true
               - mountPath: /host/var/recovery
                 name: host-var-recovery
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/etcd
+                name: host-var
+                subPath: lib/etcd
+                readOnly: true
               - mountPath: /host/var/lib/kubelet
                 name: host-var-lib-kubelet
                 readOnly: true
-              - mountPath: /host/var/lib/etcd
-                name: host-var-lib
-                subPath: etcd
-                readOnly: true
               - mountPath: /host/var/lib/ovn-ic
-                name: host-var-lib
-                subPath: ovn-ic
+                name: host-var
+                subPath: lib/ovn-ic
                 readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
+              - mountPath: /host/run
+                name: host-run
               - mountPath: /host/sysroot
                 name: host-sysroot
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
               - mountPath: /host/dev/log
                 name: host-dev-log
+              - mountPath: /host/tmp
+                name: host-tmp
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
@@ -227,9 +247,9 @@ spec:
                 type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
-                path: /var/lib/
+                path: /var/
                 type: Directory
-              name: host-var-lib
+              name: host-var
             - hostPath:
                 path: /var/lib/kubelet
                 type: Directory
@@ -247,9 +267,21 @@ spec:
                 type: Directory
               name: host-sysroot
             - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
                 path: /dev/log
                 type: Socket
               name: host-dev-log
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -305,32 +337,52 @@ spec:
               - mountPath: /host/usr/local
                 name: host-usrlocal
                 readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
               - mountPath: /host/proc
                 name: host-proc
                 readOnly: true
               - mountPath: /host/etc
                 name: host-etc
-                readOnly: true
               - mountPath: /host/var/recovery
                 name: host-var-recovery
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/etcd
+                name: host-var
+                subPath: lib/etcd
+                readOnly: true
               - mountPath: /host/var/lib/kubelet
                 name: host-var-lib-kubelet
                 readOnly: true
-              - mountPath: /host/var/lib/etcd
-                name: host-var-lib
-                subPath: etcd
-                readOnly: true
               - mountPath: /host/var/lib/ovn-ic
-                name: host-var-lib
-                subPath: ovn-ic
+                name: host-var
+                subPath: lib/ovn-ic
                 readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
+              - mountPath: /host/run
+                name: host-run
               - mountPath: /host/sysroot
                 name: host-sysroot
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
               - mountPath: /host/dev/log
                 name: host-dev-log
+              - mountPath: /host/tmp
+                name: host-tmp
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
@@ -353,9 +405,9 @@ spec:
                 type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
-                path: /var/lib/
+                path: /var/
                 type: Directory
-              name: host-var-lib
+              name: host-var
             - hostPath:
                 path: /var/lib/kubelet
                 type: Directory
@@ -373,9 +425,21 @@ spec:
                 type: Directory
               name: host-sysroot
             - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
                 path: /dev/log
                 type: Socket
               name: host-dev-log
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -431,32 +495,52 @@ spec:
               - mountPath: /host/usr/local
                 name: host-usrlocal
                 readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
               - mountPath: /host/proc
                 name: host-proc
                 readOnly: true
               - mountPath: /host/etc
                 name: host-etc
-                readOnly: true
               - mountPath: /host/var/recovery
                 name: host-var-recovery
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/etcd
+                name: host-var
+                subPath: lib/etcd
+                readOnly: true
               - mountPath: /host/var/lib/kubelet
                 name: host-var-lib-kubelet
                 readOnly: true
-              - mountPath: /host/var/lib/etcd
-                name: host-var-lib
-                subPath: etcd
-                readOnly: true
               - mountPath: /host/var/lib/ovn-ic
-                name: host-var-lib
-                subPath: ovn-ic
+                name: host-var
+                subPath: lib/ovn-ic
                 readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
+              - mountPath: /host/run
+                name: host-run
               - mountPath: /host/sysroot
                 name: host-sysroot
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
               - mountPath: /host/dev/log
                 name: host-dev-log
+              - mountPath: /host/tmp
+                name: host-tmp
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
@@ -479,9 +563,9 @@ spec:
                 type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
-                path: /var/lib/
+                path: /var/
                 type: Directory
-              name: host-var-lib
+              name: host-var
             - hostPath:
                 path: /var/lib/kubelet
                 type: Directory
@@ -499,9 +583,21 @@ spec:
                 type: Directory
               name: host-sysroot
             - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
                 path: /dev/log
                 type: Socket
               name: host-dev-log
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -557,32 +653,52 @@ spec:
               - mountPath: /host/usr/local
                 name: host-usrlocal
                 readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
               - mountPath: /host/proc
                 name: host-proc
                 readOnly: true
               - mountPath: /host/etc
                 name: host-etc
-                readOnly: true
               - mountPath: /host/var/recovery
                 name: host-var-recovery
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/etcd
+                name: host-var
+                subPath: lib/etcd
+                readOnly: true
               - mountPath: /host/var/lib/kubelet
                 name: host-var-lib-kubelet
                 readOnly: true
-              - mountPath: /host/var/lib/etcd
-                name: host-var-lib
-                subPath: etcd
-                readOnly: true
               - mountPath: /host/var/lib/ovn-ic
-                name: host-var-lib
-                subPath: ovn-ic
+                name: host-var
+                subPath: lib/ovn-ic
                 readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
+              - mountPath: /host/run
+                name: host-run
               - mountPath: /host/sysroot
                 name: host-sysroot
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
               - mountPath: /host/dev/log
                 name: host-dev-log
+              - mountPath: /host/tmp
+                name: host-tmp
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
@@ -605,9 +721,9 @@ spec:
                 type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
-                path: /var/lib/
+                path: /var/
                 type: Directory
-              name: host-var-lib
+              name: host-var
             - hostPath:
                 path: /var/lib/kubelet
                 type: Directory
@@ -625,9 +741,21 @@ spec:
                 type: Directory
               name: host-sysroot
             - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
                 path: /dev/log
                 type: Socket
               name: host-dev-log
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
 ---
 
 

--- a/tests/kuttl/tests/backup-partial-complete/02-assert.yaml
+++ b/tests/kuttl/tests/backup-partial-complete/02-assert.yaml
@@ -179,32 +179,52 @@ spec:
               - mountPath: /host/usr/local
                 name: host-usrlocal
                 readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
               - mountPath: /host/proc
                 name: host-proc
                 readOnly: true
               - mountPath: /host/etc
                 name: host-etc
-                readOnly: true
               - mountPath: /host/var/recovery
                 name: host-var-recovery
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/etcd
+                name: host-var
+                subPath: lib/etcd
+                readOnly: true
               - mountPath: /host/var/lib/kubelet
                 name: host-var-lib-kubelet
                 readOnly: true
-              - mountPath: /host/var/lib/etcd
-                name: host-var-lib
-                subPath: etcd
-                readOnly: true
               - mountPath: /host/var/lib/ovn-ic
-                name: host-var-lib
-                subPath: ovn-ic
+                name: host-var
+                subPath: lib/ovn-ic
                 readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
+              - mountPath: /host/run
+                name: host-run
               - mountPath: /host/sysroot
                 name: host-sysroot
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
               - mountPath: /host/dev/log
                 name: host-dev-log
+              - mountPath: /host/tmp
+                name: host-tmp
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
@@ -227,9 +247,9 @@ spec:
                 type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
-                path: /var/lib/
+                path: /var/
                 type: Directory
-              name: host-var-lib
+              name: host-var
             - hostPath:
                 path: /var/lib/kubelet
                 type: Directory
@@ -247,9 +267,21 @@ spec:
                 type: Directory
               name: host-sysroot
             - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
                 path: /dev/log
                 type: Socket
               name: host-dev-log
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -305,32 +337,52 @@ spec:
               - mountPath: /host/usr/local
                 name: host-usrlocal
                 readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
               - mountPath: /host/proc
                 name: host-proc
                 readOnly: true
               - mountPath: /host/etc
                 name: host-etc
-                readOnly: true
               - mountPath: /host/var/recovery
                 name: host-var-recovery
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/etcd
+                name: host-var
+                subPath: lib/etcd
+                readOnly: true
               - mountPath: /host/var/lib/kubelet
                 name: host-var-lib-kubelet
                 readOnly: true
-              - mountPath: /host/var/lib/etcd
-                name: host-var-lib
-                subPath: etcd
-                readOnly: true
               - mountPath: /host/var/lib/ovn-ic
-                name: host-var-lib
-                subPath: ovn-ic
+                name: host-var
+                subPath: lib/ovn-ic
                 readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
+              - mountPath: /host/run
+                name: host-run
               - mountPath: /host/sysroot
                 name: host-sysroot
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
               - mountPath: /host/dev/log
                 name: host-dev-log
+              - mountPath: /host/tmp
+                name: host-tmp
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
@@ -353,9 +405,9 @@ spec:
                 type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
-                path: /var/lib/
+                path: /var/
                 type: Directory
-              name: host-var-lib
+              name: host-var
             - hostPath:
                 path: /var/lib/kubelet
                 type: Directory
@@ -373,9 +425,21 @@ spec:
                 type: Directory
               name: host-sysroot
             - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
                 path: /dev/log
                 type: Socket
               name: host-dev-log
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -431,32 +495,52 @@ spec:
               - mountPath: /host/usr/local
                 name: host-usrlocal
                 readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
               - mountPath: /host/proc
                 name: host-proc
                 readOnly: true
               - mountPath: /host/etc
                 name: host-etc
-                readOnly: true
               - mountPath: /host/var/recovery
                 name: host-var-recovery
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/etcd
+                name: host-var
+                subPath: lib/etcd
+                readOnly: true
               - mountPath: /host/var/lib/kubelet
                 name: host-var-lib-kubelet
                 readOnly: true
-              - mountPath: /host/var/lib/etcd
-                name: host-var-lib
-                subPath: etcd
-                readOnly: true
               - mountPath: /host/var/lib/ovn-ic
-                name: host-var-lib
-                subPath: ovn-ic
+                name: host-var
+                subPath: lib/ovn-ic
                 readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
+              - mountPath: /host/run
+                name: host-run
               - mountPath: /host/sysroot
                 name: host-sysroot
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
               - mountPath: /host/dev/log
                 name: host-dev-log
+              - mountPath: /host/tmp
+                name: host-tmp
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
@@ -479,9 +563,9 @@ spec:
                 type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
-                path: /var/lib/
+                path: /var/
                 type: Directory
-              name: host-var-lib
+              name: host-var
             - hostPath:
                 path: /var/lib/kubelet
                 type: Directory
@@ -499,9 +583,21 @@ spec:
                 type: Directory
               name: host-sysroot
             - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
                 path: /dev/log
                 type: Socket
               name: host-dev-log
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -557,32 +653,52 @@ spec:
               - mountPath: /host/usr/local
                 name: host-usrlocal
                 readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr
+                subPath: share/containers
+                readOnly: true
               - mountPath: /host/proc
                 name: host-proc
                 readOnly: true
               - mountPath: /host/etc
                 name: host-etc
-                readOnly: true
               - mountPath: /host/var/recovery
                 name: host-var-recovery
+              - mountPath: /host/var/lib/containers
+                name: host-var
+                subPath: lib/containers
+              - mountPath: /host/var/lib/cni
+                name: host-var
+                subPath: lib/cni
+                readOnly: true
+              - mountPath: /host/var/lib/etcd
+                name: host-var
+                subPath: lib/etcd
+                readOnly: true
               - mountPath: /host/var/lib/kubelet
                 name: host-var-lib-kubelet
                 readOnly: true
-              - mountPath: /host/var/lib/etcd
-                name: host-var-lib
-                subPath: etcd
-                readOnly: true
               - mountPath: /host/var/lib/ovn-ic
-                name: host-var-lib
-                subPath: ovn-ic
+                name: host-var
+                subPath: lib/ovn-ic
                 readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var
+                subPath: tmp
               - mountPath: /host/boot
                 name: host-boot
                 readOnly: true
+              - mountPath: /host/run
+                name: host-run
               - mountPath: /host/sysroot
                 name: host-sysroot
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
               - mountPath: /host/dev/log
                 name: host-dev-log
+              - mountPath: /host/tmp
+                name: host-tmp
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
@@ -605,9 +721,9 @@ spec:
                 type: DirectoryOrCreate
               name: host-var-recovery
             - hostPath:
-                path: /var/lib/
+                path: /var/
                 type: Directory
-              name: host-var-lib
+              name: host-var
             - hostPath:
                 path: /var/lib/kubelet
                 type: Directory
@@ -625,9 +741,21 @@ spec:
                 type: Directory
               name: host-sysroot
             - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+            - hostPath:
                 path: /dev/log
                 type: Socket
               name: host-dev-log
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
 ---
 
 


### PR DESCRIPTION
This PR addresses the failing upgrade-recovery backup Kubernetes job by adding the necessary mounts to support running podman in lieu of the changes made to the etcdctl dl (ref: https://github.com/openshift/cluster-etcd-operator/commit/45e54425b4fc945136f37eb36e860b076e0a07dd).

Note that by mounting `/run` directory, the `/run/ostree-booted` flag file causes issues when also mounted with other podman related dependencies and `/sysroot`. Thus, the `/run/ostree-booted` flag file is temporarily renamed to `/run/ostree-booted.tmp` to complete the backup process. This file is renamed to the original value before exiting the `LaunchBackup()` function.

/cc @jc-rh @donpenney