### PR TITLE
OCPBUGS-22973: Support object-templates-raw for config policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ testbin/*
 *~
 
 # Debug binary
-__debug_bin
+__debug_bin*

--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -1157,13 +1157,50 @@ func (r *ClusterGroupUpgradeReconciler) updateConfigurationPolicyForCopiedPolicy
 
 		// Ensure the resources referenced in the hub template policy exist if applicable
 		plcTmplDefSpec := plcTmplDef["spec"].(map[string]interface{})
-		configPlcTmpls := plcTmplDefSpec["object-templates"]
-		resolvedconfigPlcTmpls, err := r.updateConfigurationPolicyHubTemplate(
-			ctx, configPlcTmpls, clusterGroupUpgrade.GetNamespace(), managedPolicyName, managedPolicyNamespace)
-		if err != nil {
-			return err
+
+		// One and only one of [object-templates, object-templates-raw] should be defined
+		objectTemplatePresent := plcTmplDefSpec[utils.ObjectTemplates] != nil
+		objectTemplateRawPresent := plcTmplDefSpec[utils.ObjectTemplatesRaw] != nil
+
+		var configPlcTmpls interface{}
+
+		switch {
+		case objectTemplatePresent && objectTemplateRawPresent:
+			return fmt.Errorf("[updateConfigurationPolicyForCopiedPolicy] found both %s and %s in policyTemplate", utils.ObjectTemplates, utils.ObjectTemplatesRaw)
+		case !objectTemplatePresent && !objectTemplateRawPresent:
+			return fmt.Errorf("[updateConfigurationPolicyForCopiedPolicy] can't find %s or %s in policyTemplate", utils.ObjectTemplates, utils.ObjectTemplatesRaw)
+		case objectTemplatePresent:
+			configPlcTmpls = plcTmplDefSpec[utils.ObjectTemplates].([]interface{})
+
+			resolvedconfigPlcTmpls, err := r.updateConfigurationPolicyHubTemplate(
+				ctx, configPlcTmpls, clusterGroupUpgrade.GetNamespace(), managedPolicyName, managedPolicyNamespace)
+			if err != nil {
+				return err
+			}
+
+			plcTmplDefSpec[utils.ObjectTemplates] = resolvedconfigPlcTmpls
+
+		case objectTemplateRawPresent:
+			// We cannot strip the raw templating here because they must be passed down to ACM
+			configPlcTmpls := plcTmplDefSpec[utils.ObjectTemplatesRaw].(string)
+
+			resolvedconfigPlcTmpls, err := r.updateConfigurationPolicyHubTemplate(
+				ctx, configPlcTmpls, clusterGroupUpgrade.GetNamespace(), managedPolicyName, managedPolicyNamespace)
+			if err != nil {
+				return err
+			}
+
+			stringResolved, err := utils.YamlToString(resolvedconfigPlcTmpls)
+			if err != nil {
+				return err
+			}
+
+			// If we do not trim the vertical bar here then the policy will be created with two
+			// vertical bars and will not be able to be marshalled later
+			plcTmplDefSpec[utils.ObjectTemplatesRaw] = strings.TrimPrefix(stringResolved, "|")
+		default:
+			return fmt.Errorf("[updateConfigurationPolicyForCopiedPolicy] can't find %s or %s in policyTemplate", utils.ObjectTemplates, utils.ObjectTemplatesRaw)
 		}
-		plcTmplDefSpec["object-templates"] = resolvedconfigPlcTmpls
 	}
 
 	return nil

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -130,13 +130,22 @@ const (
 // https://github.com/stolostron/cluster-backup-operator#steps-to-identify-backup-data
 const ExcludeFromClusterBackup = "velero.io/exclude-from-backup"
 
+// Object template constants
+const (
+	ObjectTemplates    = "object-templates"
+	ObjectTemplatesRaw = "object-templates-raw"
+)
+
 // Policy errors
 const (
 	PlcMissTmplDef           = "policy is missing its spec.policy-templates.objectDefinition"
 	PlcMissTmplDefMeta       = "policy is missing its spec.policy-templates.objectDefinition.metadata"
 	PlcMissTmplDefSpec       = "policy is missing its spec.policy-templates.objectDefinition.spec"
-	ConfigPlcMissObjTmpl     = "policy is missing its spec.policy-templates.objectDefinition.spec.object-templates"
+	ConfigPlcFailRawMarshal  = "policy was unable to be unmmarshalled from object-templates-raw"
+	ConfigPlcHasBothObjTmpl  = "policy has both spec.policy-templates.objectDefinition.spec.object-templates and spec.policy-templates.objectDefinition.spec.object-templates-raw"
+	ConfigPlcMissAnyObjTmpl  = "policy is missing both spec.policy-templates.objectDefinition.spec.object-templates and spec.policy-templates.objectDefinition.spec.object-templates-raw"
 	ConfigPlcMissObjTmplDef  = "policy is missing its spec.policy-templates.objectDefinition.spec.object-templates.objectDefinition"
+	ConfigPlcRawObjTmplErr   = "policy defines spec.policy-templates.objectDefinition.spec.object-templates-raw but is empty"
 	PlcHasHubTmplErr         = "policy has hub template error, check the configuration policy's annotation 'policy.open-cluster-management.io/hub-templates-error' for detail"
 	PlcHubTmplFmtErr         = "template format is not supported in TALM"
 	PlcHubTmplFuncErr        = "template function is not supported in TALM"

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -146,6 +146,7 @@ const (
 	ConfigPlcMissAnyObjTmpl  = "policy is missing both spec.policy-templates.objectDefinition.spec.object-templates and spec.policy-templates.objectDefinition.spec.object-templates-raw"
 	ConfigPlcMissObjTmplDef  = "policy is missing its spec.policy-templates.objectDefinition.spec.object-templates.objectDefinition"
 	ConfigPlcRawObjTmplErr   = "policy defines spec.policy-templates.objectDefinition.spec.object-templates-raw but is empty"
+	Placeholder				 = "placeholder"
 	PlcHasHubTmplErr         = "policy has hub template error, check the configuration policy's annotation 'policy.open-cluster-management.io/hub-templates-error' for detail"
 	PlcHubTmplFmtErr         = "template format is not supported in TALM"
 	PlcHubTmplFuncErr        = "template function is not supported in TALM"

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -146,7 +146,7 @@ const (
 	ConfigPlcMissAnyObjTmpl  = "policy is missing both spec.policy-templates.objectDefinition.spec.object-templates and spec.policy-templates.objectDefinition.spec.object-templates-raw"
 	ConfigPlcMissObjTmplDef  = "policy is missing its spec.policy-templates.objectDefinition.spec.object-templates.objectDefinition"
 	ConfigPlcRawObjTmplErr   = "policy defines spec.policy-templates.objectDefinition.spec.object-templates-raw but is empty"
-	Placeholder				 = "placeholder"
+	Placeholder              = "placeholder"
 	PlcHasHubTmplErr         = "policy has hub template error, check the configuration policy's annotation 'policy.open-cluster-management.io/hub-templates-error' for detail"
 	PlcHubTmplFmtErr         = "template format is not supported in TALM"
 	PlcHubTmplFuncErr        = "template function is not supported in TALM"

--- a/controllers/utils/policy_template.go
+++ b/controllers/utils/policy_template.go
@@ -86,9 +86,9 @@ func VerifyHubTemplateFunctions(tmpl interface{}, policyName string) error {
 	var tmplStr string
 	var err error
 
-	switch tmpl.(type) {
+	switch tmpl := tmpl.(type) {
 	case string:
-		tmplStr = tmpl.(string)
+		tmplStr = tmpl
 	default:
 		tmplStr, err = YamlToString(tmpl)
 		if err != nil {
@@ -148,9 +148,9 @@ func (r *TemplateResolver) ProcessHubTemplateFunctions(tmpl interface{}) (interf
 	var tmplStr string
 	var err error
 
-	switch tmpl.(type) {
+	switch tmpl := tmpl.(type) {
 	case string:
-		tmplStr = tmpl.(string)
+		tmplStr = tmpl
 	default:
 		tmplStr, err = YamlToString(tmpl)
 		if err != nil {

--- a/controllers/utils/policy_template.go
+++ b/controllers/utils/policy_template.go
@@ -83,17 +83,9 @@ func YamlToString(y interface{}) (string, error) {
 // return error if the template is not supported
 func VerifyHubTemplateFunctions(tmpl interface{}, policyName string) error {
 
-	var tmplStr string
-	var err error
-
-	switch tmpl := tmpl.(type) {
-	case string:
-		tmplStr = tmpl
-	default:
-		tmplStr, err = YamlToString(tmpl)
-		if err != nil {
-			return err
-		}
+	tmplStr, err := typeConvertTemplateToString(tmpl)
+	if err != nil {
+		return err
 	}
 
 	hubTmplMatches := regexpHubTmplFunc.FindAllStringSubmatch(tmplStr, -1)
@@ -145,17 +137,9 @@ func VerifyHubTemplateFunctions(tmpl interface{}, policyName string) error {
 // to the CGU namespace and return the resolved template object
 func (r *TemplateResolver) ProcessHubTemplateFunctions(tmpl interface{}) (interface{}, error) {
 
-	var tmplStr string
-	var err error
-
-	switch tmpl := tmpl.(type) {
-	case string:
-		tmplStr = tmpl
-	default:
-		tmplStr, err = YamlToString(tmpl)
-		if err != nil {
-			return tmpl, err
-		}
+	tmplStr, err := typeConvertTemplateToString(tmpl)
+	if err != nil {
+		return tmpl, err
 	}
 
 	hubTmplMatches := regexpFromConfigMap.FindAllStringSubmatch(tmplStr, -1)
@@ -253,4 +237,19 @@ func (r *TemplateResolver) copyConfigmap(ctx context.Context, fromResource, toRe
 		}
 	}
 	return nil
+}
+
+func typeConvertTemplateToString(tmpl interface{}) (string, error) {
+	var tmplStr string
+	var err error
+
+	switch tmpl := tmpl.(type) {
+	case string:
+		tmplStr = tmpl
+	default:
+		// We don't need to check the err here because we will be returning it below anyway
+		tmplStr, err = YamlToString(tmpl)
+	}
+
+	return tmplStr, err
 }

--- a/controllers/utils/policy_util.go
+++ b/controllers/utils/policy_util.go
@@ -270,7 +270,7 @@ func StripObjectTemplatesRaw(tmplStr string) string {
 		// e.g. "{{ $my.example.var }}"
 
 		// Replace all plain usages of variable with placeholder
-		result = strings.ReplaceAll(result, item[0], "placeholder")
+		result = strings.ReplaceAll(result, item[0], Placeholder)
 	}
 
 	// Get all inline usage of declared ranges
@@ -283,7 +283,7 @@ func StripObjectTemplatesRaw(tmplStr string) string {
 		// e.g. "{{ .data.item }}"
 
 		// Replace all plain usages of inlines with placeholder
-		result = strings.ReplaceAll(result, item[0], "placeholder")
+		result = strings.ReplaceAll(result, item[0], Placeholder)
 	}
 
 	// Get everything between sets of brackets as substrings

--- a/controllers/utils/policy_util.go
+++ b/controllers/utils/policy_util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -165,14 +166,34 @@ func InspectPolicyObjects(policy *unstructured.Unstructured) (bool, error) {
 		}
 		plcTmplDefSpec := plcTmplDef["spec"].(map[string]interface{})
 
-		// Make sure the ConfigurationPolicy object-templates exists.
-		if plcTmplDefSpec["object-templates"] == nil {
-			return containsStatus, &PolicyErr{policyName, ConfigPlcMissObjTmpl}
+		// One and only one of [object-templates, object-templates-raw] should be defined
+		objectTemplatePresent := plcTmplDefSpec[ObjectTemplates] != nil
+		objectTemplateRawPresent := plcTmplDefSpec[ObjectTemplatesRaw] != nil
+
+		var configPlcTmpls interface{}
+
+		switch {
+		case objectTemplatePresent && objectTemplateRawPresent:
+			return containsStatus, &PolicyErr{policyName, ConfigPlcMissAnyObjTmpl}
+		case !objectTemplatePresent && !objectTemplateRawPresent:
+			return containsStatus, &PolicyErr{policyName, ConfigPlcHasBothObjTmpl}
+		case objectTemplatePresent:
+			configPlcTmpls = plcTmplDefSpec[ObjectTemplates].([]interface{})
+		case objectTemplateRawPresent:
+			stringTemplate := StripObjectTemplatesRaw(plcTmplDefSpec[ObjectTemplatesRaw].(string))
+
+			var err error
+			configPlcTmpls, err = StringToYaml(stringTemplate)
+			if err != nil {
+				return containsStatus, &PolicyErr{policyName, ConfigPlcFailRawMarshal}
+			}
+
+		default:
+			return containsStatus, &PolicyErr{policyName, ConfigPlcMissAnyObjTmpl}
 		}
-		configPlcTmpls := plcTmplDefSpec["object-templates"].([]interface{})
 
 		// Go through the ConfigurationPolicy object-templates.
-		for _, configPlcTmpl := range configPlcTmpls {
+		for _, configPlcTmpl := range configPlcTmpls.([]interface{}) {
 			// Make sure the objectDefinition of the ConfigurationPolicy object template exists.
 			if configPlcTmpl.(map[string]interface{})["objectDefinition"] == nil {
 				return containsStatus, &PolicyErr{policyName, ConfigPlcMissObjTmplDef}
@@ -188,6 +209,7 @@ func InspectPolicyObjects(policy *unstructured.Unstructured) (bool, error) {
 		if err != nil {
 			return containsStatus, err
 		}
+
 	}
 	return containsStatus, nil
 }
@@ -226,7 +248,62 @@ func UpdateManagedPolicyNamespaceList(policyNs map[string][]string, policyNameAr
 			break
 		}
 	}
-	if nsFound == false {
+	if !nsFound {
 		policyNs[crtPolicyName] = append(policyNs[crtPolicyName], crtPolicyNs)
 	}
+}
+
+// StripObjectTemplatesRaw removes all the ACM raw templating from a string and returns an interface
+// of what the object-templates would be if not for the raw templating
+func StripObjectTemplatesRaw(tmplStr string) string {
+
+	// Create a copy of the input since we will be editing it multiple times
+	result := tmplStr
+
+	// Get all variable usages
+	variableUsageRegex := regexp.MustCompile(`{{\s*\$[\w\.]*\s*}}`)
+	variableUsages := variableUsageRegex.FindAllStringSubmatch(result, -1)
+
+	// Get the usage of all of those variables
+	for _, item := range variableUsages {
+		// item[0] is the full usage of a variable
+		// e.g. "{{ $my.example.var }}"
+
+		// Replace all plain usages of variable with placeholder
+		result = strings.ReplaceAll(result, item[0], "placeholder")
+	}
+
+	// Get all inline usage of declared ranges
+	inlineUsageRegex := regexp.MustCompile(`{{\s*\.[\w\.]*\s*}}`)
+	inlineUsages := inlineUsageRegex.FindAllStringSubmatch(result, -1)
+
+	// Get the usage of all of those inlines
+	for _, item := range inlineUsages {
+		// item[0] is the full usage of a inline
+		// e.g. "{{ .data.item }}"
+
+		// Replace all plain usages of inlines with placeholder
+		result = strings.ReplaceAll(result, item[0], "placeholder")
+	}
+
+	// Get everything between sets of brackets as substrings
+	bracketRegex := regexp.MustCompile(`\{{[^}]+}\}`)
+
+	// Each result here will be a substring including the start and end brackets
+	// e.g. "{{ $example.var.usage }}"
+	bracketSubstrings := bracketRegex.FindAllStringSubmatch(result, -1)
+
+	// For our usage all our results will be an array with a single item
+	// so we will just use item[0] here
+	for _, item := range bracketSubstrings {
+		// We want to remove all the ACM templates but not the hub side templates
+		if strings.HasPrefix(item[0], "{{hub") && strings.HasSuffix(item[0], "hub}}") {
+			continue
+		}
+
+		// Else just delete the template line entirely, including the newline at the end
+		result = strings.Replace(result+"\n", item[0], "", 1)
+	}
+
+	return result
 }

--- a/controllers/validation.go
+++ b/controllers/validation.go
@@ -151,7 +151,7 @@ func (r *ClusterGroupUpgradeReconciler) validateOpenshiftUpgradeVersion(
 		// Check for all the required parameters needed to make the update graph HTTP call and retrieve the image
 		if versionInfoContainsEmptyString {
 			err = errors.New("policy with ClusterVersion must have upstream, channel, and version when image is not provided")
-		} else if (versionInfoContainsTemplate || versionInfoContainsPlaceholder) {
+		} else if versionInfoContainsTemplate || versionInfoContainsPlaceholder {
 			if clusterGroupUpgrade.Spec.PreCaching {
 				// return error if the fields contain templates
 				err = errors.New("templatized ClusterVersion fields not supported with precaching")

--- a/controllers/validation.go
+++ b/controllers/validation.go
@@ -40,7 +40,7 @@ func extractOCPVersionInfoFromPolicies(policies []*unstructured.Unstructured) (o
 				if object["spec"].(map[string]interface{})["upstream"] != nil {
 					nextUpstream := object["spec"].(map[string]interface{})["upstream"].(string)
 
-					if nextUpstream == "placeholder" {
+					if nextUpstream == utils.Placeholder {
 						return result, errors.New("templating cluster version fields not supported")
 					}
 
@@ -54,7 +54,7 @@ func extractOCPVersionInfoFromPolicies(policies []*unstructured.Unstructured) (o
 				if object["spec"].(map[string]interface{})["channel"] != nil {
 					nextChannel := object["spec"].(map[string]interface{})["channel"].(string)
 
-					if nextChannel == "placeholder" {
+					if nextChannel == utils.Placeholder {
 						return result, errors.New("templating cluster version fields not supported")
 					}
 
@@ -69,7 +69,7 @@ func extractOCPVersionInfoFromPolicies(policies []*unstructured.Unstructured) (o
 					if object["spec"].(map[string]interface{})["desiredUpdate"].(map[string]interface{})["version"] != nil {
 						nextVersion := object["spec"].(map[string]interface{})["desiredUpdate"].(map[string]interface{})["version"].(string)
 
-						if nextVersion == "placeholder" {
+						if nextVersion == utils.Placeholder {
 							return result, errors.New("templating cluster version fields not supported")
 						}
 
@@ -82,7 +82,7 @@ func extractOCPVersionInfoFromPolicies(policies []*unstructured.Unstructured) (o
 					if object["spec"].(map[string]interface{})["desiredUpdate"].(map[string]interface{})["image"] != nil {
 						nextImage := object["spec"].(map[string]interface{})["desiredUpdate"].(map[string]interface{})["image"].(string)
 
-						if nextImage == "placeholder" {
+						if nextImage == utils.Placeholder {
 							return result, errors.New("templating cluster version fields not supported")
 						}
 
@@ -146,7 +146,7 @@ func (r *ClusterGroupUpgradeReconciler) validateOpenshiftUpgradeVersion(
 		// Using a few temporary variables here makes the if below much more readable
 		versionInfoContainsEmptyString := versionInfo.upstream == "" || versionInfo.channel == "" || versionInfo.version == ""
 		versionInfoContainsTemplate := utils.ContainsTemplates(versionInfo.upstream) || utils.ContainsTemplates(versionInfo.channel) || utils.ContainsTemplates(versionInfo.version)
-		versionInfoContainsPlaceholder := versionInfo.upstream == "placeholder" || versionInfo.channel == "placeholder" || versionInfo.version == "placeholder"
+		versionInfoContainsPlaceholder := versionInfo.upstream == utils.Placeholder || versionInfo.channel == utils.Placeholder || versionInfo.version == utils.Placeholder
 
 		// Check for all the required parameters needed to make the update graph HTTP call and retrieve the image
 		if versionInfoContainsEmptyString {

--- a/controllers/validation.go
+++ b/controllers/validation.go
@@ -39,6 +39,11 @@ func extractOCPVersionInfoFromPolicies(policies []*unstructured.Unstructured) (o
 
 				if object["spec"].(map[string]interface{})["upstream"] != nil {
 					nextUpstream := object["spec"].(map[string]interface{})["upstream"].(string)
+
+					if nextUpstream == "placeholder" {
+						return result, errors.New("templating cluster version fields not supported")
+					}
+
 					if result.upstream == "" {
 						result.upstream = nextUpstream
 					} else if result.upstream != nextUpstream {
@@ -48,6 +53,11 @@ func extractOCPVersionInfoFromPolicies(policies []*unstructured.Unstructured) (o
 
 				if object["spec"].(map[string]interface{})["channel"] != nil {
 					nextChannel := object["spec"].(map[string]interface{})["channel"].(string)
+
+					if nextChannel == "placeholder" {
+						return result, errors.New("templating cluster version fields not supported")
+					}
+
 					if result.channel == "" {
 						result.channel = nextChannel
 					} else if result.channel != nextChannel {
@@ -58,6 +68,11 @@ func extractOCPVersionInfoFromPolicies(policies []*unstructured.Unstructured) (o
 				if object["spec"].(map[string]interface{})["desiredUpdate"] != nil {
 					if object["spec"].(map[string]interface{})["desiredUpdate"].(map[string]interface{})["version"] != nil {
 						nextVersion := object["spec"].(map[string]interface{})["desiredUpdate"].(map[string]interface{})["version"].(string)
+
+						if nextVersion == "placeholder" {
+							return result, errors.New("templating cluster version fields not supported")
+						}
+
 						if result.version == "" {
 							result.version = nextVersion
 						} else if result.version != nextVersion {
@@ -66,6 +81,11 @@ func extractOCPVersionInfoFromPolicies(policies []*unstructured.Unstructured) (o
 					}
 					if object["spec"].(map[string]interface{})["desiredUpdate"].(map[string]interface{})["image"] != nil {
 						nextImage := object["spec"].(map[string]interface{})["desiredUpdate"].(map[string]interface{})["image"].(string)
+
+						if nextImage == "placeholder" {
+							return result, errors.New("templating cluster version fields not supported")
+						}
+
 						if result.image == "" {
 							result.image = nextImage
 						} else if result.image != nextImage {
@@ -122,14 +142,18 @@ func (r *ClusterGroupUpgradeReconciler) validateOpenshiftUpgradeVersion(
 		if !versionInfo.clusterVersionCRFound || versionInfo.image != "" {
 			return nil
 		}
+
+		// Using a few temporary variables here makes the if below much more readable
+		versionInfoContainsEmptyString := versionInfo.upstream == "" || versionInfo.channel == "" || versionInfo.version == ""
+		versionInfoContainsTemplate := utils.ContainsTemplates(versionInfo.upstream) || utils.ContainsTemplates(versionInfo.channel) || utils.ContainsTemplates(versionInfo.version)
+		versionInfoContainsPlaceholder := versionInfo.upstream == "placeholder" || versionInfo.channel == "placeholder" || versionInfo.version == "placeholder"
+
 		// Check for all the required parameters needed to make the update graph HTTP call and retrieve the image
-		if versionInfo.upstream == "" || versionInfo.channel == "" || versionInfo.version == "" {
+		if versionInfoContainsEmptyString {
 			err = errors.New("policy with ClusterVersion must have upstream, channel, and version when image is not provided")
-		} else if utils.ContainsTemplates(versionInfo.upstream) || utils.ContainsTemplates(versionInfo.channel) || utils.ContainsTemplates(versionInfo.version) {
-			if clusterGroupUpgrade.Spec.PreCaching {
-				// return error if the fields contain templates
-				err = errors.New("templatized ClusterVersion fields not supported with precaching")
-			}
+		} else if clusterGroupUpgrade.Spec.PreCaching && (versionInfoContainsTemplate || versionInfoContainsPlaceholder) {
+			// return error if the fields contain templates
+			err = errors.New("templatized ClusterVersion fields not supported with precaching")
 		} else {
 			_, err = r.getImageForVersionFromUpdateGraph(versionInfo.upstream, versionInfo.channel, versionInfo.version)
 		}

--- a/controllers/validation.go
+++ b/controllers/validation.go
@@ -151,9 +151,11 @@ func (r *ClusterGroupUpgradeReconciler) validateOpenshiftUpgradeVersion(
 		// Check for all the required parameters needed to make the update graph HTTP call and retrieve the image
 		if versionInfoContainsEmptyString {
 			err = errors.New("policy with ClusterVersion must have upstream, channel, and version when image is not provided")
-		} else if clusterGroupUpgrade.Spec.PreCaching && (versionInfoContainsTemplate || versionInfoContainsPlaceholder) {
-			// return error if the fields contain templates
-			err = errors.New("templatized ClusterVersion fields not supported with precaching")
+		} else if (versionInfoContainsTemplate || versionInfoContainsPlaceholder) {
+			if clusterGroupUpgrade.Spec.PreCaching {
+				// return error if the fields contain templates
+				err = errors.New("templatized ClusterVersion fields not supported with precaching")
+			}
 		} else {
 			_, err = r.getImageForVersionFromUpdateGraph(versionInfo.upstream, versionInfo.channel, versionInfo.version)
 		}


### PR DESCRIPTION
ACM has support for object-templates-raw that was backported to 2.7, so we should support it in TALM as well
