### PR TITLE
 OCPBUGS-22161: Disable http2 for kube-rbac-proxy due to CVE-2023-39325

### DIFF
--- a/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -399,7 +399,8 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: quay.io/openshift/origin-kube-rbac-proxy:4.12
+                - --http2-disable=true
+                image: quay.io/openshift/origin-kube-rbac-proxy:4.15
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,12 +10,13 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/openshift/origin-kube-rbac-proxy:4.12
+        image: quay.io/openshift/origin-kube-rbac-proxy:4.15
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
         - "--v=10"
+        - "--http2-disable=true"
         ports:
         - containerPort: 8443
           name: https


### PR DESCRIPTION
Tested with latest upstream kube-rbac-proxy:4.15 @sha256:e2def4213ec0657e72eb790ae8a115511d5b8f164a62d3568d2f1bff189917e8

Without the flag:

```
$ ▶ for PROTO in h3 h2 http/1.1 http/1.0; do oc --as=system:admin -n openshift-cluster-group-upgrades exec deployment/cluster-group-upgrades-controller-manager-v2 -- openssl s_client -connect localhost:8443 -alpn "${PROTO}" 2>/dev/null | grep -i alpn;done
No ALPN negotiated
ALPN protocol: h2
ALPN protocol: http/1.1
No ALPN negotiated
```

With the flag:
```
$ ▶ for PROTO in h3 h2 http/1.1 http/1.0; do oc --as=system:admin -n openshift-cluster-group-upgrades exec deployment/cluster-group-upgrades-controller-manager-v2 -- openssl s_client -connect localhost:8443 -alpn "${PROTO}" 2>/dev/null | grep -i alpn;done
No ALPN negotiated
No ALPN negotiated
ALPN protocol: http/1.1
No ALPN negotiated
```
