### PR TITLE
OCPBUGS-25307: Replace child /var/lib volume mounts with parent /var/lib mount

### DIFF
--- a/controllers/templates/backup-templates.go
+++ b/controllers/templates/backup-templates.go
@@ -136,20 +136,8 @@ spec:
                   - mountPath: /host/usr/share/containers
                     name: host-usr-share-containers
                     readOnly: true
-                  - mountPath: /host/var/lib/cni
-                    name: host-var-lib-cni
-                    readOnly: true
-                  - mountPath: /host/var/lib/containers
-                    name: host-var-lib-containers
-                  - mountPath: /host/var/lib/etcd
-                    name: host-var-lib-etcd
-                    readOnly: true
-                  - mountPath: /host/var/lib/kubelet
-                    name: host-var-lib-kubelet
-                    readOnly: true
-                  - mountPath: /host/var/lib/ovn-ic
-                    name: host-var-lib-ovn-ic
-                    readOnly: true
+                  - mountPath: /host/var/lib
+                    name: host-var-lib
                   - mountPath: /host/var/recovery
                     name: host-var-recovery
                   - mountPath: /host/var/tmp
@@ -215,25 +203,9 @@ spec:
                   type: Directory
                 name: host-usr-share-containers
               - hostPath:
-                  path: /var/lib/cni
+                  path: /var/lib
                   type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/etcd
-                  type: Directory
-                name: host-var-lib-etcd
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/lib/ovn-ic
-                  type: Directory
-                name: host-var-lib-ovn-ic
+                name: host-var-lib
               - hostPath:
                   path: /var/recovery
                   type: DirectoryOrCreate

--- a/tests/kuttl/tests/backup-complete/02-assert.yaml
+++ b/tests/kuttl/tests/backup-complete/02-assert.yaml
@@ -194,20 +194,8 @@ spec:
                 - mountPath: /host/usr/share/containers
                   name: host-usr-share-containers
                   readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/etcd
-                  name: host-var-lib-etcd
-                  readOnly: true
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/lib/ovn-ic
-                  name: host-var-lib-ovn-ic
-                  readOnly: true
+                - mountPath: /host/var/lib
+                  name: host-var-lib
                 - mountPath: /host/var/recovery
                   name: host-var-recovery
                 - mountPath: /host/var/tmp
@@ -273,25 +261,9 @@ spec:
                   type: Directory
                 name: host-usr-share-containers
               - hostPath:
-                  path: /var/lib/cni
+                  path: /var/lib
                   type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/etcd
-                  type: Directory
-                name: host-var-lib-etcd
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/lib/ovn-ic
-                  type: Directory
-                name: host-var-lib-ovn-ic
+                name: host-var-lib
               - hostPath:
                   path: /var/recovery
                   type: DirectoryOrCreate
@@ -374,20 +346,8 @@ spec:
                 - mountPath: /host/usr/share/containers
                   name: host-usr-share-containers
                   readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/etcd
-                  name: host-var-lib-etcd
-                  readOnly: true
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/lib/ovn-ic
-                  name: host-var-lib-ovn-ic
-                  readOnly: true
+                - mountPath: /host/var/lib
+                  name: host-var-lib
                 - mountPath: /host/var/recovery
                   name: host-var-recovery
                 - mountPath: /host/var/tmp
@@ -453,25 +413,9 @@ spec:
                   type: Directory
                 name: host-usr-share-containers
               - hostPath:
-                  path: /var/lib/cni
+                  path: /var/lib
                   type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/etcd
-                  type: Directory
-                name: host-var-lib-etcd
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/lib/ovn-ic
-                  type: Directory
-                name: host-var-lib-ovn-ic
+                name: host-var-lib
               - hostPath:
                   path: /var/recovery
                   type: DirectoryOrCreate
@@ -554,20 +498,8 @@ spec:
                 - mountPath: /host/usr/share/containers
                   name: host-usr-share-containers
                   readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/etcd
-                  name: host-var-lib-etcd
-                  readOnly: true
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/lib/ovn-ic
-                  name: host-var-lib-ovn-ic
-                  readOnly: true
+                - mountPath: /host/var/lib
+                  name: host-var-lib
                 - mountPath: /host/var/recovery
                   name: host-var-recovery
                 - mountPath: /host/var/tmp
@@ -633,25 +565,9 @@ spec:
                   type: Directory
                 name: host-usr-share-containers
               - hostPath:
-                  path: /var/lib/cni
+                  path: /var/lib
                   type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/etcd
-                  type: Directory
-                name: host-var-lib-etcd
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/lib/ovn-ic
-                  type: Directory
-                name: host-var-lib-ovn-ic
+                name: host-var-lib
               - hostPath:
                   path: /var/recovery
                   type: DirectoryOrCreate
@@ -734,20 +650,8 @@ spec:
                 - mountPath: /host/usr/share/containers
                   name: host-usr-share-containers
                   readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/etcd
-                  name: host-var-lib-etcd
-                  readOnly: true
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/lib/ovn-ic
-                  name: host-var-lib-ovn-ic
-                  readOnly: true
+                - mountPath: /host/var/lib
+                  name: host-var-lib
                 - mountPath: /host/var/recovery
                   name: host-var-recovery
                 - mountPath: /host/var/tmp
@@ -813,25 +717,9 @@ spec:
                   type: Directory
                 name: host-usr-share-containers
               - hostPath:
-                  path: /var/lib/cni
+                  path: /var/lib
                   type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/etcd
-                  type: Directory
-                name: host-var-lib-etcd
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/lib/ovn-ic
-                  type: Directory
-                name: host-var-lib-ovn-ic
+                name: host-var-lib
               - hostPath:
                   path: /var/recovery
                   type: DirectoryOrCreate

--- a/tests/kuttl/tests/backup-fail/02-assert.yaml
+++ b/tests/kuttl/tests/backup-fail/02-assert.yaml
@@ -194,20 +194,8 @@ spec:
                 - mountPath: /host/usr/share/containers
                   name: host-usr-share-containers
                   readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/etcd
-                  name: host-var-lib-etcd
-                  readOnly: true
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/lib/ovn-ic
-                  name: host-var-lib-ovn-ic
-                  readOnly: true
+                - mountPath: /host/var/lib
+                  name: host-var-lib
                 - mountPath: /host/var/recovery
                   name: host-var-recovery
                 - mountPath: /host/var/tmp
@@ -273,25 +261,9 @@ spec:
                   type: Directory
                 name: host-usr-share-containers
               - hostPath:
-                  path: /var/lib/cni
+                  path: /var/lib
                   type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/etcd
-                  type: Directory
-                name: host-var-lib-etcd
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/lib/ovn-ic
-                  type: Directory
-                name: host-var-lib-ovn-ic
+                name: host-var-lib
               - hostPath:
                   path: /var/recovery
                   type: DirectoryOrCreate
@@ -374,20 +346,8 @@ spec:
                 - mountPath: /host/usr/share/containers
                   name: host-usr-share-containers
                   readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/etcd
-                  name: host-var-lib-etcd
-                  readOnly: true
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/lib/ovn-ic
-                  name: host-var-lib-ovn-ic
-                  readOnly: true
+                - mountPath: /host/var/lib
+                  name: host-var-lib
                 - mountPath: /host/var/recovery
                   name: host-var-recovery
                 - mountPath: /host/var/tmp
@@ -453,25 +413,9 @@ spec:
                   type: Directory
                 name: host-usr-share-containers
               - hostPath:
-                  path: /var/lib/cni
+                  path: /var/lib
                   type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/etcd
-                  type: Directory
-                name: host-var-lib-etcd
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/lib/ovn-ic
-                  type: Directory
-                name: host-var-lib-ovn-ic
+                name: host-var-lib
               - hostPath:
                   path: /var/recovery
                   type: DirectoryOrCreate
@@ -554,20 +498,8 @@ spec:
                 - mountPath: /host/usr/share/containers
                   name: host-usr-share-containers
                   readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/etcd
-                  name: host-var-lib-etcd
-                  readOnly: true
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/lib/ovn-ic
-                  name: host-var-lib-ovn-ic
-                  readOnly: true
+                - mountPath: /host/var/lib
+                  name: host-var-lib
                 - mountPath: /host/var/recovery
                   name: host-var-recovery
                 - mountPath: /host/var/tmp
@@ -633,25 +565,9 @@ spec:
                   type: Directory
                 name: host-usr-share-containers
               - hostPath:
-                  path: /var/lib/cni
+                  path: /var/lib
                   type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/etcd
-                  type: Directory
-                name: host-var-lib-etcd
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/lib/ovn-ic
-                  type: Directory
-                name: host-var-lib-ovn-ic
+                name: host-var-lib
               - hostPath:
                   path: /var/recovery
                   type: DirectoryOrCreate
@@ -734,20 +650,8 @@ spec:
                 - mountPath: /host/usr/share/containers
                   name: host-usr-share-containers
                   readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/etcd
-                  name: host-var-lib-etcd
-                  readOnly: true
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/lib/ovn-ic
-                  name: host-var-lib-ovn-ic
-                  readOnly: true
+                - mountPath: /host/var/lib
+                  name: host-var-lib
                 - mountPath: /host/var/recovery
                   name: host-var-recovery
                 - mountPath: /host/var/tmp
@@ -813,25 +717,9 @@ spec:
                   type: Directory
                 name: host-usr-share-containers
               - hostPath:
-                  path: /var/lib/cni
+                  path: /var/lib
                   type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/etcd
-                  type: Directory
-                name: host-var-lib-etcd
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/lib/ovn-ic
-                  type: Directory
-                name: host-var-lib-ovn-ic
+                name: host-var-lib
               - hostPath:
                   path: /var/recovery
                   type: DirectoryOrCreate

--- a/tests/kuttl/tests/backup-partial-complete/02-assert.yaml
+++ b/tests/kuttl/tests/backup-partial-complete/02-assert.yaml
@@ -194,20 +194,8 @@ spec:
                 - mountPath: /host/usr/share/containers
                   name: host-usr-share-containers
                   readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/etcd
-                  name: host-var-lib-etcd
-                  readOnly: true
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/lib/ovn-ic
-                  name: host-var-lib-ovn-ic
-                  readOnly: true
+                - mountPath: /host/var/lib
+                  name: host-var-lib
                 - mountPath: /host/var/recovery
                   name: host-var-recovery
                 - mountPath: /host/var/tmp
@@ -273,25 +261,9 @@ spec:
                   type: Directory
                 name: host-usr-share-containers
               - hostPath:
-                  path: /var/lib/cni
+                  path: /var/lib
                   type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/etcd
-                  type: Directory
-                name: host-var-lib-etcd
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/lib/ovn-ic
-                  type: Directory
-                name: host-var-lib-ovn-ic
+                name: host-var-lib
               - hostPath:
                   path: /var/recovery
                   type: DirectoryOrCreate
@@ -374,20 +346,8 @@ spec:
                 - mountPath: /host/usr/share/containers
                   name: host-usr-share-containers
                   readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/etcd
-                  name: host-var-lib-etcd
-                  readOnly: true
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/lib/ovn-ic
-                  name: host-var-lib-ovn-ic
-                  readOnly: true
+                - mountPath: /host/var/lib
+                  name: host-var-lib
                 - mountPath: /host/var/recovery
                   name: host-var-recovery
                 - mountPath: /host/var/tmp
@@ -453,25 +413,9 @@ spec:
                   type: Directory
                 name: host-usr-share-containers
               - hostPath:
-                  path: /var/lib/cni
+                  path: /var/lib
                   type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/etcd
-                  type: Directory
-                name: host-var-lib-etcd
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/lib/ovn-ic
-                  type: Directory
-                name: host-var-lib-ovn-ic
+                name: host-var-lib
               - hostPath:
                   path: /var/recovery
                   type: DirectoryOrCreate
@@ -554,20 +498,8 @@ spec:
                 - mountPath: /host/usr/share/containers
                   name: host-usr-share-containers
                   readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/etcd
-                  name: host-var-lib-etcd
-                  readOnly: true
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/lib/ovn-ic
-                  name: host-var-lib-ovn-ic
-                  readOnly: true
+                - mountPath: /host/var/lib
+                  name: host-var-lib
                 - mountPath: /host/var/recovery
                   name: host-var-recovery
                 - mountPath: /host/var/tmp
@@ -633,25 +565,9 @@ spec:
                   type: Directory
                 name: host-usr-share-containers
               - hostPath:
-                  path: /var/lib/cni
+                  path: /var/lib
                   type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/etcd
-                  type: Directory
-                name: host-var-lib-etcd
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/lib/ovn-ic
-                  type: Directory
-                name: host-var-lib-ovn-ic
+                name: host-var-lib
               - hostPath:
                   path: /var/recovery
                   type: DirectoryOrCreate
@@ -734,20 +650,8 @@ spec:
                 - mountPath: /host/usr/share/containers
                   name: host-usr-share-containers
                   readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/etcd
-                  name: host-var-lib-etcd
-                  readOnly: true
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/lib/ovn-ic
-                  name: host-var-lib-ovn-ic
-                  readOnly: true
+                - mountPath: /host/var/lib
+                  name: host-var-lib
                 - mountPath: /host/var/recovery
                   name: host-var-recovery
                 - mountPath: /host/var/tmp
@@ -813,25 +717,9 @@ spec:
                   type: Directory
                 name: host-usr-share-containers
               - hostPath:
-                  path: /var/lib/cni
+                  path: /var/lib
                   type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/etcd
-                  type: Directory
-                name: host-var-lib-etcd
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/lib/ovn-ic
-                  type: Directory
-                name: host-var-lib-ovn-ic
+                name: host-var-lib
               - hostPath:
                   path: /var/recovery
                   type: DirectoryOrCreate


### PR DESCRIPTION
The child volume mounts for /var/lib are replaced with the parent /var/lib mount in order to increase support over older and newer OCP releases (note that OVN-IC was enabled with 4.14).

The commit was manually tested against the QE test bed (helix61). Below are sample output for validation.

**Backup-agent job**

```console
sakhoury-mac:~ sakhoury$ oc -n openshift-talo-backup get jobs
NAME           COMPLETIONS   DURATION   AGE
test-agent     1/1           14s        66s

sakhoury-mac:~ sakhoury$ 
sakhoury-mac:~ sakhoury$ oc -n openshift-talo-backup describe job test-agent
Name:                     test-agent
Namespace:                openshift-talo-backup
Selector:                 controller-uid=18c605fd-5b83-4434-8eb8-3fccd667a690
Labels:                   job-name=test-agent
Annotations:              batch.kubernetes.io/job-tracking: 
Parallelism:              1
Completions:              1
Completion Mode:          NonIndexed
Start Time:               Thu, 14 Dec 2023 11:48:31 -0500
Completed At:             Thu, 14 Dec 2023 11:48:45 -0500
Duration:                 14s
Active Deadline Seconds:  480s
Pods Statuses:            0 Active (0 Ready) / 1 Succeeded / 0 Failed
Pod Template:
  Labels:           controller-uid=18c605fd-5b83-4434-8eb8-3fccd667a690
                    job-name=test-agent
  Annotations:      target.workload.openshift.io/management: {"effect":"PreferredDuringScheduling"}
  Service Account:  backup-agent
  Containers:
   container-image:
    Image:      quay.io/sakhoury/cluster-group-upgrades-operator-recovery:4.15.0
    Port:       <none>
    Host Port:  <none>
    Args:
      launchBackup
    Environment:  <none>
    Mounts:
      /host from host (rw)
      /host/boot from host-boot (ro)
      /host/dev/log from host-dev-log (rw)
      /host/etc from host-etc (rw)
      /host/proc from host-proc (ro)
      /host/run from host-run (rw)
      /host/sys/fs/cgroup from sys-fs-cgroup (ro)
      /host/sysroot from host-sysroot (rw)
      /host/tmp from host-tmp (rw)
      /host/usr/bin from host-usr-bin (ro)
      /host/usr/lib from host-usr-lib (ro)
      /host/usr/lib64 from host-usr-lib64 (ro)
      /host/usr/libexec from host-usr-libexec (ro)
      /host/usr/local from host-usr-local (ro)
      /host/usr/share/containers from host-usr-share-containers (ro)
      /host/var/lib from host-var-lib (rw)
      /host/var/recovery from host-var-recovery (rw)
      /host/var/tmp from host-var-tmp (rw)
  Volumes:
   host:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:     
    SizeLimit:  <unset>
   host-boot:
    Type:          HostPath (bare host directory volume)
    Path:          /boot
    HostPathType:  Directory
   host-dev-log:
    Type:          HostPath (bare host directory volume)
    Path:          /dev/log
    HostPathType:  Socket
   host-etc:
    Type:          HostPath (bare host directory volume)
    Path:          /etc
    HostPathType:  Directory
   host-proc:
    Type:          HostPath (bare host directory volume)
    Path:          /proc
    HostPathType:  Directory
   host-run:
    Type:          HostPath (bare host directory volume)
    Path:          /run
    HostPathType:  Directory
   host-sysroot:
    Type:          HostPath (bare host directory volume)
    Path:          /sysroot
    HostPathType:  Directory
   host-tmp:
    Type:          HostPath (bare host directory volume)
    Path:          /tmp
    HostPathType:  Directory
   host-usr-bin:
    Type:          HostPath (bare host directory volume)
    Path:          /usr/bin
    HostPathType:  Directory
   host-usr-lib:
    Type:          HostPath (bare host directory volume)
    Path:          /usr/lib
    HostPathType:  Directory
   host-usr-lib64:
    Type:          HostPath (bare host directory volume)
    Path:          /usr/lib64
    HostPathType:  Directory
   host-usr-libexec:
    Type:          HostPath (bare host directory volume)
    Path:          /usr/libexec
    HostPathType:  Directory
   host-usr-local:
    Type:          HostPath (bare host directory volume)
    Path:          /usr/local
    HostPathType:  Directory
   host-usr-share-containers:
    Type:          HostPath (bare host directory volume)
    Path:          /usr/share/containers
    HostPathType:  Directory
   host-var-lib:
    Type:          HostPath (bare host directory volume)
    Path:          /var/lib
    HostPathType:  Directory
   host-var-recovery:
    Type:          HostPath (bare host directory volume)
    Path:          /var/recovery
    HostPathType:  DirectoryOrCreate
   host-var-tmp:
    Type:          HostPath (bare host directory volume)
    Path:          /var/tmp
    HostPathType:  Directory
   sys-fs-cgroup:
    Type:          HostPath (bare host directory volume)
    Path:          /sys/fs/cgroup
    HostPathType:  Directory
Events:
  Type    Reason            Age        From            Message
  ----    ------            ----       ----            -------
  Normal  SuccessfulCreate  0s         job-controller  Created pod: test-agent-prwzb
  Normal  Completed         <invalid>  job-controller  Job completed
```

**Log for backup-agent pod:**

```console
sakhoury-mac:~ sakhoury$ oc -n openshift-talo-backup logs -f test-agent-prwzb
INFO[0000] Successfully mounted /host/dev/shm           
INFO[0000] Successfully remounted /host/sysroot with r/w permission 
INFO[0000] Successfully renamed /run/ostree-booted to /run/ostree-booted.tmp 
INFO[0000] ------------------------------------------------------------ 
INFO[0000] Cleaning up old content...                   
INFO[0000] ------------------------------------------------------------ 
INFO[0000] Old directories deleted with contents        
INFO[0000] Old contents have been cleaned up            
INFO[0000] Available disk space : 39.67 GiB; Estimated disk space required for backup: 2.06 GiB  
INFO[0000] Sufficient disk space found to trigger backup 
INFO[0000] Upgrade recovery script written              
INFO[0000] Running: bash -c /var/recovery/upgrade-recovery.sh --take-backup --dir /var/recovery 
INFO[0000] ##### Thu Dec 14 16:48:37 UTC 2023: Taking backup 
INFO[0000] ##### Thu Dec 14 16:48:37 UTC 2023: Wiping previous deployments and pinning active 
INFO[0000] error: Out of range deployment index 1, expected < 1 
INFO[0000] Deployment 0 is now pinned                   
INFO[0000] ##### Thu Dec 14 16:48:37 UTC 2023: Backing up container cluster and required files 
INFO[0000] Certificate /etc/kubernetes/static-pod-certs/configmaps/etcd-serving-ca/ca-bundle.crt is missing. Checking in different directory 
INFO[0000] Certificate /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-serving-ca/ca-bundle.crt found! 
INFO[0000] found latest kube-apiserver: /etc/kubernetes/static-pod-resources/kube-apiserver-pod-9 
INFO[0000] found latest kube-controller-manager: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod-6 
INFO[0000] found latest kube-scheduler: /etc/kubernetes/static-pod-resources/kube-scheduler-pod-6 
INFO[0000] found latest etcd: /etc/kubernetes/static-pod-resources/etcd-pod-3 
INFO[0001] d0983475ecb5c60f8f198b6b18b25235c9e1909483376a3f57a635fa8bd617d6 
INFO[0001] etcdctl version: 3.5.9                       
INFO[0001] API version: 3.5                             
INFO[0001] {"level":"info","ts":"2023-12-14T16:48:38.097653Z","caller":"snapshot/v3_snapshot.go:65","msg":"created temporary db file","path":"/var/recovery/cluster/snapshot_2023-12-14_164837__POSSIBLY_DIRTY__.db.part"} 
INFO[0001] {"level":"info","ts":"2023-12-14T16:48:38.110616Z","logger":"client","caller":"v3@v3.5.9/maintenance.go:212","msg":"opened snapshot stream; downloading"} 
INFO[0001] {"level":"info","ts":"2023-12-14T16:48:38.110663Z","caller":"snapshot/v3_snapshot.go:73","msg":"fetching snapshot","endpoint":"https://10.8.3.187:2379"} 
INFO[0002] {"level":"info","ts":"2023-12-14T16:48:39.021653Z","logger":"client","caller":"v3@v3.5.9/maintenance.go:220","msg":"completed snapshot read; closing"} 
INFO[0002] {"level":"info","ts":"2023-12-14T16:48:39.061314Z","caller":"snapshot/v3_snapshot.go:88","msg":"fetched snapshot","endpoint":"https://10.8.3.187:2379","size":"81 MB","took":"now"} 
INFO[0002] {"level":"info","ts":"2023-12-14T16:48:39.061409Z","caller":"snapshot/v3_snapshot.go:97","msg":"saved","path":"/var/recovery/cluster/snapshot_2023-12-14_164837__POSSIBLY_DIRTY__.db"} 
INFO[0002] Snapshot saved at /var/recovery/cluster/snapshot_2023-12-14_164837__POSSIBLY_DIRTY__.db 
INFO[0002] {"hash":3892943378,"revision":1018454,"totalKey":6089,"totalSize":80580608} 
INFO[0002] snapshot db and kube resources are successfully saved to /var/recovery/cluster 
INFO[0002] Command succeeded: cp -Ra /etc/ /var/recovery/ 
INFO[0002] Command succeeded: cp -Ra /usr/local/ /var/recovery/ 
INFO[0004] Command succeeded: cp -Ra /var/lib/kubelet/ /var/recovery/ 
INFO[0004] ##### Thu Dec 14 16:48:41 UTC 2023: Backup complete 
INFO[0004] ------------------------------------------------------------ 
INFO[0004] backup has successfully finished ...         
INFO[0004] Successfully renamed /run/ostree-booted.tmp back to /run/ostree-booted 
```

