### PR TITLE
[release-4.14]  OCPBUGS-30571: Fix for ACM Policy Generator Plugin

### DIFF
--- a/controllers/monitoring.go
+++ b/controllers/monitoring.go
@@ -210,7 +210,7 @@ func (r *ClusterGroupUpgradeReconciler) processMonitoredObject(
 	// Get the managedClusterView for the monitored object contained in the current managedPolicy.
 	// If missing, then return error.
 	mcvName := utils.GetMultiCloudObjectName(clusterGroupUpgrade, object.Kind, object.Name)
-	safeName := utils.GetSafeResourceName(mcvName, clusterGroupUpgrade, utils.MaxObjectNameLength, 0)
+	safeName := utils.GetSafeResourceName(mcvName, "", clusterGroupUpgrade, utils.MaxObjectNameLength)
 	mcv, err := utils.EnsureManagedClusterView(
 		ctx, r.Client, safeName, mcvName, clusterName, object.Kind+"."+strings.Split(object.APIVersion, "/")[0],
 		object.Name, *object.Namespace, clusterGroupUpgrade.Namespace+"-"+clusterGroupUpgrade.Name)

--- a/controllers/utils/common.go
+++ b/controllers/utils/common.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"regexp"
+	"unicode/utf8"
 
 	ranv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -32,25 +33,30 @@ func GetMinOf3(number1, number2, number3 int) int {
 }
 
 // GetSafeResourceName returns the safename if already allocated in the map and creates a new one if not
-func GetSafeResourceName(name string, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, maxLength, spareLength int) string {
+func GetSafeResourceName(name, namespace string, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, maxLength int) string {
 	if clusterGroupUpgrade.Status.SafeResourceNames == nil {
 		clusterGroupUpgrade.Status.SafeResourceNames = make(map[string]string)
 	}
-	safeName, ok := clusterGroupUpgrade.Status.SafeResourceNames[name]
+	safeName, ok := clusterGroupUpgrade.Status.SafeResourceNames[PrefixNameWithNamespace(namespace, name)]
+
 	if !ok {
-		safeName = NewSafeResourceName(name, clusterGroupUpgrade.GetAnnotations()[NameSuffixAnnotation], maxLength, spareLength)
-		clusterGroupUpgrade.Status.SafeResourceNames[name] = safeName
+		safeName = NewSafeResourceName(name, namespace, clusterGroupUpgrade.GetAnnotations()[NameSuffixAnnotation], maxLength)
+		clusterGroupUpgrade.Status.SafeResourceNames[PrefixNameWithNamespace(namespace, name)] = safeName
 	}
 	return safeName
 }
 
+const (
+	finalDashLength = 1
+)
+
 // NewSafeResourceName creates a safe name to use with random suffix and possible truncation based on limits passed in
-func NewSafeResourceName(name, suffix string, maxLength, spareLength int) string {
+func NewSafeResourceName(name, namespace, suffix string, maxLength int) (safename string) {
 	if suffix == "" {
 		suffix = rand.String(RandomNameSuffixLength)
 	}
-	suffixLength := len(suffix)
-	maxGeneratedNameLength := maxLength - suffixLength - spareLength - 1
+	suffixLength := utf8.RuneCountInString(suffix)
+	maxGeneratedNameLength := maxLength - suffixLength - utf8.RuneCountInString(namespace) - finalDashLength
 	var base string
 	if len(name) > maxGeneratedNameLength {
 		base = name[:maxGeneratedNameLength]
@@ -59,12 +65,17 @@ func NewSafeResourceName(name, suffix string, maxLength, spareLength int) string
 	}
 
 	// Make sure base ends in '-' or an alphanumerical character.
-	for !regexp.MustCompile(`^[a-zA-Z0-9-]*$`).MatchString(base[len(base)-1:]) {
-		base = base[:len(base)-1]
+	for !regexp.MustCompile(`^[a-zA-Z0-9-]*$`).MatchString(base[utf8.RuneCountInString(base)-1:]) {
+		base = base[:utf8.RuneCountInString(base)-1]
 	}
 
 	// The newSafeResourceName should match regex
 	// `[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*` as per
 	// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
 	return fmt.Sprintf("%s-%s", base, suffix)
+}
+
+// PrefixNameWithNamespace Prefixes the passed name with the passed namespace. Use '/' as a separator
+func PrefixNameWithNamespace(namespace, name string) string {
+	return namespace + "/" + name
 }

--- a/controllers/utils/common_test.go
+++ b/controllers/utils/common_test.go
@@ -10,42 +10,42 @@ func TestNewSafeResourceNames(t *testing.T) {
 
 	name := "cnfdf18-new-common-cnfdf18-looooong-subscriptions-policy"
 	namespace := "ztp-install"
-	safeName := NewSafeResourceName(name, "", MaxPolicyNameLength, len(namespace)+1)
-	assert.Equal(t, MaxPolicyNameLength-len(namespace)-1, len(safeName))
-	assert.Equal(t, name[:MaxPolicyNameLength-len(namespace)-7]+"-", safeName[:MaxPolicyNameLength-len(namespace)-6])
+	safeName := NewSafeResourceName(name, namespace, "", MaxPolicyNameLengthExcludingTheDot)
+	assert.Equal(t, MaxPolicyNameLengthExcludingTheDot-len(namespace), len(safeName))
+	assert.Equal(t, name[:MaxPolicyNameLengthExcludingTheDot-len(namespace)-6]+"-", safeName[:MaxPolicyNameLengthExcludingTheDot-len(namespace)-5])
 
 	name = "cnfdf18-new-common-cnfdf18-looooong-subscriptions-policy-config"
-	safeName = NewSafeResourceName(name, "", MaxPolicyNameLength, 0)
-	assert.Equal(t, MaxPolicyNameLength, len(safeName))
-	assert.Equal(t, name[:MaxPolicyNameLength-7]+"-", safeName[:MaxPolicyNameLength-6])
+	safeName = NewSafeResourceName(name, "", "", MaxPolicyNameLengthExcludingTheDot)
+	assert.Equal(t, MaxPolicyNameLengthExcludingTheDot, len(safeName))
+	assert.Equal(t, name[:MaxPolicyNameLengthExcludingTheDot-6]+"-", safeName[:MaxPolicyNameLengthExcludingTheDot-5])
 
 	name = "cnfdf18-new-common-cnfdf18-looooong-subscriptions-policy-placement"
-	safeName = NewSafeResourceName(name, "", MaxObjectNameLength, 0)
+	safeName = NewSafeResourceName(name, "", "", MaxObjectNameLength)
 	assert.Equal(t, len(name)+6, len(safeName))
 	assert.Equal(t, name+"-", safeName[:len(name)+1])
 
 	name = "cnfdf18-new-common-cnfdf18-looooong-subscriptions-policy"
-	safeName = NewSafeResourceName(name, "kuttl", MaxPolicyNameLength, len(namespace)+1)
-	assert.Equal(t, MaxPolicyNameLength-len(namespace)-1, len(safeName))
-	assert.Equal(t, name[:MaxPolicyNameLength-len(namespace)-7]+"-kuttl", safeName)
+	safeName = NewSafeResourceName(name, namespace, "kuttl", MaxPolicyNameLengthExcludingTheDot)
+	assert.Equal(t, MaxPolicyNameLengthExcludingTheDot-len(namespace), len(safeName))
+	assert.Equal(t, name[:MaxPolicyNameLengthExcludingTheDot-len(namespace)-6]+"-kuttl", safeName)
 
 	name = "cnfdf18-new-common-cnfdf18-looooong-subscriptions-policy-config"
-	safeName = NewSafeResourceName(name, "kuttl", MaxPolicyNameLength, 0)
-	assert.Equal(t, MaxPolicyNameLength, len(safeName))
-	assert.Equal(t, name[:MaxPolicyNameLength-6]+"-kuttl", safeName)
+	safeName = NewSafeResourceName(name, "", "kuttl", MaxPolicyNameLengthExcludingTheDot)
+	assert.Equal(t, MaxPolicyNameLengthExcludingTheDot, len(safeName))
+	assert.Equal(t, name[:MaxPolicyNameLengthExcludingTheDot-6]+"-kuttl", safeName)
 
 	name = "cnfdf18-new-common-cnfdf18-looooong-subscriptions-policy-placement"
-	safeName = NewSafeResourceName(name, "kuttl", MaxObjectNameLength, 0)
+	safeName = NewSafeResourceName(name, "", "kuttl", MaxObjectNameLength)
 	assert.Equal(t, len(name)+6, len(safeName))
 	assert.Equal(t, name+"-kuttl", safeName)
 
 	name = "cgu-sriov-cloudransno-site9-spree-lb-du-cvslcm-4.14.0-rc.4-config"
-	safeName = NewSafeResourceName(name, "", MaxPolicyNameLength, 0)
-	assert.Equal(t, MaxPolicyNameLength-1, len(safeName))
-	assert.Equal(t, name[:MaxPolicyNameLength-7]+"-", safeName[:MaxPolicyNameLength-6])
+	safeName = NewSafeResourceName(name, "", "", MaxPolicyNameLengthExcludingTheDot)
+	assert.Equal(t, MaxPolicyNameLengthExcludingTheDot, len(safeName))
+	assert.Equal(t, name[:MaxPolicyNameLengthExcludingTheDot-6]+"-", safeName[:MaxPolicyNameLengthExcludingTheDot-5])
 
 	name = "cgu-sriov-cloudransno-site9-spree-lb-du-cvslcm-4.14.0-rc.4"
-	safeName = NewSafeResourceName(name, "", MaxPolicyNameLength, 8)
-	assert.Equal(t, MaxPolicyNameLength-9, len(safeName))
-	assert.Equal(t, name[:MaxPolicyNameLength-15]+"-", safeName[:MaxPolicyNameLength-14])
+	safeName = NewSafeResourceName(name, "", "12345678", MaxPolicyNameLengthExcludingTheDot)
+	assert.Equal(t, MaxPolicyNameLengthExcludingTheDot, len(safeName))
+	assert.Equal(t, name[:MaxPolicyNameLengthExcludingTheDot-9]+"-", safeName[:MaxPolicyNameLengthExcludingTheDot-8])
 }

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -41,10 +41,12 @@ const (
 
 // CR name length limits and suffix annotation
 const (
-	MaxPolicyNameLength    = 63
-	MaxObjectNameLength    = 253
-	NameSuffixAnnotation   = CsvNamePrefix + "/name-suffix"
-	RandomNameSuffixLength = 5
+	// Maximum length of policy + namespace (not including extra separator dot so 63 -1 = 62)
+	// this is calculated with utf8.RuneCountInString(policy.Name)+utf8.RuneCountInString+utf8.RuneCountInString(policy.Namespace)
+	MaxPolicyNameLengthExcludingTheDot = 62
+	MaxObjectNameLength                = 253
+	NameSuffixAnnotation               = CsvNamePrefix + "/name-suffix"
+	RandomNameSuffixLength             = 5
 )
 
 // Pre-cache constants

--- a/controllers/utils/multicloud_util.go
+++ b/controllers/utils/multicloud_util.go
@@ -170,7 +170,7 @@ func EnsureManagedClusterView(
 					"openshift-cluster-group-upgrades/clusterGroupUpgrade": cguLabel,
 				},
 				Annotations: map[string]string{
-					DesiredResourceName: name,
+					DesiredResourceName: PrefixNameWithNamespace(namespace, name),
 				},
 			}
 			viewSpec := viewv1beta1.ViewSpec{

--- a/tests/kuttl/tests/adjust-max-concurrency/00-assert.yaml
+++ b/tests/kuttl/tests/adjust-max-concurrency/00-assert.yaml
@@ -18,15 +18,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Not enabled
     reason: NotEnabled
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-adjust-max-conc-policy1-common-cluster-versio-kuttl
@@ -50,10 +50,10 @@ status:
   remediationPlan:
   - - spoke1
   safeResourceNames:
-    cgu-adjust-max-conc-common-cluster-version-policy-config: cgu-adjust-max-conc-common-cluster-version-policy-config-kuttl
-    cgu-adjust-max-conc-common-pao-sub-policy-config: cgu-adjust-max-conc-common-pao-sub-policy-config-kuttl
-    cgu-adjust-max-conc-policy1-common-cluster-version-policy: cgu-adjust-max-conc-policy1-common-cluster-versio-kuttl
-    cgu-adjust-max-conc-policy1-common-cluster-version-policy-placement: cgu-adjust-max-conc-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-adjust-max-conc-policy2-common-pao-sub-policy: cgu-adjust-max-conc-policy2-common-pao-sub-policy-kuttl
-    cgu-adjust-max-conc-policy2-common-pao-sub-policy-placement: cgu-adjust-max-conc-policy2-common-pao-sub-policy-placement-kuttl
+    /cgu-adjust-max-conc-common-cluster-version-policy-config: cgu-adjust-max-conc-common-cluster-version-policy-config-kuttl
+    /cgu-adjust-max-conc-common-pao-sub-policy-config: cgu-adjust-max-conc-common-pao-sub-policy-config-kuttl
+    default/cgu-adjust-max-conc-policy1-common-cluster-version-policy: cgu-adjust-max-conc-policy1-common-cluster-versio-kuttl
+    default/cgu-adjust-max-conc-policy1-common-cluster-version-policy-placement: cgu-adjust-max-conc-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-adjust-max-conc-policy2-common-pao-sub-policy: cgu-adjust-max-conc-policy2-common-pao-sub-policy-kuttl
+    default/cgu-adjust-max-conc-policy2-common-pao-sub-policy-placement: cgu-adjust-max-conc-policy2-common-pao-sub-policy-placement-kuttl
   status: {}

--- a/tests/kuttl/tests/backup-complete/00-assert.yaml
+++ b/tests/kuttl/tests/backup-complete/00-assert.yaml
@@ -30,19 +30,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Backup in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: BackupSuceeded
   - message: Cluster backup is in progress
     reason: NotStarted
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -73,14 +73,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-#MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -123,7 +122,7 @@ spec:
   actionType: Delete
   kube:
     name: backup-agent
-    resource: clusterrolebinding    
+    resource: clusterrolebinding
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -145,7 +144,7 @@ spec:
   actionType: Delete
   kube:
     name: backup-agent
-    resource: clusterrolebinding    
+    resource: clusterrolebinding
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -167,9 +166,8 @@ spec:
   actionType: Delete
   kube:
     name: backup-agent
-    resource: clusterrolebinding    
+    resource: clusterrolebinding
 ---
-#MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:

--- a/tests/kuttl/tests/backup-complete/01-assert.yaml
+++ b/tests/kuttl/tests/backup-complete/01-assert.yaml
@@ -30,19 +30,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Backup in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: BackupSuceeded
   - message: Cluster backup is in progress
     reason: NotStarted
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -73,14 +73,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-# MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -313,7 +312,6 @@ spec:
         name: backup-agent
         namespace: openshift-talo-backup
 ---
-#MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
@@ -326,7 +324,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
@@ -341,7 +339,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
@@ -356,7 +354,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
@@ -371,6 +369,6 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---

--- a/tests/kuttl/tests/backup-complete/02-assert.yaml
+++ b/tests/kuttl/tests/backup-complete/02-assert.yaml
@@ -29,19 +29,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Backup in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: BackupSuceeded
   - message: Cluster backup is in progress
     reason: NotStarted
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -72,14 +72,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-# MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
@@ -124,7 +123,6 @@ spec:
     namespace: openshift-talo-backup
     resource: jobs
 ---
-# MCA
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -158,124 +156,124 @@ spec:
                 runAsUser: 0
               tty: true
               volumeMounts:
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/boot
-                  name: host-boot
-                  readOnly: true
-                - mountPath: /host/dev/log
-                  name: host-dev-log
-                - mountPath: /host/etc
-                  name: host-etc
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/sysroot
-                  name: host-sysroot
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/local
-                  name: host-usr-local
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib
-                  name: host-var-lib
-                - mountPath: /host/var/recovery
-                  name: host-var-recovery
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/boot
+                name: host-boot
+                readOnly: true
+              - mountPath: /host/dev/log
+                name: host-dev-log
+              - mountPath: /host/etc
+                name: host-etc
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/sysroot
+                name: host-sysroot
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/local
+                name: host-usr-local
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib
+                name: host-var-lib
+              - mountPath: /host/var/recovery
+                name: host-var-recovery
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /boot
-                  type: Directory
-                name: host-boot
-              - hostPath:
-                  path: /dev/log
-                  type: Socket
-                name: host-dev-log
-              - hostPath:
-                  path: /etc
-                  type: Directory
-                name: host-etc
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /sysroot
-                  type: Directory
-                name: host-sysroot
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/local
-                  type: Directory
-                name: host-usr-local
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib
-                  type: Directory
-                name: host-var-lib
-              - hostPath:
-                  path: /var/recovery
-                  type: DirectoryOrCreate
-                name: host-var-recovery
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /boot
+                type: Directory
+              name: host-boot
+            - hostPath:
+                path: /dev/log
+                type: Socket
+              name: host-dev-log
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sysroot
+                type: Directory
+              name: host-sysroot
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/local
+                type: Directory
+              name: host-usr-local
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib
+                type: Directory
+              name: host-var-lib
+            - hostPath:
+                path: /var/recovery
+                type: DirectoryOrCreate
+              name: host-var-recovery
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -310,124 +308,124 @@ spec:
                 runAsUser: 0
               tty: true
               volumeMounts:
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/boot
-                  name: host-boot
-                  readOnly: true
-                - mountPath: /host/dev/log
-                  name: host-dev-log
-                - mountPath: /host/etc
-                  name: host-etc
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/sysroot
-                  name: host-sysroot
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/local
-                  name: host-usr-local
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib
-                  name: host-var-lib
-                - mountPath: /host/var/recovery
-                  name: host-var-recovery
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/boot
+                name: host-boot
+                readOnly: true
+              - mountPath: /host/dev/log
+                name: host-dev-log
+              - mountPath: /host/etc
+                name: host-etc
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/sysroot
+                name: host-sysroot
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/local
+                name: host-usr-local
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib
+                name: host-var-lib
+              - mountPath: /host/var/recovery
+                name: host-var-recovery
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /boot
-                  type: Directory
-                name: host-boot
-              - hostPath:
-                  path: /dev/log
-                  type: Socket
-                name: host-dev-log
-              - hostPath:
-                  path: /etc
-                  type: Directory
-                name: host-etc
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /sysroot
-                  type: Directory
-                name: host-sysroot
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/local
-                  type: Directory
-                name: host-usr-local
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib
-                  type: Directory
-                name: host-var-lib
-              - hostPath:
-                  path: /var/recovery
-                  type: DirectoryOrCreate
-                name: host-var-recovery
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /boot
+                type: Directory
+              name: host-boot
+            - hostPath:
+                path: /dev/log
+                type: Socket
+              name: host-dev-log
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sysroot
+                type: Directory
+              name: host-sysroot
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/local
+                type: Directory
+              name: host-usr-local
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib
+                type: Directory
+              name: host-var-lib
+            - hostPath:
+                path: /var/recovery
+                type: DirectoryOrCreate
+              name: host-var-recovery
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -462,124 +460,124 @@ spec:
                 runAsUser: 0
               tty: true
               volumeMounts:
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/boot
-                  name: host-boot
-                  readOnly: true
-                - mountPath: /host/dev/log
-                  name: host-dev-log
-                - mountPath: /host/etc
-                  name: host-etc
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/sysroot
-                  name: host-sysroot
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/local
-                  name: host-usr-local
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib
-                  name: host-var-lib
-                - mountPath: /host/var/recovery
-                  name: host-var-recovery
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/boot
+                name: host-boot
+                readOnly: true
+              - mountPath: /host/dev/log
+                name: host-dev-log
+              - mountPath: /host/etc
+                name: host-etc
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/sysroot
+                name: host-sysroot
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/local
+                name: host-usr-local
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib
+                name: host-var-lib
+              - mountPath: /host/var/recovery
+                name: host-var-recovery
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /boot
-                  type: Directory
-                name: host-boot
-              - hostPath:
-                  path: /dev/log
-                  type: Socket
-                name: host-dev-log
-              - hostPath:
-                  path: /etc
-                  type: Directory
-                name: host-etc
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /sysroot
-                  type: Directory
-                name: host-sysroot
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/local
-                  type: Directory
-                name: host-usr-local
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib
-                  type: Directory
-                name: host-var-lib
-              - hostPath:
-                  path: /var/recovery
-                  type: DirectoryOrCreate
-                name: host-var-recovery
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /boot
+                type: Directory
+              name: host-boot
+            - hostPath:
+                path: /dev/log
+                type: Socket
+              name: host-dev-log
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sysroot
+                type: Directory
+              name: host-sysroot
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/local
+                type: Directory
+              name: host-usr-local
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib
+                type: Directory
+              name: host-var-lib
+            - hostPath:
+                path: /var/recovery
+                type: DirectoryOrCreate
+              name: host-var-recovery
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -614,125 +612,122 @@ spec:
                 runAsUser: 0
               tty: true
               volumeMounts:
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/boot
-                  name: host-boot
-                  readOnly: true
-                - mountPath: /host/dev/log
-                  name: host-dev-log
-                - mountPath: /host/etc
-                  name: host-etc
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/sysroot
-                  name: host-sysroot
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/local
-                  name: host-usr-local
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib
-                  name: host-var-lib
-                - mountPath: /host/var/recovery
-                  name: host-var-recovery
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/boot
+                name: host-boot
+                readOnly: true
+              - mountPath: /host/dev/log
+                name: host-dev-log
+              - mountPath: /host/etc
+                name: host-etc
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/sysroot
+                name: host-sysroot
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/local
+                name: host-usr-local
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib
+                name: host-var-lib
+              - mountPath: /host/var/recovery
+                name: host-var-recovery
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /boot
-                  type: Directory
-                name: host-boot
-              - hostPath:
-                  path: /dev/log
-                  type: Socket
-                name: host-dev-log
-              - hostPath:
-                  path: /etc
-                  type: Directory
-                name: host-etc
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /sysroot
-                  type: Directory
-                name: host-sysroot
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/local
-                  type: Directory
-                name: host-usr-local
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib
-                  type: Directory
-                name: host-var-lib
-              - hostPath:
-                  path: /var/recovery
-                  type: DirectoryOrCreate
-                name: host-var-recovery
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /boot
+                type: Directory
+              name: host-boot
+            - hostPath:
+                path: /dev/log
+                type: Socket
+              name: host-dev-log
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sysroot
+                type: Directory
+              name: host-sysroot
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/local
+                type: Directory
+              name: host-usr-local
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib
+                type: Directory
+              name: host-var-lib
+            - hostPath:
+                path: /var/recovery
+                type: DirectoryOrCreate
+              name: host-var-recovery
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
 ---
-
-
-

--- a/tests/kuttl/tests/backup-complete/03-assert.yaml
+++ b/tests/kuttl/tests/backup-complete/03-assert.yaml
@@ -29,19 +29,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Backup in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: BackupSuceeded
   - message: Cluster backup is in progress
     reason: NotStarted
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -72,9 +72,9 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl

--- a/tests/kuttl/tests/backup-complete/04-assert.yaml
+++ b/tests/kuttl/tests/backup-complete/04-assert.yaml
@@ -29,19 +29,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Backup is completed for all clusters
     reason: BackupCompleted
-    status: "True"
+    status: 'True'
     type: BackupSuceeded
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -72,14 +72,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-#MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -122,7 +121,7 @@ spec:
   actionType: Delete
   kube:
     name: backup-agent
-    resource: clusterrolebinding    
+    resource: clusterrolebinding
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -144,7 +143,7 @@ spec:
   actionType: Delete
   kube:
     name: backup-agent
-    resource: clusterrolebinding    
+    resource: clusterrolebinding
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction

--- a/tests/kuttl/tests/backup-fail/00-assert.yaml
+++ b/tests/kuttl/tests/backup-fail/00-assert.yaml
@@ -30,19 +30,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Backup in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: BackupSuceeded
   - message: Cluster backup is in progress
     reason: NotStarted
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -73,14 +73,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-#MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -125,7 +124,6 @@ spec:
     name: openshift-talo-backup
     resource: namespace
 ---
-#MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:

--- a/tests/kuttl/tests/backup-fail/01-assert.yaml
+++ b/tests/kuttl/tests/backup-fail/01-assert.yaml
@@ -30,19 +30,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Backup in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: BackupSuceeded
   - message: Cluster backup is in progress
     reason: NotStarted
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -73,14 +73,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-# MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -313,7 +312,6 @@ spec:
         name: backup-agent
         namespace: openshift-talo-backup
 ---
-#MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
@@ -326,7 +324,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
@@ -341,7 +339,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
@@ -356,7 +354,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
@@ -371,6 +369,6 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---

--- a/tests/kuttl/tests/backup-fail/02-assert.yaml
+++ b/tests/kuttl/tests/backup-fail/02-assert.yaml
@@ -29,19 +29,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Backup in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: BackupSuceeded
   - message: Cluster backup is in progress
     reason: NotStarted
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -72,14 +72,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-# MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
@@ -124,7 +123,6 @@ spec:
     namespace: openshift-talo-backup
     resource: jobs
 ---
-# MCA
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -158,124 +156,124 @@ spec:
                 runAsUser: 0
               tty: true
               volumeMounts:
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/boot
-                  name: host-boot
-                  readOnly: true
-                - mountPath: /host/dev/log
-                  name: host-dev-log
-                - mountPath: /host/etc
-                  name: host-etc
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/sysroot
-                  name: host-sysroot
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/local
-                  name: host-usr-local
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib
-                  name: host-var-lib
-                - mountPath: /host/var/recovery
-                  name: host-var-recovery
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/boot
+                name: host-boot
+                readOnly: true
+              - mountPath: /host/dev/log
+                name: host-dev-log
+              - mountPath: /host/etc
+                name: host-etc
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/sysroot
+                name: host-sysroot
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/local
+                name: host-usr-local
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib
+                name: host-var-lib
+              - mountPath: /host/var/recovery
+                name: host-var-recovery
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /boot
-                  type: Directory
-                name: host-boot
-              - hostPath:
-                  path: /dev/log
-                  type: Socket
-                name: host-dev-log
-              - hostPath:
-                  path: /etc
-                  type: Directory
-                name: host-etc
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /sysroot
-                  type: Directory
-                name: host-sysroot
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/local
-                  type: Directory
-                name: host-usr-local
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib
-                  type: Directory
-                name: host-var-lib
-              - hostPath:
-                  path: /var/recovery
-                  type: DirectoryOrCreate
-                name: host-var-recovery
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /boot
+                type: Directory
+              name: host-boot
+            - hostPath:
+                path: /dev/log
+                type: Socket
+              name: host-dev-log
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sysroot
+                type: Directory
+              name: host-sysroot
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/local
+                type: Directory
+              name: host-usr-local
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib
+                type: Directory
+              name: host-var-lib
+            - hostPath:
+                path: /var/recovery
+                type: DirectoryOrCreate
+              name: host-var-recovery
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -310,124 +308,124 @@ spec:
                 runAsUser: 0
               tty: true
               volumeMounts:
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/boot
-                  name: host-boot
-                  readOnly: true
-                - mountPath: /host/dev/log
-                  name: host-dev-log
-                - mountPath: /host/etc
-                  name: host-etc
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/sysroot
-                  name: host-sysroot
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/local
-                  name: host-usr-local
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib
-                  name: host-var-lib
-                - mountPath: /host/var/recovery
-                  name: host-var-recovery
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/boot
+                name: host-boot
+                readOnly: true
+              - mountPath: /host/dev/log
+                name: host-dev-log
+              - mountPath: /host/etc
+                name: host-etc
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/sysroot
+                name: host-sysroot
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/local
+                name: host-usr-local
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib
+                name: host-var-lib
+              - mountPath: /host/var/recovery
+                name: host-var-recovery
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /boot
-                  type: Directory
-                name: host-boot
-              - hostPath:
-                  path: /dev/log
-                  type: Socket
-                name: host-dev-log
-              - hostPath:
-                  path: /etc
-                  type: Directory
-                name: host-etc
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /sysroot
-                  type: Directory
-                name: host-sysroot
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/local
-                  type: Directory
-                name: host-usr-local
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib
-                  type: Directory
-                name: host-var-lib
-              - hostPath:
-                  path: /var/recovery
-                  type: DirectoryOrCreate
-                name: host-var-recovery
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /boot
+                type: Directory
+              name: host-boot
+            - hostPath:
+                path: /dev/log
+                type: Socket
+              name: host-dev-log
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sysroot
+                type: Directory
+              name: host-sysroot
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/local
+                type: Directory
+              name: host-usr-local
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib
+                type: Directory
+              name: host-var-lib
+            - hostPath:
+                path: /var/recovery
+                type: DirectoryOrCreate
+              name: host-var-recovery
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -462,124 +460,124 @@ spec:
                 runAsUser: 0
               tty: true
               volumeMounts:
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/boot
-                  name: host-boot
-                  readOnly: true
-                - mountPath: /host/dev/log
-                  name: host-dev-log
-                - mountPath: /host/etc
-                  name: host-etc
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/sysroot
-                  name: host-sysroot
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/local
-                  name: host-usr-local
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib
-                  name: host-var-lib
-                - mountPath: /host/var/recovery
-                  name: host-var-recovery
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/boot
+                name: host-boot
+                readOnly: true
+              - mountPath: /host/dev/log
+                name: host-dev-log
+              - mountPath: /host/etc
+                name: host-etc
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/sysroot
+                name: host-sysroot
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/local
+                name: host-usr-local
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib
+                name: host-var-lib
+              - mountPath: /host/var/recovery
+                name: host-var-recovery
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /boot
-                  type: Directory
-                name: host-boot
-              - hostPath:
-                  path: /dev/log
-                  type: Socket
-                name: host-dev-log
-              - hostPath:
-                  path: /etc
-                  type: Directory
-                name: host-etc
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /sysroot
-                  type: Directory
-                name: host-sysroot
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/local
-                  type: Directory
-                name: host-usr-local
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib
-                  type: Directory
-                name: host-var-lib
-              - hostPath:
-                  path: /var/recovery
-                  type: DirectoryOrCreate
-                name: host-var-recovery
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /boot
+                type: Directory
+              name: host-boot
+            - hostPath:
+                path: /dev/log
+                type: Socket
+              name: host-dev-log
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sysroot
+                type: Directory
+              name: host-sysroot
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/local
+                type: Directory
+              name: host-usr-local
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib
+                type: Directory
+              name: host-var-lib
+            - hostPath:
+                path: /var/recovery
+                type: DirectoryOrCreate
+              name: host-var-recovery
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -614,125 +612,122 @@ spec:
                 runAsUser: 0
               tty: true
               volumeMounts:
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/boot
-                  name: host-boot
-                  readOnly: true
-                - mountPath: /host/dev/log
-                  name: host-dev-log
-                - mountPath: /host/etc
-                  name: host-etc
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/sysroot
-                  name: host-sysroot
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/local
-                  name: host-usr-local
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib
-                  name: host-var-lib
-                - mountPath: /host/var/recovery
-                  name: host-var-recovery
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/boot
+                name: host-boot
+                readOnly: true
+              - mountPath: /host/dev/log
+                name: host-dev-log
+              - mountPath: /host/etc
+                name: host-etc
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/sysroot
+                name: host-sysroot
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/local
+                name: host-usr-local
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib
+                name: host-var-lib
+              - mountPath: /host/var/recovery
+                name: host-var-recovery
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /boot
-                  type: Directory
-                name: host-boot
-              - hostPath:
-                  path: /dev/log
-                  type: Socket
-                name: host-dev-log
-              - hostPath:
-                  path: /etc
-                  type: Directory
-                name: host-etc
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /sysroot
-                  type: Directory
-                name: host-sysroot
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/local
-                  type: Directory
-                name: host-usr-local
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib
-                  type: Directory
-                name: host-var-lib
-              - hostPath:
-                  path: /var/recovery
-                  type: DirectoryOrCreate
-                name: host-var-recovery
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /boot
+                type: Directory
+              name: host-boot
+            - hostPath:
+                path: /dev/log
+                type: Socket
+              name: host-dev-log
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sysroot
+                type: Directory
+              name: host-sysroot
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/local
+                type: Directory
+              name: host-usr-local
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib
+                type: Directory
+              name: host-var-lib
+            - hostPath:
+                path: /var/recovery
+                type: DirectoryOrCreate
+              name: host-var-recovery
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
 ---
-
-
-

--- a/tests/kuttl/tests/backup-fail/03-assert.yaml
+++ b/tests/kuttl/tests/backup-fail/03-assert.yaml
@@ -29,19 +29,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Backup in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: BackupSuceeded
   - message: Cluster backup is in progress
     reason: NotStarted
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -72,9 +72,9 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl

--- a/tests/kuttl/tests/backup-fail/04-assert.yaml
+++ b/tests/kuttl/tests/backup-fail/04-assert.yaml
@@ -29,19 +29,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Backup failed for all clusters
     reason: Failed
-    status: "False"
+    status: 'False'
     type: BackupSuceeded
   - message: Cluster backup is in progress
-    reason:  NotStarted
-    status: "False"
+    reason: NotStarted
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -72,9 +72,9 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl

--- a/tests/kuttl/tests/backup-partial-complete/00-assert.yaml
+++ b/tests/kuttl/tests/backup-partial-complete/00-assert.yaml
@@ -30,19 +30,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Backup in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: BackupSuceeded
   - message: Cluster backup is in progress
     reason: NotStarted
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -73,14 +73,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-#MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -123,7 +122,7 @@ spec:
   actionType: Delete
   kube:
     name: backup-agent
-    resource: clusterrolebinding    
+    resource: clusterrolebinding
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -145,7 +144,7 @@ spec:
   actionType: Delete
   kube:
     name: backup-agent
-    resource: clusterrolebinding    
+    resource: clusterrolebinding
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -167,9 +166,8 @@ spec:
   actionType: Delete
   kube:
     name: backup-agent
-    resource: clusterrolebinding    
+    resource: clusterrolebinding
 ---
-#MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:

--- a/tests/kuttl/tests/backup-partial-complete/01-assert.yaml
+++ b/tests/kuttl/tests/backup-partial-complete/01-assert.yaml
@@ -30,19 +30,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Backup in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: BackupSuceeded
   - message: Cluster backup is in progress
     reason: NotStarted
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -73,14 +73,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-# MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -313,7 +312,6 @@ spec:
         name: backup-agent
         namespace: openshift-talo-backup
 ---
-#MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
@@ -326,7 +324,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
@@ -341,7 +339,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
@@ -356,7 +354,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
@@ -371,6 +369,6 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---

--- a/tests/kuttl/tests/backup-partial-complete/02-assert.yaml
+++ b/tests/kuttl/tests/backup-partial-complete/02-assert.yaml
@@ -29,19 +29,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Backup in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: BackupSuceeded
   - message: Cluster backup is in progress
     reason: NotStarted
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -72,14 +72,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-# MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
@@ -124,7 +123,6 @@ spec:
     namespace: openshift-talo-backup
     resource: jobs
 ---
-# MCA
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -158,124 +156,124 @@ spec:
                 runAsUser: 0
               tty: true
               volumeMounts:
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/boot
-                  name: host-boot
-                  readOnly: true
-                - mountPath: /host/dev/log
-                  name: host-dev-log
-                - mountPath: /host/etc
-                  name: host-etc
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/sysroot
-                  name: host-sysroot
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/local
-                  name: host-usr-local
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib
-                  name: host-var-lib
-                - mountPath: /host/var/recovery
-                  name: host-var-recovery
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/boot
+                name: host-boot
+                readOnly: true
+              - mountPath: /host/dev/log
+                name: host-dev-log
+              - mountPath: /host/etc
+                name: host-etc
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/sysroot
+                name: host-sysroot
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/local
+                name: host-usr-local
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib
+                name: host-var-lib
+              - mountPath: /host/var/recovery
+                name: host-var-recovery
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /boot
-                  type: Directory
-                name: host-boot
-              - hostPath:
-                  path: /dev/log
-                  type: Socket
-                name: host-dev-log
-              - hostPath:
-                  path: /etc
-                  type: Directory
-                name: host-etc
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /sysroot
-                  type: Directory
-                name: host-sysroot
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/local
-                  type: Directory
-                name: host-usr-local
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib
-                  type: Directory
-                name: host-var-lib
-              - hostPath:
-                  path: /var/recovery
-                  type: DirectoryOrCreate
-                name: host-var-recovery
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /boot
+                type: Directory
+              name: host-boot
+            - hostPath:
+                path: /dev/log
+                type: Socket
+              name: host-dev-log
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sysroot
+                type: Directory
+              name: host-sysroot
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/local
+                type: Directory
+              name: host-usr-local
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib
+                type: Directory
+              name: host-var-lib
+            - hostPath:
+                path: /var/recovery
+                type: DirectoryOrCreate
+              name: host-var-recovery
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -310,124 +308,124 @@ spec:
                 runAsUser: 0
               tty: true
               volumeMounts:
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/boot
-                  name: host-boot
-                  readOnly: true
-                - mountPath: /host/dev/log
-                  name: host-dev-log
-                - mountPath: /host/etc
-                  name: host-etc
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/sysroot
-                  name: host-sysroot
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/local
-                  name: host-usr-local
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib
-                  name: host-var-lib
-                - mountPath: /host/var/recovery
-                  name: host-var-recovery
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/boot
+                name: host-boot
+                readOnly: true
+              - mountPath: /host/dev/log
+                name: host-dev-log
+              - mountPath: /host/etc
+                name: host-etc
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/sysroot
+                name: host-sysroot
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/local
+                name: host-usr-local
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib
+                name: host-var-lib
+              - mountPath: /host/var/recovery
+                name: host-var-recovery
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /boot
-                  type: Directory
-                name: host-boot
-              - hostPath:
-                  path: /dev/log
-                  type: Socket
-                name: host-dev-log
-              - hostPath:
-                  path: /etc
-                  type: Directory
-                name: host-etc
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /sysroot
-                  type: Directory
-                name: host-sysroot
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/local
-                  type: Directory
-                name: host-usr-local
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib
-                  type: Directory
-                name: host-var-lib
-              - hostPath:
-                  path: /var/recovery
-                  type: DirectoryOrCreate
-                name: host-var-recovery
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /boot
+                type: Directory
+              name: host-boot
+            - hostPath:
+                path: /dev/log
+                type: Socket
+              name: host-dev-log
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sysroot
+                type: Directory
+              name: host-sysroot
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/local
+                type: Directory
+              name: host-usr-local
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib
+                type: Directory
+              name: host-var-lib
+            - hostPath:
+                path: /var/recovery
+                type: DirectoryOrCreate
+              name: host-var-recovery
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -462,124 +460,124 @@ spec:
                 runAsUser: 0
               tty: true
               volumeMounts:
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/boot
-                  name: host-boot
-                  readOnly: true
-                - mountPath: /host/dev/log
-                  name: host-dev-log
-                - mountPath: /host/etc
-                  name: host-etc
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/sysroot
-                  name: host-sysroot
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/local
-                  name: host-usr-local
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib
-                  name: host-var-lib
-                - mountPath: /host/var/recovery
-                  name: host-var-recovery
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/boot
+                name: host-boot
+                readOnly: true
+              - mountPath: /host/dev/log
+                name: host-dev-log
+              - mountPath: /host/etc
+                name: host-etc
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/sysroot
+                name: host-sysroot
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/local
+                name: host-usr-local
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib
+                name: host-var-lib
+              - mountPath: /host/var/recovery
+                name: host-var-recovery
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /boot
-                  type: Directory
-                name: host-boot
-              - hostPath:
-                  path: /dev/log
-                  type: Socket
-                name: host-dev-log
-              - hostPath:
-                  path: /etc
-                  type: Directory
-                name: host-etc
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /sysroot
-                  type: Directory
-                name: host-sysroot
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/local
-                  type: Directory
-                name: host-usr-local
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib
-                  type: Directory
-                name: host-var-lib
-              - hostPath:
-                  path: /var/recovery
-                  type: DirectoryOrCreate
-                name: host-var-recovery
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /boot
+                type: Directory
+              name: host-boot
+            - hostPath:
+                path: /dev/log
+                type: Socket
+              name: host-dev-log
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sysroot
+                type: Directory
+              name: host-sysroot
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/local
+                type: Directory
+              name: host-usr-local
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib
+                type: Directory
+              name: host-var-lib
+            - hostPath:
+                path: /var/recovery
+                type: DirectoryOrCreate
+              name: host-var-recovery
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -614,125 +612,122 @@ spec:
                 runAsUser: 0
               tty: true
               volumeMounts:
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/boot
-                  name: host-boot
-                  readOnly: true
-                - mountPath: /host/dev/log
-                  name: host-dev-log
-                - mountPath: /host/etc
-                  name: host-etc
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/sysroot
-                  name: host-sysroot
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/local
-                  name: host-usr-local
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib
-                  name: host-var-lib
-                - mountPath: /host/var/recovery
-                  name: host-var-recovery
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/boot
+                name: host-boot
+                readOnly: true
+              - mountPath: /host/dev/log
+                name: host-dev-log
+              - mountPath: /host/etc
+                name: host-etc
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/sysroot
+                name: host-sysroot
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/local
+                name: host-usr-local
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib
+                name: host-var-lib
+              - mountPath: /host/var/recovery
+                name: host-var-recovery
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             restartPolicy: Never
             serviceAccountName: backup-agent
             volumes:
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /boot
-                  type: Directory
-                name: host-boot
-              - hostPath:
-                  path: /dev/log
-                  type: Socket
-                name: host-dev-log
-              - hostPath:
-                  path: /etc
-                  type: Directory
-                name: host-etc
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /sysroot
-                  type: Directory
-                name: host-sysroot
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/local
-                  type: Directory
-                name: host-usr-local
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib
-                  type: Directory
-                name: host-var-lib
-              - hostPath:
-                  path: /var/recovery
-                  type: DirectoryOrCreate
-                name: host-var-recovery
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /boot
+                type: Directory
+              name: host-boot
+            - hostPath:
+                path: /dev/log
+                type: Socket
+              name: host-dev-log
+            - hostPath:
+                path: /etc
+                type: Directory
+              name: host-etc
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /sysroot
+                type: Directory
+              name: host-sysroot
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/local
+                type: Directory
+              name: host-usr-local
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib
+                type: Directory
+              name: host-var-lib
+            - hostPath:
+                path: /var/recovery
+                type: DirectoryOrCreate
+              name: host-var-recovery
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
 ---
-
-
-

--- a/tests/kuttl/tests/backup-partial-complete/03-assert.yaml
+++ b/tests/kuttl/tests/backup-partial-complete/03-assert.yaml
@@ -29,19 +29,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Backup in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: BackupSuceeded
   - message: Cluster backup is in progress
     reason: NotStarted
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -72,9 +72,9 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl

--- a/tests/kuttl/tests/backup-partial-complete/04-assert.yaml
+++ b/tests/kuttl/tests/backup-partial-complete/04-assert.yaml
@@ -29,19 +29,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Backup failed for 1 clusters
     reason: PartiallyDone
-    status: "True"
+    status: 'True'
     type: BackupSuceeded
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -71,14 +71,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-#MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -121,7 +120,7 @@ spec:
   actionType: Delete
   kube:
     name: backup-agent
-    resource: clusterrolebinding    
+    resource: clusterrolebinding
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction

--- a/tests/kuttl/tests/blocking-mechanisms/00-assert.yaml
+++ b/tests/kuttl/tests/blocking-mechanisms/00-assert.yaml
@@ -25,15 +25,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Not enabled
     reason: NotEnabled
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-a-policy1-common-cluster-version-policy-kuttl
@@ -65,15 +65,15 @@ status:
   - - spoke1
   - - spoke2
   safeResourceNames:
-    cgu-a-common-cluster-version-policy-config: cgu-a-common-cluster-version-policy-config-kuttl
-    cgu-a-common-pao-sub-policy-config: cgu-a-common-pao-sub-policy-config-kuttl
-    cgu-a-common-ptp-sub-policy-config: cgu-a-common-ptp-sub-policy-config-kuttl
-    cgu-a-policy1-common-cluster-version-policy: cgu-a-policy1-common-cluster-version-policy-kuttl
-    cgu-a-policy1-common-cluster-version-policy-placement: cgu-a-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-a-policy2-common-pao-sub-policy: cgu-a-policy2-common-pao-sub-policy-kuttl
-    cgu-a-policy2-common-pao-sub-policy-placement: cgu-a-policy2-common-pao-sub-policy-placement-kuttl
-    cgu-a-policy3-common-ptp-sub-policy: cgu-a-policy3-common-ptp-sub-policy-kuttl
-    cgu-a-policy3-common-ptp-sub-policy-placement: cgu-a-policy3-common-ptp-sub-policy-placement-kuttl
+    /cgu-a-common-cluster-version-policy-config: cgu-a-common-cluster-version-policy-config-kuttl
+    /cgu-a-common-pao-sub-policy-config: cgu-a-common-pao-sub-policy-config-kuttl
+    /cgu-a-common-ptp-sub-policy-config: cgu-a-common-ptp-sub-policy-config-kuttl
+    default/cgu-a-policy1-common-cluster-version-policy: cgu-a-policy1-common-cluster-version-policy-kuttl
+    default/cgu-a-policy1-common-cluster-version-policy-placement: cgu-a-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-a-policy2-common-pao-sub-policy: cgu-a-policy2-common-pao-sub-policy-kuttl
+    default/cgu-a-policy2-common-pao-sub-policy-placement: cgu-a-policy2-common-pao-sub-policy-placement-kuttl
+    default/cgu-a-policy3-common-ptp-sub-policy: cgu-a-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-a-policy3-common-ptp-sub-policy-placement: cgu-a-policy3-common-ptp-sub-policy-placement-kuttl
   status: {}
 ---
 apiVersion: ran.openshift.io/v1alpha1
@@ -101,15 +101,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Not enabled
     reason: NotEnabled
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-b-policy1-common-cluster-version-policy-kuttl
@@ -148,18 +148,18 @@ status:
   - - spoke4
   - - spoke5
   safeResourceNames:
-    cgu-b-common-cluster-version-policy-config: cgu-b-common-cluster-version-policy-config-kuttl
-    cgu-b-common-pao-sub-policy-config: cgu-b-common-pao-sub-policy-config-kuttl
-    cgu-b-common-ptp-sub-policy-config: cgu-b-common-ptp-sub-policy-config-kuttl
-    cgu-b-common-sriov-sub-policy-config: cgu-b-common-sriov-sub-policy-config-kuttl
-    cgu-b-policy1-common-cluster-version-policy: cgu-b-policy1-common-cluster-version-policy-kuttl
-    cgu-b-policy1-common-cluster-version-policy-placement: cgu-b-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-b-policy2-common-pao-sub-policy: cgu-b-policy2-common-pao-sub-policy-kuttl
-    cgu-b-policy2-common-pao-sub-policy-placement: cgu-b-policy2-common-pao-sub-policy-placement-kuttl
-    cgu-b-policy3-common-ptp-sub-policy: cgu-b-policy3-common-ptp-sub-policy-kuttl
-    cgu-b-policy3-common-ptp-sub-policy-placement: cgu-b-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-b-policy4-common-sriov-sub-policy: cgu-b-policy4-common-sriov-sub-policy-kuttl
-    cgu-b-policy4-common-sriov-sub-policy-placement: cgu-b-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-b-common-cluster-version-policy-config: cgu-b-common-cluster-version-policy-config-kuttl
+    /cgu-b-common-pao-sub-policy-config: cgu-b-common-pao-sub-policy-config-kuttl
+    /cgu-b-common-ptp-sub-policy-config: cgu-b-common-ptp-sub-policy-config-kuttl
+    /cgu-b-common-sriov-sub-policy-config: cgu-b-common-sriov-sub-policy-config-kuttl
+    default/cgu-b-policy1-common-cluster-version-policy: cgu-b-policy1-common-cluster-version-policy-kuttl
+    default/cgu-b-policy1-common-cluster-version-policy-placement: cgu-b-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-b-policy2-common-pao-sub-policy: cgu-b-policy2-common-pao-sub-policy-kuttl
+    default/cgu-b-policy2-common-pao-sub-policy-placement: cgu-b-policy2-common-pao-sub-policy-placement-kuttl
+    default/cgu-b-policy3-common-ptp-sub-policy: cgu-b-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-b-policy3-common-ptp-sub-policy-placement: cgu-b-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-b-policy4-common-sriov-sub-policy: cgu-b-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-b-policy4-common-sriov-sub-policy-placement: cgu-b-policy4-common-sriov-sub-policy-placement-kuttl
   status: {}
 ---
 apiVersion: ran.openshift.io/v1alpha1
@@ -183,15 +183,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Not enabled
     reason: NotEnabled
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-c-policy1-common-cluster-version-policy-kuttl
@@ -218,12 +218,10 @@ status:
   remediationPlan:
   - - spoke6
   safeResourceNames:
-    cgu-c-common-cluster-version-policy-config: cgu-c-common-cluster-version-policy-config-kuttl
-    cgu-c-common-sriov-sub-policy-config: cgu-c-common-sriov-sub-policy-config-kuttl
-    cgu-c-policy1-common-cluster-version-policy: cgu-c-policy1-common-cluster-version-policy-kuttl
-    cgu-c-policy1-common-cluster-version-policy-placement: cgu-c-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-c-policy4-common-sriov-sub-policy: cgu-c-policy4-common-sriov-sub-policy-kuttl
-    cgu-c-policy4-common-sriov-sub-policy-placement: cgu-c-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-c-common-cluster-version-policy-config: cgu-c-common-cluster-version-policy-config-kuttl
+    /cgu-c-common-sriov-sub-policy-config: cgu-c-common-sriov-sub-policy-config-kuttl
+    default/cgu-c-policy1-common-cluster-version-policy: cgu-c-policy1-common-cluster-version-policy-kuttl
+    default/cgu-c-policy1-common-cluster-version-policy-placement: cgu-c-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-c-policy4-common-sriov-sub-policy: cgu-c-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-c-policy4-common-sriov-sub-policy-placement: cgu-c-policy4-common-sriov-sub-policy-placement-kuttl
   status: {}
-
-

--- a/tests/kuttl/tests/blocking-mechanisms/01-assert.yaml
+++ b/tests/kuttl/tests/blocking-mechanisms/01-assert.yaml
@@ -25,15 +25,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: 'Blocking CRs that are not completed: [cgu-c]'
     reason: IncompleteBlockingCR
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-a-policy1-common-cluster-version-policy-kuttl
@@ -65,15 +65,15 @@ status:
   - - spoke1
   - - spoke2
   safeResourceNames:
-    cgu-a-common-cluster-version-policy-config: cgu-a-common-cluster-version-policy-config-kuttl
-    cgu-a-common-pao-sub-policy-config: cgu-a-common-pao-sub-policy-config-kuttl
-    cgu-a-common-ptp-sub-policy-config: cgu-a-common-ptp-sub-policy-config-kuttl
-    cgu-a-policy1-common-cluster-version-policy: cgu-a-policy1-common-cluster-version-policy-kuttl
-    cgu-a-policy1-common-cluster-version-policy-placement: cgu-a-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-a-policy2-common-pao-sub-policy: cgu-a-policy2-common-pao-sub-policy-kuttl
-    cgu-a-policy2-common-pao-sub-policy-placement: cgu-a-policy2-common-pao-sub-policy-placement-kuttl
-    cgu-a-policy3-common-ptp-sub-policy: cgu-a-policy3-common-ptp-sub-policy-kuttl
-    cgu-a-policy3-common-ptp-sub-policy-placement: cgu-a-policy3-common-ptp-sub-policy-placement-kuttl
+    /cgu-a-common-cluster-version-policy-config: cgu-a-common-cluster-version-policy-config-kuttl
+    /cgu-a-common-pao-sub-policy-config: cgu-a-common-pao-sub-policy-config-kuttl
+    /cgu-a-common-ptp-sub-policy-config: cgu-a-common-ptp-sub-policy-config-kuttl
+    default/cgu-a-policy1-common-cluster-version-policy: cgu-a-policy1-common-cluster-version-policy-kuttl
+    default/cgu-a-policy1-common-cluster-version-policy-placement: cgu-a-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-a-policy2-common-pao-sub-policy: cgu-a-policy2-common-pao-sub-policy-kuttl
+    default/cgu-a-policy2-common-pao-sub-policy-placement: cgu-a-policy2-common-pao-sub-policy-placement-kuttl
+    default/cgu-a-policy3-common-ptp-sub-policy: cgu-a-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-a-policy3-common-ptp-sub-policy-placement: cgu-a-policy3-common-ptp-sub-policy-placement-kuttl
   status: {}
 ---
 apiVersion: ran.openshift.io/v1alpha1
@@ -101,15 +101,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: 'Blocking CRs that are not completed: [cgu-a]'
     reason: IncompleteBlockingCR
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-b-policy1-common-cluster-version-policy-kuttl
@@ -148,18 +148,18 @@ status:
   - - spoke4
   - - spoke5
   safeResourceNames:
-    cgu-b-common-cluster-version-policy-config: cgu-b-common-cluster-version-policy-config-kuttl
-    cgu-b-common-pao-sub-policy-config: cgu-b-common-pao-sub-policy-config-kuttl
-    cgu-b-common-ptp-sub-policy-config: cgu-b-common-ptp-sub-policy-config-kuttl
-    cgu-b-common-sriov-sub-policy-config: cgu-b-common-sriov-sub-policy-config-kuttl
-    cgu-b-policy1-common-cluster-version-policy: cgu-b-policy1-common-cluster-version-policy-kuttl
-    cgu-b-policy1-common-cluster-version-policy-placement: cgu-b-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-b-policy2-common-pao-sub-policy: cgu-b-policy2-common-pao-sub-policy-kuttl
-    cgu-b-policy2-common-pao-sub-policy-placement: cgu-b-policy2-common-pao-sub-policy-placement-kuttl
-    cgu-b-policy3-common-ptp-sub-policy: cgu-b-policy3-common-ptp-sub-policy-kuttl
-    cgu-b-policy3-common-ptp-sub-policy-placement: cgu-b-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-b-policy4-common-sriov-sub-policy: cgu-b-policy4-common-sriov-sub-policy-kuttl
-    cgu-b-policy4-common-sriov-sub-policy-placement: cgu-b-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-b-common-cluster-version-policy-config: cgu-b-common-cluster-version-policy-config-kuttl
+    /cgu-b-common-pao-sub-policy-config: cgu-b-common-pao-sub-policy-config-kuttl
+    /cgu-b-common-ptp-sub-policy-config: cgu-b-common-ptp-sub-policy-config-kuttl
+    /cgu-b-common-sriov-sub-policy-config: cgu-b-common-sriov-sub-policy-config-kuttl
+    default/cgu-b-policy1-common-cluster-version-policy: cgu-b-policy1-common-cluster-version-policy-kuttl
+    default/cgu-b-policy1-common-cluster-version-policy-placement: cgu-b-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-b-policy2-common-pao-sub-policy: cgu-b-policy2-common-pao-sub-policy-kuttl
+    default/cgu-b-policy2-common-pao-sub-policy-placement: cgu-b-policy2-common-pao-sub-policy-placement-kuttl
+    default/cgu-b-policy3-common-ptp-sub-policy: cgu-b-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-b-policy3-common-ptp-sub-policy-placement: cgu-b-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-b-policy4-common-sriov-sub-policy: cgu-b-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-b-policy4-common-sriov-sub-policy-placement: cgu-b-policy4-common-sriov-sub-policy-placement-kuttl
   status: {}
 ---
 apiVersion: ran.openshift.io/v1alpha1
@@ -183,15 +183,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-c-policy1-common-cluster-version-policy-kuttl
@@ -218,12 +218,12 @@ status:
   remediationPlan:
   - - spoke6
   safeResourceNames:
-    cgu-c-common-cluster-version-policy-config: cgu-c-common-cluster-version-policy-config-kuttl
-    cgu-c-common-sriov-sub-policy-config: cgu-c-common-sriov-sub-policy-config-kuttl
-    cgu-c-policy1-common-cluster-version-policy: cgu-c-policy1-common-cluster-version-policy-kuttl
-    cgu-c-policy1-common-cluster-version-policy-placement: cgu-c-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-c-policy4-common-sriov-sub-policy: cgu-c-policy4-common-sriov-sub-policy-kuttl
-    cgu-c-policy4-common-sriov-sub-policy-placement: cgu-c-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-c-common-cluster-version-policy-config: cgu-c-common-cluster-version-policy-config-kuttl
+    /cgu-c-common-sriov-sub-policy-config: cgu-c-common-sriov-sub-policy-config-kuttl
+    default/cgu-c-policy1-common-cluster-version-policy: cgu-c-policy1-common-cluster-version-policy-kuttl
+    default/cgu-c-policy1-common-cluster-version-policy-placement: cgu-c-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-c-policy4-common-sriov-sub-policy: cgu-c-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-c-policy4-common-sriov-sub-policy-placement: cgu-c-policy4-common-sriov-sub-policy-placement-kuttl
   status:
     currentBatch: 1
     currentBatchRemediationProgress:

--- a/tests/kuttl/tests/blocking-mechanisms/02-assert.yaml
+++ b/tests/kuttl/tests/blocking-mechanisms/02-assert.yaml
@@ -1,4 +1,3 @@
-# Ensure that cgu-a has been unblocked
 apiVersion: ran.openshift.io/v1alpha1
 kind: ClusterGroupUpgrade
 metadata:
@@ -26,15 +25,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-a-policy1-common-cluster-version-policy-kuttl
@@ -66,15 +65,15 @@ status:
   - - spoke1
   - - spoke2
   safeResourceNames:
-    cgu-a-common-cluster-version-policy-config: cgu-a-common-cluster-version-policy-config-kuttl
-    cgu-a-common-pao-sub-policy-config: cgu-a-common-pao-sub-policy-config-kuttl
-    cgu-a-common-ptp-sub-policy-config: cgu-a-common-ptp-sub-policy-config-kuttl
-    cgu-a-policy1-common-cluster-version-policy: cgu-a-policy1-common-cluster-version-policy-kuttl
-    cgu-a-policy1-common-cluster-version-policy-placement: cgu-a-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-a-policy2-common-pao-sub-policy: cgu-a-policy2-common-pao-sub-policy-kuttl
-    cgu-a-policy2-common-pao-sub-policy-placement: cgu-a-policy2-common-pao-sub-policy-placement-kuttl
-    cgu-a-policy3-common-ptp-sub-policy: cgu-a-policy3-common-ptp-sub-policy-kuttl
-    cgu-a-policy3-common-ptp-sub-policy-placement: cgu-a-policy3-common-ptp-sub-policy-placement-kuttl
+    /cgu-a-common-cluster-version-policy-config: cgu-a-common-cluster-version-policy-config-kuttl
+    /cgu-a-common-pao-sub-policy-config: cgu-a-common-pao-sub-policy-config-kuttl
+    /cgu-a-common-ptp-sub-policy-config: cgu-a-common-ptp-sub-policy-config-kuttl
+    default/cgu-a-policy1-common-cluster-version-policy: cgu-a-policy1-common-cluster-version-policy-kuttl
+    default/cgu-a-policy1-common-cluster-version-policy-placement: cgu-a-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-a-policy2-common-pao-sub-policy: cgu-a-policy2-common-pao-sub-policy-kuttl
+    default/cgu-a-policy2-common-pao-sub-policy-placement: cgu-a-policy2-common-pao-sub-policy-placement-kuttl
+    default/cgu-a-policy3-common-ptp-sub-policy: cgu-a-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-a-policy3-common-ptp-sub-policy-placement: cgu-a-policy3-common-ptp-sub-policy-placement-kuttl
   status:
     currentBatch: 1
     currentBatchRemediationProgress:
@@ -82,7 +81,6 @@ status:
         policyIndex: 0
         state: InProgress
 ---
-# Check that cgu-b is still blocked
 apiVersion: ran.openshift.io/v1alpha1
 kind: ClusterGroupUpgrade
 metadata:
@@ -108,15 +106,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: 'Blocking CRs that are not completed: [cgu-a]'
     reason: IncompleteBlockingCR
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-b-policy1-common-cluster-version-policy-kuttl
@@ -155,16 +153,16 @@ status:
   - - spoke4
   - - spoke5
   safeResourceNames:
-    cgu-b-common-cluster-version-policy-config: cgu-b-common-cluster-version-policy-config-kuttl
-    cgu-b-common-pao-sub-policy-config: cgu-b-common-pao-sub-policy-config-kuttl
-    cgu-b-common-ptp-sub-policy-config: cgu-b-common-ptp-sub-policy-config-kuttl
-    cgu-b-common-sriov-sub-policy-config: cgu-b-common-sriov-sub-policy-config-kuttl
-    cgu-b-policy1-common-cluster-version-policy: cgu-b-policy1-common-cluster-version-policy-kuttl
-    cgu-b-policy1-common-cluster-version-policy-placement: cgu-b-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-b-policy2-common-pao-sub-policy: cgu-b-policy2-common-pao-sub-policy-kuttl
-    cgu-b-policy2-common-pao-sub-policy-placement: cgu-b-policy2-common-pao-sub-policy-placement-kuttl
-    cgu-b-policy3-common-ptp-sub-policy: cgu-b-policy3-common-ptp-sub-policy-kuttl
-    cgu-b-policy3-common-ptp-sub-policy-placement: cgu-b-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-b-policy4-common-sriov-sub-policy: cgu-b-policy4-common-sriov-sub-policy-kuttl
-    cgu-b-policy4-common-sriov-sub-policy-placement: cgu-b-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-b-common-cluster-version-policy-config: cgu-b-common-cluster-version-policy-config-kuttl
+    /cgu-b-common-pao-sub-policy-config: cgu-b-common-pao-sub-policy-config-kuttl
+    /cgu-b-common-ptp-sub-policy-config: cgu-b-common-ptp-sub-policy-config-kuttl
+    /cgu-b-common-sriov-sub-policy-config: cgu-b-common-sriov-sub-policy-config-kuttl
+    default/cgu-b-policy1-common-cluster-version-policy: cgu-b-policy1-common-cluster-version-policy-kuttl
+    default/cgu-b-policy1-common-cluster-version-policy-placement: cgu-b-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-b-policy2-common-pao-sub-policy: cgu-b-policy2-common-pao-sub-policy-kuttl
+    default/cgu-b-policy2-common-pao-sub-policy-placement: cgu-b-policy2-common-pao-sub-policy-placement-kuttl
+    default/cgu-b-policy3-common-ptp-sub-policy: cgu-b-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-b-policy3-common-ptp-sub-policy-placement: cgu-b-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-b-policy4-common-sriov-sub-policy: cgu-b-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-b-policy4-common-sriov-sub-policy-placement: cgu-b-policy4-common-sriov-sub-policy-placement-kuttl
   status: {}

--- a/tests/kuttl/tests/cluster-selector/00-assert.yaml
+++ b/tests/kuttl/tests/cluster-selector/00-assert.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   clusterLabelSelectors:
   - matchLabels:
-      upgrade2: "true"
+      upgrade2: 'true'
   - matchExpressions:
-      - key: upgrade
-        operator: Exists
+    - key: upgrade
+      operator: Exists
   clusters:
   - spoke1
   - spoke2
@@ -28,15 +28,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Not enabled
     reason: NotEnabled
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-cluster-selector-policy1-common-cluster-versi-kuttl
@@ -78,17 +78,16 @@ status:
     - spoke6
   - - spoke4
   safeResourceNames:
-    cgu-cluster-selector-common-cluster-version-policy-config: cgu-cluster-selector-common-cluster-version-policy-config-kuttl
-    cgu-cluster-selector-common-pao-sub-policy-config: cgu-cluster-selector-common-pao-sub-policy-config-kuttl
-    cgu-cluster-selector-common-ptp-sub-policy-config: cgu-cluster-selector-common-ptp-sub-policy-config-kuttl
-    cgu-cluster-selector-common-sriov-sub-policy-config: cgu-cluster-selector-common-sriov-sub-policy-config-kuttl
-    cgu-cluster-selector-policy1-common-cluster-version-policy: cgu-cluster-selector-policy1-common-cluster-versi-kuttl
-    cgu-cluster-selector-policy1-common-cluster-version-policy-placement: cgu-cluster-selector-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-cluster-selector-policy2-common-pao-sub-policy: cgu-cluster-selector-policy2-common-pao-sub-polic-kuttl
-    cgu-cluster-selector-policy2-common-pao-sub-policy-placement: cgu-cluster-selector-policy2-common-pao-sub-policy-placement-kuttl
-    cgu-cluster-selector-policy3-common-ptp-sub-policy: cgu-cluster-selector-policy3-common-ptp-sub-polic-kuttl
-    cgu-cluster-selector-policy3-common-ptp-sub-policy-placement: cgu-cluster-selector-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-cluster-selector-policy4-common-sriov-sub-policy: cgu-cluster-selector-policy4-common-sriov-sub-pol-kuttl
-    cgu-cluster-selector-policy4-common-sriov-sub-policy-placement: cgu-cluster-selector-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-cluster-selector-common-cluster-version-policy-config: cgu-cluster-selector-common-cluster-version-policy-confi-kuttl
+    /cgu-cluster-selector-common-pao-sub-policy-config: cgu-cluster-selector-common-pao-sub-policy-config-kuttl
+    /cgu-cluster-selector-common-ptp-sub-policy-config: cgu-cluster-selector-common-ptp-sub-policy-config-kuttl
+    /cgu-cluster-selector-common-sriov-sub-policy-config: cgu-cluster-selector-common-sriov-sub-policy-config-kuttl
+    default/cgu-cluster-selector-policy1-common-cluster-version-policy: cgu-cluster-selector-policy1-common-cluster-versi-kuttl
+    default/cgu-cluster-selector-policy1-common-cluster-version-policy-placement: cgu-cluster-selector-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-cluster-selector-policy2-common-pao-sub-policy: cgu-cluster-selector-policy2-common-pao-sub-polic-kuttl
+    default/cgu-cluster-selector-policy2-common-pao-sub-policy-placement: cgu-cluster-selector-policy2-common-pao-sub-policy-placement-kuttl
+    default/cgu-cluster-selector-policy3-common-ptp-sub-policy: cgu-cluster-selector-policy3-common-ptp-sub-polic-kuttl
+    default/cgu-cluster-selector-policy3-common-ptp-sub-policy-placement: cgu-cluster-selector-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-cluster-selector-policy4-common-sriov-sub-policy: cgu-cluster-selector-policy4-common-sriov-sub-pol-kuttl
+    default/cgu-cluster-selector-policy4-common-sriov-sub-policy-placement: cgu-cluster-selector-policy4-common-sriov-sub-policy-placement-kuttl
   status: {}
-

--- a/tests/kuttl/tests/do-not-skip-compliant-policies-with-status/00-assert.yaml
+++ b/tests/kuttl/tests/do-not-skip-compliant-policies-with-status/00-assert.yaml
@@ -23,15 +23,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-policy1-common-cluster-version-policy-kuttl
@@ -72,19 +72,19 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-cluster-version-policy-config: cgu-common-cluster-version-policy-config-kuttl
-    cgu-common-pao-sub-policy-config: cgu-common-pao-sub-policy-config-kuttl
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-default-subscription-ptp-operator-subscription: cgu-default-subscription-ptp-operator-subscription-kuttl
-    cgu-default-subscription-sriov-network-operator-subscription: cgu-default-subscription-sriov-network-operator-subscription-kuttl
-    cgu-policy1-common-cluster-version-policy: cgu-policy1-common-cluster-version-policy-kuttl
-    cgu-policy1-common-cluster-version-policy-placement: cgu-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-policy2-common-pao-sub-policy: cgu-policy2-common-pao-sub-policy-kuttl
-    cgu-policy2-common-pao-sub-policy-placement: cgu-policy2-common-pao-sub-policy-placement-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    /cgu-common-cluster-version-policy-config: cgu-common-cluster-version-policy-config-kuttl
+    /cgu-common-pao-sub-policy-config: cgu-common-pao-sub-policy-config-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    /cgu-default-subscription-ptp-operator-subscription: cgu-default-subscription-ptp-operator-subscription-kuttl
+    /cgu-default-subscription-sriov-network-operator-subscription: cgu-default-subscription-sriov-network-operator-subscription-kuttl
+    default/cgu-policy1-common-cluster-version-policy: cgu-policy1-common-cluster-version-policy-kuttl
+    default/cgu-policy1-common-cluster-version-policy-placement: cgu-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-policy2-common-pao-sub-policy: cgu-policy2-common-pao-sub-policy-kuttl
+    default/cgu-policy2-common-pao-sub-policy-placement: cgu-policy2-common-pao-sub-policy-placement-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
   status:
     currentBatch: 1
     currentBatchRemediationProgress:

--- a/tests/kuttl/tests/duplicated-managed-policy-name/02-assert.yaml
+++ b/tests/kuttl/tests/duplicated-managed-policy-name/02-assert.yaml
@@ -29,15 +29,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-policy1-common-cluster-version-policy-kuttl
@@ -78,19 +78,19 @@ status:
   - - spoke4
     - spoke6
   safeResourceNames:
-    cgu-common-cluster-version-policy-config: cgu-common-cluster-version-policy-config-kuttl
-    cgu-common-pao-sub-policy-config: cgu-common-pao-sub-policy-config-kuttl
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-default-subscription-performance-addon-operator: cgu-default-subscription-performance-addon-operator-kuttl
-    cgu-policy1-common-cluster-version-policy: cgu-policy1-common-cluster-version-policy-kuttl
-    cgu-policy1-common-cluster-version-policy-placement: cgu-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-policy2-common-pao-sub-policy: cgu-policy2-common-pao-sub-policy-kuttl
-    cgu-policy2-common-pao-sub-policy-placement: cgu-policy2-common-pao-sub-policy-placement-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-cluster-version-policy-config: cgu-common-cluster-version-policy-config-kuttl
+    /cgu-common-pao-sub-policy-config: cgu-common-pao-sub-policy-config-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    /cgu-default-subscription-performance-addon-operator: cgu-default-subscription-performance-addon-operator-kuttl
+    default/cgu-policy1-common-cluster-version-policy: cgu-policy1-common-cluster-version-policy-kuttl
+    default/cgu-policy1-common-cluster-version-policy-placement: cgu-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-policy2-common-pao-sub-policy: cgu-policy2-common-pao-sub-policy-kuttl
+    default/cgu-policy2-common-pao-sub-policy-placement: cgu-policy2-common-pao-sub-policy-placement-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
   status:
     currentBatch: 1
     currentBatchRemediationProgress:

--- a/tests/kuttl/tests/operator-upgrade/00-assert.yaml
+++ b/tests/kuttl/tests/operator-upgrade/00-assert.yaml
@@ -20,15 +20,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Not enabled
     reason: NotEnabled
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-policy5-subscriptions-kuttl
@@ -48,7 +48,7 @@ status:
     - spoke2
   - - spoke5
   safeResourceNames:
-    cgu-common-subscriptions-policy-config: cgu-common-subscriptions-policy-config-kuttl
-    cgu-policy5-subscriptions: cgu-policy5-subscriptions-kuttl
-    cgu-policy5-subscriptions-placement: cgu-policy5-subscriptions-placement-kuttl
+    /cgu-common-subscriptions-policy-config: cgu-common-subscriptions-policy-config-kuttl
+    default/cgu-policy5-subscriptions: cgu-policy5-subscriptions-kuttl
+    default/cgu-policy5-subscriptions-placement: cgu-policy5-subscriptions-placement-kuttl
   status: {}

--- a/tests/kuttl/tests/operator-upgrade/01-assert.yaml
+++ b/tests/kuttl/tests/operator-upgrade/01-assert.yaml
@@ -20,15 +20,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-policy5-subscriptions-kuttl
@@ -48,14 +48,14 @@ status:
     - spoke2
   - - spoke5
   safeResourceNames:
-    cgu-common-subscriptions-policy-config: cgu-common-subscriptions-policy-config-kuttl
-    cgu-default-subscription-cluster-logging: cgu-default-subscription-cluster-logging-kuttl
-    cgu-default-subscription-local-storage-operator: cgu-default-subscription-local-storage-operator-kuttl
-    cgu-default-subscription-performance-addon-operator: cgu-default-subscription-performance-addon-operator-kuttl
-    cgu-default-subscription-ptp-operator-subscription: cgu-default-subscription-ptp-operator-subscription-kuttl
-    cgu-default-subscription-sriov-network-operator-subscription: cgu-default-subscription-sriov-network-operator-subscription-kuttl
-    cgu-policy5-subscriptions: cgu-policy5-subscriptions-kuttl
-    cgu-policy5-subscriptions-placement: cgu-policy5-subscriptions-placement-kuttl
+    /cgu-common-subscriptions-policy-config: cgu-common-subscriptions-policy-config-kuttl
+    /cgu-default-subscription-cluster-logging: cgu-default-subscription-cluster-logging-kuttl
+    /cgu-default-subscription-local-storage-operator: cgu-default-subscription-local-storage-operator-kuttl
+    /cgu-default-subscription-performance-addon-operator: cgu-default-subscription-performance-addon-operator-kuttl
+    /cgu-default-subscription-ptp-operator-subscription: cgu-default-subscription-ptp-operator-subscription-kuttl
+    /cgu-default-subscription-sriov-network-operator-subscription: cgu-default-subscription-sriov-network-operator-subscription-kuttl
+    default/cgu-policy5-subscriptions: cgu-policy5-subscriptions-kuttl
+    default/cgu-policy5-subscriptions-placement: cgu-policy5-subscriptions-placement-kuttl
   status:
     currentBatch: 1
     currentBatchRemediationProgress:
@@ -66,8 +66,6 @@ status:
         policyIndex: 0
         state: InProgress
 ---
-# Check that all the ManagedClusterViews exist in all the spoke namespaces.
-# Check for the cluster logging operator subscription.
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
@@ -90,7 +88,6 @@ spec:
     namespace: openshift-logging
     resource: Subscription.operators.coreos.com
 ---
-# Check for the local storage operator subscription.
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
@@ -113,7 +110,6 @@ spec:
     namespace: openshift-local-storage
     resource: Subscription.operators.coreos.com
 ---
-# Check for the PAO operator subscription.
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
@@ -136,7 +132,6 @@ spec:
     namespace: openshift-performance-addon-operator
     resource: Subscription.operators.coreos.com
 ---
-# Check for the PTP operator subscription.
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
@@ -159,7 +154,6 @@ spec:
     namespace: openshift-ptp
     resource: Subscription.operators.coreos.com
 ---
-# Check for the SRIOV operator subscription.
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:

--- a/tests/kuttl/tests/operator-upgrade/02-assert.yaml
+++ b/tests/kuttl/tests/operator-upgrade/02-assert.yaml
@@ -20,15 +20,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-policy5-subscriptions-kuttl
@@ -48,14 +48,14 @@ status:
     - spoke2
   - - spoke5
   safeResourceNames:
-    cgu-common-subscriptions-policy-config: cgu-common-subscriptions-policy-config-kuttl
-    cgu-default-subscription-cluster-logging: cgu-default-subscription-cluster-logging-kuttl
-    cgu-default-subscription-local-storage-operator: cgu-default-subscription-local-storage-operator-kuttl
-    cgu-default-subscription-performance-addon-operator: cgu-default-subscription-performance-addon-operator-kuttl
-    cgu-default-subscription-ptp-operator-subscription: cgu-default-subscription-ptp-operator-subscription-kuttl
-    cgu-default-subscription-sriov-network-operator-subscription: cgu-default-subscription-sriov-network-operator-subscription-kuttl
-    cgu-policy5-subscriptions: cgu-policy5-subscriptions-kuttl
-    cgu-policy5-subscriptions-placement: cgu-policy5-subscriptions-placement-kuttl
+    /cgu-common-subscriptions-policy-config: cgu-common-subscriptions-policy-config-kuttl
+    /cgu-default-subscription-cluster-logging: cgu-default-subscription-cluster-logging-kuttl
+    /cgu-default-subscription-local-storage-operator: cgu-default-subscription-local-storage-operator-kuttl
+    /cgu-default-subscription-performance-addon-operator: cgu-default-subscription-performance-addon-operator-kuttl
+    /cgu-default-subscription-ptp-operator-subscription: cgu-default-subscription-ptp-operator-subscription-kuttl
+    /cgu-default-subscription-sriov-network-operator-subscription: cgu-default-subscription-sriov-network-operator-subscription-kuttl
+    default/cgu-policy5-subscriptions: cgu-policy5-subscriptions-kuttl
+    default/cgu-policy5-subscriptions-placement: cgu-policy5-subscriptions-placement-kuttl
   status:
     currentBatch: 1
     currentBatchRemediationProgress:
@@ -66,8 +66,6 @@ status:
         policyIndex: 0
         state: InProgress
 ---
-# Check the ManagedClusterActions for approving the install plans have been created.
-# Check spoke1.
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
@@ -133,7 +131,6 @@ spec:
     namespace: openshift-sriov-network-operator
     resource: InstallPlan
 ---
-# Check spoke2
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:

--- a/tests/kuttl/tests/operator-upgrade/04-assert.yaml
+++ b/tests/kuttl/tests/operator-upgrade/04-assert.yaml
@@ -17,21 +17,21 @@ spec:
     timeout: 240
 status:
   clusters:
-    - name: spoke1
-      state: complete      
+  - name: spoke1
+    state: complete
   computedMaxConcurrency: 2
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-policy5-subscriptions-kuttl
@@ -51,14 +51,14 @@ status:
     - spoke2
   - - spoke5
   safeResourceNames:
-    cgu-common-subscriptions-policy-config: cgu-common-subscriptions-policy-config-kuttl
-    cgu-default-subscription-cluster-logging: cgu-default-subscription-cluster-logging-kuttl
-    cgu-default-subscription-local-storage-operator: cgu-default-subscription-local-storage-operator-kuttl
-    cgu-default-subscription-performance-addon-operator: cgu-default-subscription-performance-addon-operator-kuttl
-    cgu-default-subscription-ptp-operator-subscription: cgu-default-subscription-ptp-operator-subscription-kuttl
-    cgu-default-subscription-sriov-network-operator-subscription: cgu-default-subscription-sriov-network-operator-subscription-kuttl
-    cgu-policy5-subscriptions: cgu-policy5-subscriptions-kuttl
-    cgu-policy5-subscriptions-placement: cgu-policy5-subscriptions-placement-kuttl
+    /cgu-common-subscriptions-policy-config: cgu-common-subscriptions-policy-config-kuttl
+    /cgu-default-subscription-cluster-logging: cgu-default-subscription-cluster-logging-kuttl
+    /cgu-default-subscription-local-storage-operator: cgu-default-subscription-local-storage-operator-kuttl
+    /cgu-default-subscription-performance-addon-operator: cgu-default-subscription-performance-addon-operator-kuttl
+    /cgu-default-subscription-ptp-operator-subscription: cgu-default-subscription-ptp-operator-subscription-kuttl
+    /cgu-default-subscription-sriov-network-operator-subscription: cgu-default-subscription-sriov-network-operator-subscription-kuttl
+    default/cgu-policy5-subscriptions: cgu-policy5-subscriptions-kuttl
+    default/cgu-policy5-subscriptions-placement: cgu-policy5-subscriptions-placement-kuttl
   status:
     currentBatch: 1
     currentBatchRemediationProgress:
@@ -67,7 +67,6 @@ status:
       spoke2:
         policyIndex: 0
         state: InProgress
-# Spoke2 mcv should be still around
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
@@ -129,7 +128,6 @@ metadata:
   name: install-bbbb5
   namespace: spoke2
 ---
-# MCAs should be there for both
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:

--- a/tests/kuttl/tests/policy-has-missing-cluster-status/00-assert.yaml
+++ b/tests/kuttl/tests/policy-has-missing-cluster-status/00-assert.yaml
@@ -22,15 +22,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Not enabled
     reason: NotEnabled
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-policy2-common-pao-sub-policy-kuttl
@@ -57,10 +57,10 @@ status:
     - spoke2
   - - spoke4
   safeResourceNames:
-    cgu-common-pao-sub-policy-config: cgu-common-pao-sub-policy-config-kuttl
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-policy2-common-pao-sub-policy: cgu-policy2-common-pao-sub-policy-kuttl
-    cgu-policy2-common-pao-sub-policy-placement: cgu-policy2-common-pao-sub-policy-placement-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    /cgu-common-pao-sub-policy-config: cgu-common-pao-sub-policy-config-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    default/cgu-policy2-common-pao-sub-policy: cgu-policy2-common-pao-sub-policy-kuttl
+    default/cgu-policy2-common-pao-sub-policy-placement: cgu-policy2-common-pao-sub-policy-placement-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
   status: {}

--- a/tests/kuttl/tests/policy-has-missing-cluster-status/01-assert.yaml
+++ b/tests/kuttl/tests/policy-has-missing-cluster-status/01-assert.yaml
@@ -22,15 +22,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-policy2-common-pao-sub-policy-kuttl
@@ -57,14 +57,14 @@ status:
     - spoke2
   - - spoke4
   safeResourceNames:
-    cgu-common-pao-sub-policy-config: cgu-common-pao-sub-policy-config-kuttl
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-default-subscription-performance-addon-operator: cgu-default-subscription-performance-addon-operator-kuttl
-    cgu-default-subscription-ptp-operator-subscription: cgu-default-subscription-ptp-operator-subscription-kuttl
-    cgu-policy2-common-pao-sub-policy: cgu-policy2-common-pao-sub-policy-kuttl
-    cgu-policy2-common-pao-sub-policy-placement: cgu-policy2-common-pao-sub-policy-placement-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    /cgu-common-pao-sub-policy-config: cgu-common-pao-sub-policy-config-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-default-subscription-performance-addon-operator: cgu-default-subscription-performance-addon-operator-kuttl
+    /cgu-default-subscription-ptp-operator-subscription: cgu-default-subscription-ptp-operator-subscription-kuttl
+    default/cgu-policy2-common-pao-sub-policy: cgu-policy2-common-pao-sub-policy-kuttl
+    default/cgu-policy2-common-pao-sub-policy-placement: cgu-policy2-common-pao-sub-policy-placement-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
   status:
     currentBatch: 1
     currentBatchRemediationProgress:

--- a/tests/kuttl/tests/pre-caching-complete/00-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/00-assert.yaml
@@ -24,19 +24,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
-    status: "True"
+    status: 'True'
     type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -69,7 +69,7 @@ status:
       - ptp-operator:4.9
       - sriov-network-operator:4.9
       - performance-addon-operator:4.9
-      spaceRequired: "35"
+      spaceRequired: '35'
     status:
       spoke1: PreparingToStart
       spoke2: PreparingToStart
@@ -81,14 +81,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-#MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -177,7 +176,6 @@ spec:
     name: pre-cache-crb
     resource: clusterrolebinding
 ---
-#MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:

--- a/tests/kuttl/tests/pre-caching-complete/01-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/01-assert.yaml
@@ -25,19 +25,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
-    status: "True"
+    status: 'True'
     type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -70,7 +70,7 @@ status:
       - ptp-operator:4.9
       - sriov-network-operator:4.9
       - performance-addon-operator:4.9
-      spaceRequired: "35"
+      spaceRequired: '35'
     status:
       spoke1: Starting
       spoke2: Starting
@@ -82,14 +82,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-# MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -160,10 +159,12 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11 \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9  \nperformance-addon-operator:4.9 \n"
+        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
+          \ \n"
+        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
+          \  \nperformance-addon-operator:4.9 \n"
         platform.image: null
-        spaceRequired: "35"
+        spaceRequired: '35'
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -239,10 +240,12 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11 \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9  \nperformance-addon-operator:4.9 \n"
+        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
+          \ \n"
+        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
+          \  \nperformance-addon-operator:4.9 \n"
         platform.image: null
-        spaceRequired: "35"
+        spaceRequired: '35'
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -318,10 +321,12 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11 \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9  \nperformance-addon-operator:4.9 \n"
+        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
+          \ \n"
+        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
+          \  \nperformance-addon-operator:4.9 \n"
         platform.image: null
-        spaceRequired: "35"
+        spaceRequired: '35'
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -397,16 +402,17 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11 \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9  \nperformance-addon-operator:4.9 \n"
+        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
+          \ \n"
+        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
+          \  \nperformance-addon-operator:4.9 \n"
         platform.image: null
-        spaceRequired: "35"
+        spaceRequired: '35'
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
         namespace: openshift-talo-pre-cache
 ---
-#MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
@@ -416,7 +422,7 @@ spec:
   scope:
     name: pre-cache-crb
     resource: clusterrolebinding
-    updateIntervalSeconds: 30    
+    updateIntervalSeconds: 30
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
@@ -431,7 +437,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
@@ -482,7 +488,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
@@ -533,7 +539,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
@@ -584,7 +590,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1

--- a/tests/kuttl/tests/pre-caching-complete/02-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/02-assert.yaml
@@ -25,19 +25,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
-    status: "True"
+    status: 'True'
     type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -70,7 +70,7 @@ status:
       - ptp-operator:4.9
       - sriov-network-operator:4.9
       - performance-addon-operator:4.9
-      spaceRequired: "35"
+      spaceRequired: '35'
     status:
       spoke1: Starting
       spoke2: Starting
@@ -82,14 +82,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-# MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:

--- a/tests/kuttl/tests/pre-caching-complete/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/03-assert.yaml
@@ -25,19 +25,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
-    status: "True"
+    status: 'True'
     type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -70,7 +70,7 @@ status:
       - ptp-operator:4.9
       - sriov-network-operator:4.9
       - performance-addon-operator:4.9
-      spaceRequired: "35"
+      spaceRequired: '35'
     status:
       spoke1: Starting
       spoke2: Starting
@@ -82,14 +82,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-# MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -139,58 +138,58 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-                - mountPath: /etc/config
-                  name: config-volume
-                  readOnly: true
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/etc/containers
-                  name: host-etc-containers
-                  readOnly: true
-                - mountPath: /host/etc/pki/ca-trust
-                  name: host-etc-pki-ca-trust
-                  readOnly: true
-                - mountPath: /host/etc/resolv.conf
-                  name: host-etc-resolv-conf
-                  readOnly: true
-                - mountPath: /host/lib64
-                  name: host-lib64
-                  readOnly: true
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /etc/config
+                name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/etc/containers
+                name: host-etc-containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc-pki-ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc-resolv-conf
+                readOnly: true
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib/cni
+                name: host-var-lib-cni
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var-lib-containers
+              - mountPath: /host/var/lib/kubelet
+                name: host-var-lib-kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
             restartPolicy: Never
@@ -198,81 +197,81 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
-              - configMap:
-                  defaultMode: 420
-                  name: pre-cache-spec
-                name: config-volume
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /etc/containers
-                  type: Directory
-                name: host-etc-containers
-              - hostPath:
-                  path: /etc/pki/ca-trust
-                  type: Directory
-                name: host-etc-pki-ca-trust
-              - hostPath:
-                  path: /etc/resolv.conf
-                  type: File
-                name: host-etc-resolv-conf
-              - hostPath:
-                  path: /lib64
-                  type: Directory
-                name: host-lib64
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib/cni
-                  type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
----              
+            - configMap:
+                defaultMode: 420
+                name: pre-cache-spec
+              name: config-volume
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /etc/containers
+                type: Directory
+              name: host-etc-containers
+            - hostPath:
+                path: /etc/pki/ca-trust
+                type: Directory
+              name: host-etc-pki-ca-trust
+            - hostPath:
+                path: /etc/resolv.conf
+                type: File
+              name: host-etc-resolv-conf
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib/cni
+                type: Directory
+              name: host-var-lib-cni
+            - hostPath:
+                path: /var/lib/containers
+                type: Directory
+              name: host-var-lib-containers
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -322,58 +321,58 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-                - mountPath: /etc/config
-                  name: config-volume
-                  readOnly: true
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/etc/containers
-                  name: host-etc-containers
-                  readOnly: true
-                - mountPath: /host/etc/pki/ca-trust
-                  name: host-etc-pki-ca-trust
-                  readOnly: true
-                - mountPath: /host/etc/resolv.conf
-                  name: host-etc-resolv-conf
-                  readOnly: true
-                - mountPath: /host/lib64
-                  name: host-lib64
-                  readOnly: true
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /etc/config
+                name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/etc/containers
+                name: host-etc-containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc-pki-ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc-resolv-conf
+                readOnly: true
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib/cni
+                name: host-var-lib-cni
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var-lib-containers
+              - mountPath: /host/var/lib/kubelet
+                name: host-var-lib-kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
             restartPolicy: Never
@@ -381,81 +380,81 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
-              - configMap:
-                  defaultMode: 420
-                  name: pre-cache-spec
-                name: config-volume
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /etc/containers
-                  type: Directory
-                name: host-etc-containers
-              - hostPath:
-                  path: /etc/pki/ca-trust
-                  type: Directory
-                name: host-etc-pki-ca-trust
-              - hostPath:
-                  path: /etc/resolv.conf
-                  type: File
-                name: host-etc-resolv-conf
-              - hostPath:
-                  path: /lib64
-                  type: Directory
-                name: host-lib64
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib/cni
-                  type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
----              
+            - configMap:
+                defaultMode: 420
+                name: pre-cache-spec
+              name: config-volume
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /etc/containers
+                type: Directory
+              name: host-etc-containers
+            - hostPath:
+                path: /etc/pki/ca-trust
+                type: Directory
+              name: host-etc-pki-ca-trust
+            - hostPath:
+                path: /etc/resolv.conf
+                type: File
+              name: host-etc-resolv-conf
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib/cni
+                type: Directory
+              name: host-var-lib-cni
+            - hostPath:
+                path: /var/lib/containers
+                type: Directory
+              name: host-var-lib-containers
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -505,58 +504,58 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-                - mountPath: /etc/config
-                  name: config-volume
-                  readOnly: true
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/etc/containers
-                  name: host-etc-containers
-                  readOnly: true
-                - mountPath: /host/etc/pki/ca-trust
-                  name: host-etc-pki-ca-trust
-                  readOnly: true
-                - mountPath: /host/etc/resolv.conf
-                  name: host-etc-resolv-conf
-                  readOnly: true
-                - mountPath: /host/lib64
-                  name: host-lib64
-                  readOnly: true
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /etc/config
+                name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/etc/containers
+                name: host-etc-containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc-pki-ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc-resolv-conf
+                readOnly: true
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib/cni
+                name: host-var-lib-cni
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var-lib-containers
+              - mountPath: /host/var/lib/kubelet
+                name: host-var-lib-kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
             restartPolicy: Never
@@ -564,81 +563,81 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
-              - configMap:
-                  defaultMode: 420
-                  name: pre-cache-spec
-                name: config-volume
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /etc/containers
-                  type: Directory
-                name: host-etc-containers
-              - hostPath:
-                  path: /etc/pki/ca-trust
-                  type: Directory
-                name: host-etc-pki-ca-trust
-              - hostPath:
-                  path: /etc/resolv.conf
-                  type: File
-                name: host-etc-resolv-conf
-              - hostPath:
-                  path: /lib64
-                  type: Directory
-                name: host-lib64
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib/cni
-                  type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
----              
+            - configMap:
+                defaultMode: 420
+                name: pre-cache-spec
+              name: config-volume
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /etc/containers
+                type: Directory
+              name: host-etc-containers
+            - hostPath:
+                path: /etc/pki/ca-trust
+                type: Directory
+              name: host-etc-pki-ca-trust
+            - hostPath:
+                path: /etc/resolv.conf
+                type: File
+              name: host-etc-resolv-conf
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib/cni
+                type: Directory
+              name: host-var-lib-cni
+            - hostPath:
+                path: /var/lib/containers
+                type: Directory
+              name: host-var-lib-containers
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -688,58 +687,58 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-                - mountPath: /etc/config
-                  name: config-volume
-                  readOnly: true
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/etc/containers
-                  name: host-etc-containers
-                  readOnly: true
-                - mountPath: /host/etc/pki/ca-trust
-                  name: host-etc-pki-ca-trust
-                  readOnly: true
-                - mountPath: /host/etc/resolv.conf
-                  name: host-etc-resolv-conf
-                  readOnly: true
-                - mountPath: /host/lib64
-                  name: host-lib64
-                  readOnly: true
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /etc/config
+                name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/etc/containers
+                name: host-etc-containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc-pki-ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc-resolv-conf
+                readOnly: true
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib/cni
+                name: host-var-lib-cni
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var-lib-containers
+              - mountPath: /host/var/lib/kubelet
+                name: host-var-lib-kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
             restartPolicy: Never
@@ -747,77 +746,77 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
-              - configMap:
-                  defaultMode: 420
-                  name: pre-cache-spec
-                name: config-volume
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /etc/containers
-                  type: Directory
-                name: host-etc-containers
-              - hostPath:
-                  path: /etc/pki/ca-trust
-                  type: Directory
-                name: host-etc-pki-ca-trust
-              - hostPath:
-                  path: /etc/resolv.conf
-                  type: File
-                name: host-etc-resolv-conf
-              - hostPath:
-                  path: /lib64
-                  type: Directory
-                name: host-lib64
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib/cni
-                  type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - configMap:
+                defaultMode: 420
+                name: pre-cache-spec
+              name: config-volume
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /etc/containers
+                type: Directory
+              name: host-etc-containers
+            - hostPath:
+                path: /etc/pki/ca-trust
+                type: Directory
+              name: host-etc-pki-ca-trust
+            - hostPath:
+                path: /etc/resolv.conf
+                type: File
+              name: host-etc-resolv-conf
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib/cni
+                type: Directory
+              name: host-var-lib-cni
+            - hostPath:
+                path: /var/lib/containers
+                type: Directory
+              name: host-var-lib-containers
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup

--- a/tests/kuttl/tests/pre-caching-complete/04-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/04-assert.yaml
@@ -25,19 +25,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
-    status: "True"
+    status: 'True'
     type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -70,7 +70,7 @@ status:
       - ptp-operator:4.9
       - sriov-network-operator:4.9
       - performance-addon-operator:4.9
-      spaceRequired: "35"
+      spaceRequired: '35'
     status:
       spoke1: Active
       spoke2: Active
@@ -82,9 +82,9 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl

--- a/tests/kuttl/tests/pre-caching-complete/05-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/05-assert.yaml
@@ -25,23 +25,23 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
-    status: "True"
+    status: 'True'
     type: PrecacheSpecValid
   - message: Precaching is completed for all clusters
     reason: PrecachingCompleted
-    status: "True"
+    status: 'True'
     type: PrecachingSuceeded
   - message: Not enabled
     reason: NotEnabled
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -74,7 +74,7 @@ status:
       - ptp-operator:4.9
       - sriov-network-operator:4.9
       - performance-addon-operator:4.9
-      spaceRequired: "35"
+      spaceRequired: '35'
     status:
       spoke1: Succeeded
       spoke2: Succeeded
@@ -86,14 +86,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-#MCAs for clean up
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:

--- a/tests/kuttl/tests/pre-caching-missing-sub-policy/00-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-missing-sub-policy/00-assert.yaml
@@ -21,18 +21,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
-  - message: "Precaching spec is incomplete: inconsistent precaching configuration: olm index provided, but no packages"
+  - message: 'Precaching spec is incomplete: inconsistent precaching configuration:
+      olm index provided, but no packages'
     reason: PrecacheSpecIncomplete
-    status: "False"
+    status: 'False'
     type: PrecacheSpecValid
   copiedPolicies:
-    - cgu-policy0-common-config-policy-kuttl
+  - cgu-policy0-common-config-policy-kuttl
   managedPoliciesForUpgrade:
   - name: policy0-common-config-policy
     namespace: default
@@ -45,8 +46,8 @@ status:
   precaching:
     spec: {}
   safeResourceNames:
-    cgu-common-config-policy-config: cgu-common-config-policy-config-kuttl
-    cgu-policy0-common-config-policy: cgu-policy0-common-config-policy-kuttl
-    cgu-policy0-common-config-policy-placement: cgu-policy0-common-config-policy-placement-kuttl
+    /cgu-common-config-policy-config: cgu-common-config-policy-config-kuttl
+    default/cgu-policy0-common-config-policy: cgu-policy0-common-config-policy-kuttl
+    default/cgu-policy0-common-config-policy-placement: cgu-policy0-common-config-policy-placement-kuttl
   remediationPlan:
   - - spoke1

--- a/tests/kuttl/tests/pre-caching-missing-sub-policy/01-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-missing-sub-policy/01-assert.yaml
@@ -24,19 +24,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
-    status: "True"
+    status: 'True'
     type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy0-common-config-policy-kuttl
@@ -85,17 +85,16 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-config-policy-config: cgu-common-config-policy-config-kuttl
-    cgu-policy0-common-config-policy: cgu-policy0-common-config-policy-kuttl
-    cgu-policy0-common-config-policy-placement: cgu-policy0-common-config-policy-placement-kuttl
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-config-policy-config: cgu-common-config-policy-config-kuttl
+    default/cgu-policy0-common-config-policy: cgu-policy0-common-config-policy-kuttl
+    default/cgu-policy0-common-config-policy-placement: cgu-policy0-common-config-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-#MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -140,7 +139,6 @@ spec:
     name: openshift-talo-pre-cache
     resource: namespace
 ---
-#MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:

--- a/tests/kuttl/tests/pre-caching-partial-complete/00-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/00-assert.yaml
@@ -24,19 +24,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
-    status: "True"
+    status: 'True'
     type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -69,7 +69,7 @@ status:
       - ptp-operator:4.9
       - sriov-network-operator:4.9
       - performance-addon-operator:4.9
-      spaceRequired: "35"
+      spaceRequired: '35'
     status:
       spoke1: PreparingToStart
       spoke2: PreparingToStart
@@ -81,14 +81,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-#MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -177,7 +176,6 @@ spec:
     name: pre-cache-crb
     resource: clusterrolebinding
 ---
-#MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:

--- a/tests/kuttl/tests/pre-caching-partial-complete/01-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/01-assert.yaml
@@ -25,19 +25,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
-    status: "True"
+    status: 'True'
     type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -81,14 +81,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-# MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -159,8 +158,10 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11 \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9  \nperformance-addon-operator:4.9 \n"
+        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
+          \ \n"
+        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
+          \  \nperformance-addon-operator:4.9 \n"
         platform.image: null
       kind: ConfigMap
       metadata:
@@ -237,8 +238,10 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11 \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9  \nperformance-addon-operator:4.9 \n"
+        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
+          \ \n"
+        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
+          \  \nperformance-addon-operator:4.9 \n"
         platform.image: null
       kind: ConfigMap
       metadata:
@@ -315,8 +318,10 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11 \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9  \nperformance-addon-operator:4.9 \n"
+        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
+          \ \n"
+        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
+          \  \nperformance-addon-operator:4.9 \n"
         platform.image: null
       kind: ConfigMap
       metadata:
@@ -393,15 +398,16 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11 \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9  \nperformance-addon-operator:4.9 \n"
+        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
+          \ \n"
+        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
+          \  \nperformance-addon-operator:4.9 \n"
         platform.image: null
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
         namespace: openshift-talo-pre-cache
 ---
-#MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
@@ -411,7 +417,7 @@ spec:
   scope:
     name: pre-cache-crb
     resource: clusterrolebinding
-    updateIntervalSeconds: 30    
+    updateIntervalSeconds: 30
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
@@ -426,7 +432,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
@@ -477,7 +483,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
@@ -528,7 +534,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
@@ -579,7 +585,7 @@ spec:
 status:
   conditions:
   - reason: GetResourceFailed
-    status: "False"
+    status: 'False'
     type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1

--- a/tests/kuttl/tests/pre-caching-partial-complete/02-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/02-assert.yaml
@@ -25,19 +25,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
-    status: "True"
+    status: 'True'
     type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -69,7 +69,7 @@ status:
       operatorsPackagesAndChannels:
       - ptp-operator:4.9
       - sriov-network-operator:4.9
-      - performance-addon-operator:4.9      
+      - performance-addon-operator:4.9
     status:
       spoke1: Starting
       spoke2: Starting
@@ -81,14 +81,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-# MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:

--- a/tests/kuttl/tests/pre-caching-partial-complete/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/03-assert.yaml
@@ -25,19 +25,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
-    status: "True"
+    status: 'True'
     type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -69,7 +69,7 @@ status:
       operatorsPackagesAndChannels:
       - ptp-operator:4.9
       - sriov-network-operator:4.9
-      - performance-addon-operator:4.9      
+      - performance-addon-operator:4.9
     status:
       spoke1: Starting
       spoke2: Starting
@@ -81,14 +81,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-# MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -128,7 +127,7 @@ spec:
               - name: NODE_NAME
                 valueFrom:
                   fieldRef:
-                    fieldPath: spec.nodeName                
+                    fieldPath: spec.nodeName
               image: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.14.0
               name: pre-cache-container
               resources: {}
@@ -138,58 +137,58 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-                - mountPath: /etc/config
-                  name: config-volume
-                  readOnly: true
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/etc/containers
-                  name: host-etc-containers
-                  readOnly: true
-                - mountPath: /host/etc/pki/ca-trust
-                  name: host-etc-pki-ca-trust
-                  readOnly: true
-                - mountPath: /host/etc/resolv.conf
-                  name: host-etc-resolv-conf
-                  readOnly: true
-                - mountPath: /host/lib64
-                  name: host-lib64
-                  readOnly: true
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /etc/config
+                name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/etc/containers
+                name: host-etc-containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc-pki-ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc-resolv-conf
+                readOnly: true
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib/cni
+                name: host-var-lib-cni
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var-lib-containers
+              - mountPath: /host/var/lib/kubelet
+                name: host-var-lib-kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
             restartPolicy: Never
@@ -197,81 +196,81 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
-              - configMap:
-                  defaultMode: 420
-                  name: pre-cache-spec
-                name: config-volume
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /etc/containers
-                  type: Directory
-                name: host-etc-containers
-              - hostPath:
-                  path: /etc/pki/ca-trust
-                  type: Directory
-                name: host-etc-pki-ca-trust
-              - hostPath:
-                  path: /etc/resolv.conf
-                  type: File
-                name: host-etc-resolv-conf
-              - hostPath:
-                  path: /lib64
-                  type: Directory
-                name: host-lib64
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib/cni
-                  type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
----              
+            - configMap:
+                defaultMode: 420
+                name: pre-cache-spec
+              name: config-volume
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /etc/containers
+                type: Directory
+              name: host-etc-containers
+            - hostPath:
+                path: /etc/pki/ca-trust
+                type: Directory
+              name: host-etc-pki-ca-trust
+            - hostPath:
+                path: /etc/resolv.conf
+                type: File
+              name: host-etc-resolv-conf
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib/cni
+                type: Directory
+              name: host-var-lib-cni
+            - hostPath:
+                path: /var/lib/containers
+                type: Directory
+              name: host-var-lib-containers
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -311,7 +310,7 @@ spec:
               - name: NODE_NAME
                 valueFrom:
                   fieldRef:
-                    fieldPath: spec.nodeName                
+                    fieldPath: spec.nodeName
               image: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.14.0
               name: pre-cache-container
               resources: {}
@@ -321,58 +320,58 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-                - mountPath: /etc/config
-                  name: config-volume
-                  readOnly: true
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/etc/containers
-                  name: host-etc-containers
-                  readOnly: true
-                - mountPath: /host/etc/pki/ca-trust
-                  name: host-etc-pki-ca-trust
-                  readOnly: true
-                - mountPath: /host/etc/resolv.conf
-                  name: host-etc-resolv-conf
-                  readOnly: true
-                - mountPath: /host/lib64
-                  name: host-lib64
-                  readOnly: true
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /etc/config
+                name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/etc/containers
+                name: host-etc-containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc-pki-ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc-resolv-conf
+                readOnly: true
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib/cni
+                name: host-var-lib-cni
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var-lib-containers
+              - mountPath: /host/var/lib/kubelet
+                name: host-var-lib-kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
             restartPolicy: Never
@@ -380,81 +379,81 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
-              - configMap:
-                  defaultMode: 420
-                  name: pre-cache-spec
-                name: config-volume
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /etc/containers
-                  type: Directory
-                name: host-etc-containers
-              - hostPath:
-                  path: /etc/pki/ca-trust
-                  type: Directory
-                name: host-etc-pki-ca-trust
-              - hostPath:
-                  path: /etc/resolv.conf
-                  type: File
-                name: host-etc-resolv-conf
-              - hostPath:
-                  path: /lib64
-                  type: Directory
-                name: host-lib64
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib/cni
-                  type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
----              
+            - configMap:
+                defaultMode: 420
+                name: pre-cache-spec
+              name: config-volume
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /etc/containers
+                type: Directory
+              name: host-etc-containers
+            - hostPath:
+                path: /etc/pki/ca-trust
+                type: Directory
+              name: host-etc-pki-ca-trust
+            - hostPath:
+                path: /etc/resolv.conf
+                type: File
+              name: host-etc-resolv-conf
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib/cni
+                type: Directory
+              name: host-var-lib-cni
+            - hostPath:
+                path: /var/lib/containers
+                type: Directory
+              name: host-var-lib-containers
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -494,7 +493,7 @@ spec:
               - name: NODE_NAME
                 valueFrom:
                   fieldRef:
-                    fieldPath: spec.nodeName                
+                    fieldPath: spec.nodeName
               image: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.14.0
               name: pre-cache-container
               resources: {}
@@ -504,58 +503,58 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-                - mountPath: /etc/config
-                  name: config-volume
-                  readOnly: true
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/etc/containers
-                  name: host-etc-containers
-                  readOnly: true
-                - mountPath: /host/etc/pki/ca-trust
-                  name: host-etc-pki-ca-trust
-                  readOnly: true
-                - mountPath: /host/etc/resolv.conf
-                  name: host-etc-resolv-conf
-                  readOnly: true
-                - mountPath: /host/lib64
-                  name: host-lib64
-                  readOnly: true
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /etc/config
+                name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/etc/containers
+                name: host-etc-containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc-pki-ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc-resolv-conf
+                readOnly: true
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib/cni
+                name: host-var-lib-cni
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var-lib-containers
+              - mountPath: /host/var/lib/kubelet
+                name: host-var-lib-kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
             restartPolicy: Never
@@ -563,81 +562,81 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
-              - configMap:
-                  defaultMode: 420
-                  name: pre-cache-spec
-                name: config-volume
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /etc/containers
-                  type: Directory
-                name: host-etc-containers
-              - hostPath:
-                  path: /etc/pki/ca-trust
-                  type: Directory
-                name: host-etc-pki-ca-trust
-              - hostPath:
-                  path: /etc/resolv.conf
-                  type: File
-                name: host-etc-resolv-conf
-              - hostPath:
-                  path: /lib64
-                  type: Directory
-                name: host-lib64
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib/cni
-                  type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
----              
+            - configMap:
+                defaultMode: 420
+                name: pre-cache-spec
+              name: config-volume
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /etc/containers
+                type: Directory
+              name: host-etc-containers
+            - hostPath:
+                path: /etc/pki/ca-trust
+                type: Directory
+              name: host-etc-pki-ca-trust
+            - hostPath:
+                path: /etc/resolv.conf
+                type: File
+              name: host-etc-resolv-conf
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib/cni
+                type: Directory
+              name: host-var-lib-cni
+            - hostPath:
+                path: /var/lib/containers
+                type: Directory
+              name: host-var-lib-containers
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
+---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -677,7 +676,7 @@ spec:
               - name: NODE_NAME
                 valueFrom:
                   fieldRef:
-                    fieldPath: spec.nodeName                
+                    fieldPath: spec.nodeName
               image: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.14.0
               name: pre-cache-container
               resources: {}
@@ -687,58 +686,58 @@ spec:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-                - mountPath: /etc/config
-                  name: config-volume
-                  readOnly: true
-                - mountPath: /host
-                  name: host
-                - mountPath: /host/etc/containers
-                  name: host-etc-containers
-                  readOnly: true
-                - mountPath: /host/etc/pki/ca-trust
-                  name: host-etc-pki-ca-trust
-                  readOnly: true
-                - mountPath: /host/etc/resolv.conf
-                  name: host-etc-resolv-conf
-                  readOnly: true
-                - mountPath: /host/lib64
-                  name: host-lib64
-                  readOnly: true
-                - mountPath: /host/proc
-                  name: host-proc
-                  readOnly: true
-                - mountPath: /host/run
-                  name: host-run
-                - mountPath: /host/tmp
-                  name: host-tmp
-                - mountPath: /host/usr/bin
-                  name: host-usr-bin
-                  readOnly: true
-                - mountPath: /host/usr/lib
-                  name: host-usr-lib
-                  readOnly: true
-                - mountPath: /host/usr/lib64
-                  name: host-usr-lib64
-                  readOnly: true
-                - mountPath: /host/usr/libexec
-                  name: host-usr-libexec
-                  readOnly: true
-                - mountPath: /host/usr/share/containers
-                  name: host-usr-share-containers
-                  readOnly: true
-                - mountPath: /host/var/lib/cni
-                  name: host-var-lib-cni
-                  readOnly: true
-                - mountPath: /host/var/lib/containers
-                  name: host-var-lib-containers
-                - mountPath: /host/var/lib/kubelet
-                  name: host-var-lib-kubelet
-                  readOnly: true
-                - mountPath: /host/var/tmp
-                  name: host-var-tmp
-                - mountPath: /host/sys/fs/cgroup
-                  name: sys-fs-cgroup
-                  readOnly: true
+              - mountPath: /etc/config
+                name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/etc/containers
+                name: host-etc-containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc-pki-ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc-resolv-conf
+                readOnly: true
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib/cni
+                name: host-var-lib-cni
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var-lib-containers
+              - mountPath: /host/var/lib/kubelet
+                name: host-var-lib-kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
             restartPolicy: Never
@@ -746,77 +745,77 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
-              - configMap:
-                  defaultMode: 420
-                  name: pre-cache-spec
-                name: config-volume
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /etc/containers
-                  type: Directory
-                name: host-etc-containers
-              - hostPath:
-                  path: /etc/pki/ca-trust
-                  type: Directory
-                name: host-etc-pki-ca-trust
-              - hostPath:
-                  path: /etc/resolv.conf
-                  type: File
-                name: host-etc-resolv-conf
-              - hostPath:
-                  path: /lib64
-                  type: Directory
-                name: host-lib64
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib/cni
-                  type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - configMap:
+                defaultMode: 420
+                name: pre-cache-spec
+              name: config-volume
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /etc/containers
+                type: Directory
+              name: host-etc-containers
+            - hostPath:
+                path: /etc/pki/ca-trust
+                type: Directory
+              name: host-etc-pki-ca-trust
+            - hostPath:
+                path: /etc/resolv.conf
+                type: File
+              name: host-etc-resolv-conf
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib/cni
+                type: Directory
+              name: host-var-lib-cni
+            - hostPath:
+                path: /var/lib/containers
+                type: Directory
+              name: host-var-lib-containers
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup

--- a/tests/kuttl/tests/pre-caching-partial-complete/04-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/04-assert.yaml
@@ -25,19 +25,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
-    status: "True"
+    status: 'True'
     type: PrecacheSpecValid
   - message: Precaching in progress for 4 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -69,7 +69,7 @@ status:
       operatorsPackagesAndChannels:
       - ptp-operator:4.9
       - sriov-network-operator:4.9
-      - performance-addon-operator:4.9      
+      - performance-addon-operator:4.9
     status:
       spoke1: Active
       spoke2: Active
@@ -81,9 +81,9 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl

--- a/tests/kuttl/tests/pre-caching-partial-complete/05-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/05-assert.yaml
@@ -25,19 +25,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
-    status: "True"
+    status: 'True'
     type: PrecacheSpecValid
   - message: Precaching in progress for 1 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -69,7 +69,7 @@ status:
       operatorsPackagesAndChannels:
       - ptp-operator:4.9
       - sriov-network-operator:4.9
-      - performance-addon-operator:4.9      
+      - performance-addon-operator:4.9
     status:
       spoke1: Succeeded
       spoke2: PrecacheTimeout
@@ -81,14 +81,13 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-#MCAs for clean up succeeded clusters
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:

--- a/tests/kuttl/tests/pre-caching-partial-complete/06-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/06-assert.yaml
@@ -25,19 +25,19 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
-    status: "True"
+    status: 'True'
     type: PrecacheSpecValid
   - message: Precaching in progress for 1 clusters
     reason: InProgress
-    status: "False"
+    status: 'False'
     type: PrecachingSuceeded
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -69,7 +69,7 @@ status:
       operatorsPackagesAndChannels:
       - ptp-operator:4.9
       - sriov-network-operator:4.9
-      - performance-addon-operator:4.9      
+      - performance-addon-operator:4.9
     status:
       spoke1: Succeeded
       spoke2: PrecacheTimeout
@@ -81,9 +81,9 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl

--- a/tests/kuttl/tests/pre-caching-partial-complete/07-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/07-assert.yaml
@@ -25,23 +25,23 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Precaching spec is valid and consistent
     reason: PrecacheSpecIsWellFormed
-    status: "True"
+    status: 'True'
     type: PrecacheSpecValid
-  - message: Precaching failed for 2 clusters 
+  - message: Precaching failed for 2 clusters
     reason: PartiallyDone
-    status: "True"
+    status: 'True'
     type: PrecachingSuceeded
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-policy3-common-ptp-sub-policy-kuttl
@@ -73,7 +73,7 @@ status:
       operatorsPackagesAndChannels:
       - ptp-operator:4.9
       - sriov-network-operator:4.9
-      - performance-addon-operator:4.9      
+      - performance-addon-operator:4.9
     status:
       spoke1: Succeeded
       spoke2: PrecacheTimeout
@@ -83,14 +83,14 @@ status:
   - - spoke6
     - spoke1
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-default-subscription-ptp-operator-subscription: cgu-default-subscription-ptp-operator-subscription-kuttl
-    cgu-default-subscription-sriov-network-operator-subscription: cgu-default-subscription-sriov-network-operator-subscription-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    /cgu-default-subscription-ptp-operator-subscription: cgu-default-subscription-ptp-operator-subscription-kuttl
+    /cgu-default-subscription-sriov-network-operator-subscription: cgu-default-subscription-sriov-network-operator-subscription-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
   status:
     currentBatch: 1
     currentBatchRemediationProgress:
@@ -100,4 +100,3 @@ status:
       spoke6:
         policyIndex: 1
         state: InProgress
-

--- a/tests/kuttl/tests/pre-caching-with-configs/00-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-with-configs/00-assert.yaml
@@ -5,73 +5,74 @@ metadata:
   namespace: default
 spec:
   clusters:
-    - spoke6
-    - spoke2
-    - spoke1
-    - spoke5
+  - spoke6
+  - spoke2
+  - spoke1
+  - spoke5
   enable: false
   preCaching: true
   preCachingConfigRef:
     name: pre-caching-config
     namespace: default
   managedPolicies:
-    - policy0-common-config-policy
-    - policy2-common-pao-sub-policy
-    - policy3-common-ptp-sub-policy
-    - policy4-common-sriov-sub-policy
+  - policy0-common-config-policy
+  - policy2-common-pao-sub-policy
+  - policy3-common-ptp-sub-policy
+  - policy4-common-sriov-sub-policy
   remediationStrategy:
     maxConcurrency: 4
     timeout: 240
 status:
   computedMaxConcurrency: 4
   conditions:
-    - message: All selected clusters are valid
-      reason: ClusterSelectionCompleted
-      status: "True"
-      type: ClustersSelected
-    - message: Completed validation
-      reason: ValidationCompleted
-      status: "True"
-      type: Validated
-    - message: 'Precaching spec is incomplete: failed to get PreCachingConfig resource due to PreCachingConfig.ran.openshift.io "pre-caching-config" not found'
-      reason: PrecacheSpecIncomplete
-      status: "False"
-      type: PrecacheSpecValid
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: 'True'
+    type: ClustersSelected
+  - message: Completed validation
+    reason: ValidationCompleted
+    status: 'True'
+    type: Validated
+  - message: 'Precaching spec is incomplete: failed to get PreCachingConfig resource
+      due to PreCachingConfig.ran.openshift.io "pre-caching-config" not found'
+    reason: PrecacheSpecIncomplete
+    status: 'False'
+    type: PrecacheSpecValid
   copiedPolicies:
-    - cgu-policy3-common-ptp-sub-policy-kuttl
-    - cgu-policy4-common-sriov-sub-policy-kuttl
+  - cgu-policy3-common-ptp-sub-policy-kuttl
+  - cgu-policy4-common-sriov-sub-policy-kuttl
   managedPoliciesCompliantBeforeUpgrade:
-    - policy0-common-config-policy
-    - policy2-common-pao-sub-policy
+  - policy0-common-config-policy
+  - policy2-common-pao-sub-policy
   managedPoliciesContent:
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'
     policy4-common-sriov-sub-policy: '[{"kind":"Subscription","name":"sriov-network-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-sriov-network-operator"}]'
   managedPoliciesForUpgrade:
-    - name: policy3-common-ptp-sub-policy
-      namespace: default
-    - name: policy4-common-sriov-sub-policy
-      namespace: default
+  - name: policy3-common-ptp-sub-policy
+    namespace: default
+  - name: policy4-common-sriov-sub-policy
+    namespace: default
   managedPoliciesNs:
     policy3-common-ptp-sub-policy: default
     policy4-common-sriov-sub-policy: default
   placementBindings:
-    - cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   placementRules:
-    - cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   precaching:
     spec: {}
   remediationPlan:
-    - - spoke6
-      - spoke2
-      - spoke1
-      - spoke5
+  - - spoke6
+    - spoke2
+    - spoke1
+    - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---

--- a/tests/kuttl/tests/pre-caching-with-configs/01-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-with-configs/01-assert.yaml
@@ -5,100 +5,99 @@ metadata:
   namespace: default
 spec:
   clusters:
-    - spoke6
-    - spoke2
-    - spoke1
-    - spoke5
+  - spoke6
+  - spoke2
+  - spoke1
+  - spoke5
   enable: false
   preCaching: true
   preCachingConfigRef:
     name: pre-caching-config
     namespace: default
   managedPolicies:
-    - policy0-common-config-policy
-    - policy2-common-pao-sub-policy
-    - policy3-common-ptp-sub-policy
-    - policy4-common-sriov-sub-policy
+  - policy0-common-config-policy
+  - policy2-common-pao-sub-policy
+  - policy3-common-ptp-sub-policy
+  - policy4-common-sriov-sub-policy
   remediationStrategy:
     maxConcurrency: 4
     timeout: 242
 status:
   computedMaxConcurrency: 4
   conditions:
-    - message: All selected clusters are valid
-      reason: ClusterSelectionCompleted
-      status: "True"
-      type: ClustersSelected
-    - message: Completed validation
-      reason: ValidationCompleted
-      status: "True"
-      type: Validated
-    - message: Precaching spec is valid and consistent
-      reason: PrecacheSpecIsWellFormed
-      status: "True"
-      type: PrecacheSpecValid
-    - message: Precaching in progress for 4 clusters
-      reason: InProgress
-      status: "False"
-      type: PrecachingSuceeded
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: 'True'
+    type: ClustersSelected
+  - message: Completed validation
+    reason: ValidationCompleted
+    status: 'True'
+    type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: 'True'
+    type: PrecacheSpecValid
+  - message: Precaching in progress for 4 clusters
+    reason: InProgress
+    status: 'False'
+    type: PrecachingSuceeded
   copiedPolicies:
-    - cgu-policy3-common-ptp-sub-policy-kuttl
-    - cgu-policy4-common-sriov-sub-policy-kuttl
+  - cgu-policy3-common-ptp-sub-policy-kuttl
+  - cgu-policy4-common-sriov-sub-policy-kuttl
   managedPoliciesCompliantBeforeUpgrade:
-    - policy0-common-config-policy
-    - policy2-common-pao-sub-policy
+  - policy0-common-config-policy
+  - policy2-common-pao-sub-policy
   managedPoliciesContent:
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'
     policy4-common-sriov-sub-policy: '[{"kind":"Subscription","name":"sriov-network-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-sriov-network-operator"}]'
   managedPoliciesForUpgrade:
-    - name: policy3-common-ptp-sub-policy
-      namespace: default
-    - name: policy4-common-sriov-sub-policy
-      namespace: default
+  - name: policy3-common-ptp-sub-policy
+    namespace: default
+  - name: policy4-common-sriov-sub-policy
+    namespace: default
   managedPoliciesNs:
     policy3-common-ptp-sub-policy: default
     policy4-common-sriov-sub-policy: default
   placementBindings:
-    - cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   placementRules:
-    - cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   precaching:
     spec:
       platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
       operatorsIndexes:
-        - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+      - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
       operatorsPackagesAndChannels:
-        - performance-addon-operator:stable
-        - ptp-operator:stable
-        - sriov-network-operator:stable
+      - performance-addon-operator:stable
+      - ptp-operator:stable
+      - sriov-network-operator:stable
       excludePrecachePatterns:
-        - aws
-        - azure
+      - aws
+      - azure
       additionalImages:
-        - image1:latest
-        - image2:latest
-      spaceRequired: "40"
+      - image1:latest
+      - image2:latest
+      spaceRequired: '40'
     status:
       spoke1: PreparingToStart
       spoke2: PreparingToStart
       spoke5: PreparingToStart
       spoke6: PreparingToStart
   remediationPlan:
-    - - spoke6
-      - spoke2
-      - spoke1
-      - spoke5
+  - - spoke6
+    - spoke2
+    - spoke1
+    - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-#PreCachingConfig
 apiVersion: ran.openshift.io/v1alpha1
 kind: PreCachingConfig
 metadata:
@@ -109,26 +108,29 @@ spec:
     platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
     preCacheImage: quay.io/test_images/pre-cache:latest
   additionalImages:
-    - image1:latest
-    - image2:latest
+  - image1:latest
+  - image2:latest
   spaceRequired: 40GiB
 ---
-#CGU overrides ConfigMap
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cluster-group-upgrade-overrides
 data:
   platform.image: this/should/be/ignored:latest
-  operators.packagesAndChannels: |
-    performance-addon-operator:stable
+  operators.packagesAndChannels: 'performance-addon-operator:stable
+
     ptp-operator:stable
+
     sriov-network-operator:stable
-  excludePrecachePatterns: |
-    aws
+
+    '
+  excludePrecachePatterns: 'aws
+
     azure
+
+    '
 ---
-#MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -173,7 +175,6 @@ spec:
     name: openshift-talo-pre-cache
     resource: namespace
 ---
-#MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:

--- a/tests/kuttl/tests/pre-caching-with-configs/02-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-with-configs/02-assert.yaml
@@ -6,16 +6,16 @@ metadata:
 spec:
   backup: false
   clusters:
-    - spoke6
-    - spoke2
-    - spoke1
-    - spoke5
+  - spoke6
+  - spoke2
+  - spoke1
+  - spoke5
   enable: false
   managedPolicies:
-    - policy0-common-config-policy
-    - policy2-common-pao-sub-policy
-    - policy3-common-ptp-sub-policy
-    - policy4-common-sriov-sub-policy
+  - policy0-common-config-policy
+  - policy2-common-pao-sub-policy
+  - policy3-common-ptp-sub-policy
+  - policy4-common-sriov-sub-policy
   preCaching: true
   preCachingConfigRef:
     name: pre-caching-config
@@ -26,80 +26,79 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-    - message: All selected clusters are valid
-      reason: ClusterSelectionCompleted
-      status: "True"
-      type: ClustersSelected
-    - message: Completed validation
-      reason: ValidationCompleted
-      status: "True"
-      type: Validated
-    - message: Precaching spec is valid and consistent
-      reason: PrecacheSpecIsWellFormed
-      status: "True"
-      type: PrecacheSpecValid
-    - message: Precaching in progress for 4 clusters
-      reason: InProgress
-      status: "False"
-      type: PrecachingSuceeded
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: 'True'
+    type: ClustersSelected
+  - message: Completed validation
+    reason: ValidationCompleted
+    status: 'True'
+    type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: 'True'
+    type: PrecacheSpecValid
+  - message: Precaching in progress for 4 clusters
+    reason: InProgress
+    status: 'False'
+    type: PrecachingSuceeded
   copiedPolicies:
-    - cgu-policy3-common-ptp-sub-policy-kuttl
-    - cgu-policy4-common-sriov-sub-policy-kuttl
+  - cgu-policy3-common-ptp-sub-policy-kuttl
+  - cgu-policy4-common-sriov-sub-policy-kuttl
   managedPoliciesCompliantBeforeUpgrade:
-    - policy0-common-config-policy
-    - policy2-common-pao-sub-policy
+  - policy0-common-config-policy
+  - policy2-common-pao-sub-policy
   managedPoliciesContent:
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'
     policy4-common-sriov-sub-policy: '[{"kind":"Subscription","name":"sriov-network-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-sriov-network-operator"}]'
   managedPoliciesForUpgrade:
-    - name: policy3-common-ptp-sub-policy
-      namespace: default
-    - name: policy4-common-sriov-sub-policy
-      namespace: default
+  - name: policy3-common-ptp-sub-policy
+    namespace: default
+  - name: policy4-common-sriov-sub-policy
+    namespace: default
   managedPoliciesNs:
     policy3-common-ptp-sub-policy: default
     policy4-common-sriov-sub-policy: default
   placementBindings:
-    - cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   placementRules:
-    - cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   precaching:
     spec:
       platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
       operatorsIndexes:
-        - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+      - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
       operatorsPackagesAndChannels:
-        - performance-addon-operator:stable
-        - ptp-operator:stable
-        - sriov-network-operator:stable
+      - performance-addon-operator:stable
+      - ptp-operator:stable
+      - sriov-network-operator:stable
       excludePrecachePatterns:
-        - aws
-        - azure
+      - aws
+      - azure
       additionalImages:
-        - image1:latest
-        - image2:latest
-      spaceRequired: "40"
+      - image1:latest
+      - image2:latest
+      spaceRequired: '40'
     status:
       spoke1: Starting
       spoke2: Starting
       spoke5: Starting
       spoke6: Starting
   remediationPlan:
-    - - spoke6
-      - spoke2
-      - spoke1
-      - spoke5
+  - - spoke6
+    - spoke2
+    - spoke1
+    - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-# MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -119,9 +118,9 @@ spec:
         kind: ClusterRole
         name: cluster-admin
       subjects:
-        - kind: ServiceAccount
-          name: pre-cache-agent
-          namespace: openshift-talo-pre-cache
+      - kind: ServiceAccount
+        name: pre-cache-agent
+        namespace: openshift-talo-pre-cache
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -170,12 +169,14 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11 \n"
-        operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable  \nsriov-network-operator:stable \n"
+        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
+          \ \n"
+        operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable\
+          \  \nsriov-network-operator:stable \n"
         platform.image: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
         excludePrecachePatterns: "aws  \nazure \n"
         additionalImages: "image1:latest \nimage2:latest \n"
-        spaceRequired: "40"
+        spaceRequired: '40'
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -200,9 +201,9 @@ spec:
         kind: ClusterRole
         name: cluster-admin
       subjects:
-        - kind: ServiceAccount
-          name: pre-cache-agent
-          namespace: openshift-talo-pre-cache
+      - kind: ServiceAccount
+        name: pre-cache-agent
+        namespace: openshift-talo-pre-cache
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -251,12 +252,14 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11 \n"
-        operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable  \nsriov-network-operator:stable \n"
+        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
+          \ \n"
+        operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable\
+          \  \nsriov-network-operator:stable \n"
         platform.image: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
         excludePrecachePatterns: "aws  \nazure \n"
         additionalImages: "image1:latest \nimage2:latest \n"
-        spaceRequired: "40"
+        spaceRequired: '40'
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -281,9 +284,9 @@ spec:
         kind: ClusterRole
         name: cluster-admin
       subjects:
-        - kind: ServiceAccount
-          name: pre-cache-agent
-          namespace: openshift-talo-pre-cache
+      - kind: ServiceAccount
+        name: pre-cache-agent
+        namespace: openshift-talo-pre-cache
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -332,12 +335,14 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11 \n"
-        operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable  \nsriov-network-operator:stable \n"
+        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
+          \ \n"
+        operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable\
+          \  \nsriov-network-operator:stable \n"
         platform.image: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
         excludePrecachePatterns: "aws  \nazure \n"
         additionalImages: "image1:latest \nimage2:latest \n"
-        spaceRequired: "40"
+        spaceRequired: '40'
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -362,9 +367,9 @@ spec:
         kind: ClusterRole
         name: cluster-admin
       subjects:
-        - kind: ServiceAccount
-          name: pre-cache-agent
-          namespace: openshift-talo-pre-cache
+      - kind: ServiceAccount
+        name: pre-cache-agent
+        namespace: openshift-talo-pre-cache
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -413,18 +418,19 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11 \n"
-        operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable  \nsriov-network-operator:stable \n"
+        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
+          \ \n"
+        operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable\
+          \  \nsriov-network-operator:stable \n"
         platform.image: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
         excludePrecachePatterns: "aws  \nazure \n"
         additionalImages: "image1:latest \nimage2:latest \n"
-        spaceRequired: "40"
+        spaceRequired: '40'
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
         namespace: openshift-talo-pre-cache
 ---
-#MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:
@@ -448,9 +454,9 @@ spec:
     updateIntervalSeconds: 0
 status:
   conditions:
-    - reason: GetResourceFailed
-      status: "False"
-      type: Processing
+  - reason: GetResourceFailed
+    status: 'False'
+    type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
@@ -499,9 +505,9 @@ spec:
     updateIntervalSeconds: 0
 status:
   conditions:
-    - reason: GetResourceFailed
-      status: "False"
-      type: Processing
+  - reason: GetResourceFailed
+    status: 'False'
+    type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
@@ -550,9 +556,9 @@ spec:
     updateIntervalSeconds: 0
 status:
   conditions:
-    - reason: GetResourceFailed
-      status: "False"
-      type: Processing
+  - reason: GetResourceFailed
+    status: 'False'
+    type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
@@ -601,9 +607,9 @@ spec:
     updateIntervalSeconds: 0
 status:
   conditions:
-    - reason: GetResourceFailed
-      status: "False"
-      type: Processing
+  - reason: GetResourceFailed
+    status: 'False'
+    type: Processing
 ---
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView

--- a/tests/kuttl/tests/pre-caching-with-configs/03-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-with-configs/03-assert.yaml
@@ -6,16 +6,16 @@ metadata:
 spec:
   backup: false
   clusters:
-    - spoke6
-    - spoke2
-    - spoke1
-    - spoke5
+  - spoke6
+  - spoke2
+  - spoke1
+  - spoke5
   enable: false
   managedPolicies:
-    - policy0-common-config-policy
-    - policy2-common-pao-sub-policy
-    - policy3-common-ptp-sub-policy
-    - policy4-common-sriov-sub-policy
+  - policy0-common-config-policy
+  - policy2-common-pao-sub-policy
+  - policy3-common-ptp-sub-policy
+  - policy4-common-sriov-sub-policy
   preCaching: true
   preCachingConfigRef:
     name: pre-caching-config
@@ -26,80 +26,79 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-    - message: All selected clusters are valid
-      reason: ClusterSelectionCompleted
-      status: "True"
-      type: ClustersSelected
-    - message: Completed validation
-      reason: ValidationCompleted
-      status: "True"
-      type: Validated
-    - message: Precaching spec is valid and consistent
-      reason: PrecacheSpecIsWellFormed
-      status: "True"
-      type: PrecacheSpecValid
-    - message: Precaching in progress for 4 clusters
-      reason: InProgress
-      status: "False"
-      type: PrecachingSuceeded
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: 'True'
+    type: ClustersSelected
+  - message: Completed validation
+    reason: ValidationCompleted
+    status: 'True'
+    type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: 'True'
+    type: PrecacheSpecValid
+  - message: Precaching in progress for 4 clusters
+    reason: InProgress
+    status: 'False'
+    type: PrecachingSuceeded
   copiedPolicies:
-    - cgu-policy3-common-ptp-sub-policy-kuttl
-    - cgu-policy4-common-sriov-sub-policy-kuttl
+  - cgu-policy3-common-ptp-sub-policy-kuttl
+  - cgu-policy4-common-sriov-sub-policy-kuttl
   managedPoliciesCompliantBeforeUpgrade:
-    - policy0-common-config-policy
-    - policy2-common-pao-sub-policy
+  - policy0-common-config-policy
+  - policy2-common-pao-sub-policy
   managedPoliciesContent:
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'
     policy4-common-sriov-sub-policy: '[{"kind":"Subscription","name":"sriov-network-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-sriov-network-operator"}]'
   managedPoliciesForUpgrade:
-    - name: policy3-common-ptp-sub-policy
-      namespace: default
-    - name: policy4-common-sriov-sub-policy
-      namespace: default
+  - name: policy3-common-ptp-sub-policy
+    namespace: default
+  - name: policy4-common-sriov-sub-policy
+    namespace: default
   managedPoliciesNs:
     policy3-common-ptp-sub-policy: default
     policy4-common-sriov-sub-policy: default
   placementBindings:
-    - cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   placementRules:
-    - cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   precaching:
     spec:
       platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
       operatorsIndexes:
-        - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+      - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
       operatorsPackagesAndChannels:
-        - performance-addon-operator:stable
-        - ptp-operator:stable
-        - sriov-network-operator:stable
+      - performance-addon-operator:stable
+      - ptp-operator:stable
+      - sriov-network-operator:stable
       excludePrecachePatterns:
-        - aws
-        - azure
+      - aws
+      - azure
       additionalImages:
-        - image1:latest
-        - image2:latest
-      spaceRequired: "40"
+      - image1:latest
+      - image2:latest
+      spaceRequired: '40'
     status:
       spoke1: Starting
       spoke2: Starting
       spoke5: Starting
       spoke6: Starting
   remediationPlan:
-    - - spoke6
-      - spoke2
-      - spoke1
-      - spoke5
+  - - spoke6
+    - spoke2
+    - spoke1
+    - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-# MCVs
 apiVersion: view.open-cluster-management.io/v1beta1
 kind: ManagedClusterView
 metadata:

--- a/tests/kuttl/tests/pre-caching-with-configs/04-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-with-configs/04-assert.yaml
@@ -6,16 +6,16 @@ metadata:
 spec:
   backup: false
   clusters:
-    - spoke6
-    - spoke2
-    - spoke1
-    - spoke5
+  - spoke6
+  - spoke2
+  - spoke1
+  - spoke5
   enable: false
   managedPolicies:
-    - policy0-common-config-policy
-    - policy2-common-pao-sub-policy
-    - policy3-common-ptp-sub-policy
-    - policy4-common-sriov-sub-policy
+  - policy0-common-config-policy
+  - policy2-common-pao-sub-policy
+  - policy3-common-ptp-sub-policy
+  - policy4-common-sriov-sub-policy
   preCaching: true
   preCachingConfigRef:
     name: pre-caching-config
@@ -26,80 +26,79 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-    - message: All selected clusters are valid
-      reason: ClusterSelectionCompleted
-      status: "True"
-      type: ClustersSelected
-    - message: Completed validation
-      reason: ValidationCompleted
-      status: "True"
-      type: Validated
-    - message: Precaching spec is valid and consistent
-      reason: PrecacheSpecIsWellFormed
-      status: "True"
-      type: PrecacheSpecValid
-    - message: Precaching in progress for 4 clusters
-      reason: InProgress
-      status: "False"
-      type: PrecachingSuceeded
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: 'True'
+    type: ClustersSelected
+  - message: Completed validation
+    reason: ValidationCompleted
+    status: 'True'
+    type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: 'True'
+    type: PrecacheSpecValid
+  - message: Precaching in progress for 4 clusters
+    reason: InProgress
+    status: 'False'
+    type: PrecachingSuceeded
   copiedPolicies:
-    - cgu-policy3-common-ptp-sub-policy-kuttl
-    - cgu-policy4-common-sriov-sub-policy-kuttl
+  - cgu-policy3-common-ptp-sub-policy-kuttl
+  - cgu-policy4-common-sriov-sub-policy-kuttl
   managedPoliciesCompliantBeforeUpgrade:
-    - policy0-common-config-policy
-    - policy2-common-pao-sub-policy
+  - policy0-common-config-policy
+  - policy2-common-pao-sub-policy
   managedPoliciesContent:
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'
     policy4-common-sriov-sub-policy: '[{"kind":"Subscription","name":"sriov-network-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-sriov-network-operator"}]'
   managedPoliciesForUpgrade:
-    - name: policy3-common-ptp-sub-policy
-      namespace: default
-    - name: policy4-common-sriov-sub-policy
-      namespace: default
+  - name: policy3-common-ptp-sub-policy
+    namespace: default
+  - name: policy4-common-sriov-sub-policy
+    namespace: default
   managedPoliciesNs:
     policy3-common-ptp-sub-policy: default
     policy4-common-sriov-sub-policy: default
   placementBindings:
-    - cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   placementRules:
-    - cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   precaching:
     spec:
       platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
       operatorsIndexes:
-        - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+      - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
       operatorsPackagesAndChannels:
-        - performance-addon-operator:stable
-        - ptp-operator:stable
-        - sriov-network-operator:stable
+      - performance-addon-operator:stable
+      - ptp-operator:stable
+      - sriov-network-operator:stable
       excludePrecachePatterns:
-        - aws
-        - azure
+      - aws
+      - azure
       additionalImages:
-        - image1:latest
-        - image2:latest
-      spaceRequired: "40"
+      - image1:latest
+      - image2:latest
+      spaceRequired: '40'
     status:
       spoke1: Starting
       spoke2: Starting
       spoke5: Starting
       spoke6: Starting
   remediationPlan:
-    - - spoke6
-      - spoke2
-      - spoke1
-      - spoke5
+  - - spoke6
+    - spoke2
+    - spoke1
+    - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
-# MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -128,79 +127,79 @@ spec:
             name: pre-cache
           spec:
             containers:
-              - args:
-                  - /opt/precache/precache.sh
-                command:
-                  - /bin/bash
-                  - -c
-                env:
-                  - name: config_volume_path
-                    value: /tmp/precache/config
-                  - name: NODE_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: spec.nodeName
-                image: quay.io/test_images/pre-cache:latest
-                name: pre-cache-container
-                resources: {}
-                securityContext:
-                  privileged: true
-                  runAsUser: 0
-                terminationMessagePath: /dev/termination-log
-                terminationMessagePolicy: File
-                volumeMounts:
-                  - mountPath: /etc/config
-                    name: config-volume
-                    readOnly: true
-                  - mountPath: /host
-                    name: host
-                  - mountPath: /host/etc/containers
-                    name: host-etc-containers
-                    readOnly: true
-                  - mountPath: /host/etc/pki/ca-trust
-                    name: host-etc-pki-ca-trust
-                    readOnly: true
-                  - mountPath: /host/etc/resolv.conf
-                    name: host-etc-resolv-conf
-                    readOnly: true
-                  - mountPath: /host/lib64
-                    name: host-lib64
-                    readOnly: true
-                  - mountPath: /host/proc
-                    name: host-proc
-                    readOnly: true
-                  - mountPath: /host/run
-                    name: host-run
-                  - mountPath: /host/tmp
-                    name: host-tmp
-                  - mountPath: /host/usr/bin
-                    name: host-usr-bin
-                    readOnly: true
-                  - mountPath: /host/usr/lib
-                    name: host-usr-lib
-                    readOnly: true
-                  - mountPath: /host/usr/lib64
-                    name: host-usr-lib64
-                    readOnly: true
-                  - mountPath: /host/usr/libexec
-                    name: host-usr-libexec
-                    readOnly: true
-                  - mountPath: /host/usr/share/containers
-                    name: host-usr-share-containers
-                    readOnly: true
-                  - mountPath: /host/var/lib/cni
-                    name: host-var-lib-cni
-                    readOnly: true
-                  - mountPath: /host/var/lib/containers
-                    name: host-var-lib-containers
-                  - mountPath: /host/var/lib/kubelet
-                    name: host-var-lib-kubelet
-                    readOnly: true
-                  - mountPath: /host/var/tmp
-                    name: host-var-tmp
-                  - mountPath: /host/sys/fs/cgroup
-                    name: sys-fs-cgroup
-                    readOnly: true
+            - args:
+              - /opt/precache/precache.sh
+              command:
+              - /bin/bash
+              - -c
+              env:
+              - name: config_volume_path
+                value: /tmp/precache/config
+              - name: NODE_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: spec.nodeName
+              image: quay.io/test_images/pre-cache:latest
+              name: pre-cache-container
+              resources: {}
+              securityContext:
+                privileged: true
+                runAsUser: 0
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              volumeMounts:
+              - mountPath: /etc/config
+                name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/etc/containers
+                name: host-etc-containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc-pki-ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc-resolv-conf
+                readOnly: true
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib/cni
+                name: host-var-lib-cni
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var-lib-containers
+              - mountPath: /host/var/lib/kubelet
+                name: host-var-lib-kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
             restartPolicy: Never
@@ -208,80 +207,80 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
-              - configMap:
-                  defaultMode: 420
-                  name: pre-cache-spec
-                name: config-volume
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /etc/containers
-                  type: Directory
-                name: host-etc-containers
-              - hostPath:
-                  path: /etc/pki/ca-trust
-                  type: Directory
-                name: host-etc-pki-ca-trust
-              - hostPath:
-                  path: /etc/resolv.conf
-                  type: File
-                name: host-etc-resolv-conf
-              - hostPath:
-                  path: /lib64
-                  type: Directory
-                name: host-lib64
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib/cni
-                  type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - configMap:
+                defaultMode: 420
+                name: pre-cache-spec
+              name: config-volume
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /etc/containers
+                type: Directory
+              name: host-etc-containers
+            - hostPath:
+                path: /etc/pki/ca-trust
+                type: Directory
+              name: host-etc-pki-ca-trust
+            - hostPath:
+                path: /etc/resolv.conf
+                type: File
+              name: host-etc-resolv-conf
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib/cni
+                type: Directory
+              name: host-var-lib-cni
+            - hostPath:
+                path: /var/lib/containers
+                type: Directory
+              name: host-var-lib-containers
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -311,79 +310,79 @@ spec:
             name: pre-cache
           spec:
             containers:
-              - args:
-                  - /opt/precache/precache.sh
-                command:
-                  - /bin/bash
-                  - -c
-                env:
-                  - name: config_volume_path
-                    value: /tmp/precache/config
-                  - name: NODE_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: spec.nodeName
-                image: quay.io/test_images/pre-cache:latest
-                name: pre-cache-container
-                resources: {}
-                securityContext:
-                  privileged: true
-                  runAsUser: 0
-                terminationMessagePath: /dev/termination-log
-                terminationMessagePolicy: File
-                volumeMounts:
-                  - mountPath: /etc/config
-                    name: config-volume
-                    readOnly: true
-                  - mountPath: /host
-                    name: host
-                  - mountPath: /host/etc/containers
-                    name: host-etc-containers
-                    readOnly: true
-                  - mountPath: /host/etc/pki/ca-trust
-                    name: host-etc-pki-ca-trust
-                    readOnly: true
-                  - mountPath: /host/etc/resolv.conf
-                    name: host-etc-resolv-conf
-                    readOnly: true
-                  - mountPath: /host/lib64
-                    name: host-lib64
-                    readOnly: true
-                  - mountPath: /host/proc
-                    name: host-proc
-                    readOnly: true
-                  - mountPath: /host/run
-                    name: host-run
-                  - mountPath: /host/tmp
-                    name: host-tmp
-                  - mountPath: /host/usr/bin
-                    name: host-usr-bin
-                    readOnly: true
-                  - mountPath: /host/usr/lib
-                    name: host-usr-lib
-                    readOnly: true
-                  - mountPath: /host/usr/lib64
-                    name: host-usr-lib64
-                    readOnly: true
-                  - mountPath: /host/usr/libexec
-                    name: host-usr-libexec
-                    readOnly: true
-                  - mountPath: /host/usr/share/containers
-                    name: host-usr-share-containers
-                    readOnly: true
-                  - mountPath: /host/var/lib/cni
-                    name: host-var-lib-cni
-                    readOnly: true
-                  - mountPath: /host/var/lib/containers
-                    name: host-var-lib-containers
-                  - mountPath: /host/var/lib/kubelet
-                    name: host-var-lib-kubelet
-                    readOnly: true
-                  - mountPath: /host/var/tmp
-                    name: host-var-tmp
-                  - mountPath: /host/sys/fs/cgroup
-                    name: sys-fs-cgroup
-                    readOnly: true
+            - args:
+              - /opt/precache/precache.sh
+              command:
+              - /bin/bash
+              - -c
+              env:
+              - name: config_volume_path
+                value: /tmp/precache/config
+              - name: NODE_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: spec.nodeName
+              image: quay.io/test_images/pre-cache:latest
+              name: pre-cache-container
+              resources: {}
+              securityContext:
+                privileged: true
+                runAsUser: 0
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              volumeMounts:
+              - mountPath: /etc/config
+                name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/etc/containers
+                name: host-etc-containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc-pki-ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc-resolv-conf
+                readOnly: true
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib/cni
+                name: host-var-lib-cni
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var-lib-containers
+              - mountPath: /host/var/lib/kubelet
+                name: host-var-lib-kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
             restartPolicy: Never
@@ -391,80 +390,80 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
-              - configMap:
-                  defaultMode: 420
-                  name: pre-cache-spec
-                name: config-volume
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /etc/containers
-                  type: Directory
-                name: host-etc-containers
-              - hostPath:
-                  path: /etc/pki/ca-trust
-                  type: Directory
-                name: host-etc-pki-ca-trust
-              - hostPath:
-                  path: /etc/resolv.conf
-                  type: File
-                name: host-etc-resolv-conf
-              - hostPath:
-                  path: /lib64
-                  type: Directory
-                name: host-lib64
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib/cni
-                  type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - configMap:
+                defaultMode: 420
+                name: pre-cache-spec
+              name: config-volume
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /etc/containers
+                type: Directory
+              name: host-etc-containers
+            - hostPath:
+                path: /etc/pki/ca-trust
+                type: Directory
+              name: host-etc-pki-ca-trust
+            - hostPath:
+                path: /etc/resolv.conf
+                type: File
+              name: host-etc-resolv-conf
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib/cni
+                type: Directory
+              name: host-var-lib-cni
+            - hostPath:
+                path: /var/lib/containers
+                type: Directory
+              name: host-var-lib-containers
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -494,79 +493,79 @@ spec:
             name: pre-cache
           spec:
             containers:
-              - args:
-                  - /opt/precache/precache.sh
-                command:
-                  - /bin/bash
-                  - -c
-                env:
-                  - name: config_volume_path
-                    value: /tmp/precache/config
-                  - name: NODE_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: spec.nodeName
-                image: quay.io/test_images/pre-cache:latest
-                name: pre-cache-container
-                resources: {}
-                securityContext:
-                  privileged: true
-                  runAsUser: 0
-                terminationMessagePath: /dev/termination-log
-                terminationMessagePolicy: File
-                volumeMounts:
-                  - mountPath: /etc/config
-                    name: config-volume
-                    readOnly: true
-                  - mountPath: /host
-                    name: host
-                  - mountPath: /host/etc/containers
-                    name: host-etc-containers
-                    readOnly: true
-                  - mountPath: /host/etc/pki/ca-trust
-                    name: host-etc-pki-ca-trust
-                    readOnly: true
-                  - mountPath: /host/etc/resolv.conf
-                    name: host-etc-resolv-conf
-                    readOnly: true
-                  - mountPath: /host/lib64
-                    name: host-lib64
-                    readOnly: true
-                  - mountPath: /host/proc
-                    name: host-proc
-                    readOnly: true
-                  - mountPath: /host/run
-                    name: host-run
-                  - mountPath: /host/tmp
-                    name: host-tmp
-                  - mountPath: /host/usr/bin
-                    name: host-usr-bin
-                    readOnly: true
-                  - mountPath: /host/usr/lib
-                    name: host-usr-lib
-                    readOnly: true
-                  - mountPath: /host/usr/lib64
-                    name: host-usr-lib64
-                    readOnly: true
-                  - mountPath: /host/usr/libexec
-                    name: host-usr-libexec
-                    readOnly: true
-                  - mountPath: /host/usr/share/containers
-                    name: host-usr-share-containers
-                    readOnly: true
-                  - mountPath: /host/var/lib/cni
-                    name: host-var-lib-cni
-                    readOnly: true
-                  - mountPath: /host/var/lib/containers
-                    name: host-var-lib-containers
-                  - mountPath: /host/var/lib/kubelet
-                    name: host-var-lib-kubelet
-                    readOnly: true
-                  - mountPath: /host/var/tmp
-                    name: host-var-tmp
-                  - mountPath: /host/sys/fs/cgroup
-                    name: sys-fs-cgroup
-                    readOnly: true
+            - args:
+              - /opt/precache/precache.sh
+              command:
+              - /bin/bash
+              - -c
+              env:
+              - name: config_volume_path
+                value: /tmp/precache/config
+              - name: NODE_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: spec.nodeName
+              image: quay.io/test_images/pre-cache:latest
+              name: pre-cache-container
+              resources: {}
+              securityContext:
+                privileged: true
+                runAsUser: 0
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              volumeMounts:
+              - mountPath: /etc/config
+                name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/etc/containers
+                name: host-etc-containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc-pki-ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc-resolv-conf
+                readOnly: true
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib/cni
+                name: host-var-lib-cni
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var-lib-containers
+              - mountPath: /host/var/lib/kubelet
+                name: host-var-lib-kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
             restartPolicy: Never
@@ -574,80 +573,80 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
-              - configMap:
-                  defaultMode: 420
-                  name: pre-cache-spec
-                name: config-volume
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /etc/containers
-                  type: Directory
-                name: host-etc-containers
-              - hostPath:
-                  path: /etc/pki/ca-trust
-                  type: Directory
-                name: host-etc-pki-ca-trust
-              - hostPath:
-                  path: /etc/resolv.conf
-                  type: File
-                name: host-etc-resolv-conf
-              - hostPath:
-                  path: /lib64
-                  type: Directory
-                name: host-lib64
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib/cni
-                  type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - configMap:
+                defaultMode: 420
+                name: pre-cache-spec
+              name: config-volume
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /etc/containers
+                type: Directory
+              name: host-etc-containers
+            - hostPath:
+                path: /etc/pki/ca-trust
+                type: Directory
+              name: host-etc-pki-ca-trust
+            - hostPath:
+                path: /etc/resolv.conf
+                type: File
+              name: host-etc-resolv-conf
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib/cni
+                type: Directory
+              name: host-var-lib-cni
+            - hostPath:
+                path: /var/lib/containers
+                type: Directory
+              name: host-var-lib-containers
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup
 ---
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
@@ -677,79 +676,79 @@ spec:
             name: pre-cache
           spec:
             containers:
-              - args:
-                  - /opt/precache/precache.sh
-                command:
-                  - /bin/bash
-                  - -c
-                env:
-                  - name: config_volume_path
-                    value: /tmp/precache/config
-                  - name: NODE_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: spec.nodeName
-                image: quay.io/test_images/pre-cache:latest
-                name: pre-cache-container
-                resources: {}
-                securityContext:
-                  privileged: true
-                  runAsUser: 0
-                terminationMessagePath: /dev/termination-log
-                terminationMessagePolicy: File
-                volumeMounts:
-                  - mountPath: /etc/config
-                    name: config-volume
-                    readOnly: true
-                  - mountPath: /host
-                    name: host
-                  - mountPath: /host/etc/containers
-                    name: host-etc-containers
-                    readOnly: true
-                  - mountPath: /host/etc/pki/ca-trust
-                    name: host-etc-pki-ca-trust
-                    readOnly: true
-                  - mountPath: /host/etc/resolv.conf
-                    name: host-etc-resolv-conf
-                    readOnly: true
-                  - mountPath: /host/lib64
-                    name: host-lib64
-                    readOnly: true
-                  - mountPath: /host/proc
-                    name: host-proc
-                    readOnly: true
-                  - mountPath: /host/run
-                    name: host-run
-                  - mountPath: /host/tmp
-                    name: host-tmp
-                  - mountPath: /host/usr/bin
-                    name: host-usr-bin
-                    readOnly: true
-                  - mountPath: /host/usr/lib
-                    name: host-usr-lib
-                    readOnly: true
-                  - mountPath: /host/usr/lib64
-                    name: host-usr-lib64
-                    readOnly: true
-                  - mountPath: /host/usr/libexec
-                    name: host-usr-libexec
-                    readOnly: true
-                  - mountPath: /host/usr/share/containers
-                    name: host-usr-share-containers
-                    readOnly: true
-                  - mountPath: /host/var/lib/cni
-                    name: host-var-lib-cni
-                    readOnly: true
-                  - mountPath: /host/var/lib/containers
-                    name: host-var-lib-containers
-                  - mountPath: /host/var/lib/kubelet
-                    name: host-var-lib-kubelet
-                    readOnly: true
-                  - mountPath: /host/var/tmp
-                    name: host-var-tmp
-                  - mountPath: /host/sys/fs/cgroup
-                    name: sys-fs-cgroup
-                    readOnly: true
+            - args:
+              - /opt/precache/precache.sh
+              command:
+              - /bin/bash
+              - -c
+              env:
+              - name: config_volume_path
+                value: /tmp/precache/config
+              - name: NODE_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: spec.nodeName
+              image: quay.io/test_images/pre-cache:latest
+              name: pre-cache-container
+              resources: {}
+              securityContext:
+                privileged: true
+                runAsUser: 0
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              volumeMounts:
+              - mountPath: /etc/config
+                name: config-volume
+                readOnly: true
+              - mountPath: /host
+                name: host
+              - mountPath: /host/etc/containers
+                name: host-etc-containers
+                readOnly: true
+              - mountPath: /host/etc/pki/ca-trust
+                name: host-etc-pki-ca-trust
+                readOnly: true
+              - mountPath: /host/etc/resolv.conf
+                name: host-etc-resolv-conf
+                readOnly: true
+              - mountPath: /host/lib64
+                name: host-lib64
+                readOnly: true
+              - mountPath: /host/proc
+                name: host-proc
+                readOnly: true
+              - mountPath: /host/run
+                name: host-run
+              - mountPath: /host/tmp
+                name: host-tmp
+              - mountPath: /host/usr/bin
+                name: host-usr-bin
+                readOnly: true
+              - mountPath: /host/usr/lib
+                name: host-usr-lib
+                readOnly: true
+              - mountPath: /host/usr/lib64
+                name: host-usr-lib64
+                readOnly: true
+              - mountPath: /host/usr/libexec
+                name: host-usr-libexec
+                readOnly: true
+              - mountPath: /host/usr/share/containers
+                name: host-usr-share-containers
+                readOnly: true
+              - mountPath: /host/var/lib/cni
+                name: host-var-lib-cni
+                readOnly: true
+              - mountPath: /host/var/lib/containers
+                name: host-var-lib-containers
+              - mountPath: /host/var/lib/kubelet
+                name: host-var-lib-kubelet
+                readOnly: true
+              - mountPath: /host/var/tmp
+                name: host-var-tmp
+              - mountPath: /host/sys/fs/cgroup
+                name: sys-fs-cgroup
+                readOnly: true
             dnsPolicy: ClusterFirst
             priorityClassName: system-cluster-critical
             restartPolicy: Never
@@ -757,77 +756,77 @@ spec:
             securityContext: {}
             serviceAccountName: pre-cache-agent
             volumes:
-              - configMap:
-                  defaultMode: 420
-                  name: pre-cache-spec
-                name: config-volume
-              - emptyDir: {}
-                name: host
-              - hostPath:
-                  path: /etc/containers
-                  type: Directory
-                name: host-etc-containers
-              - hostPath:
-                  path: /etc/pki/ca-trust
-                  type: Directory
-                name: host-etc-pki-ca-trust
-              - hostPath:
-                  path: /etc/resolv.conf
-                  type: File
-                name: host-etc-resolv-conf
-              - hostPath:
-                  path: /lib64
-                  type: Directory
-                name: host-lib64
-              - hostPath:
-                  path: /proc
-                  type: Directory
-                name: host-proc
-              - hostPath:
-                  path: /run
-                  type: Directory
-                name: host-run
-              - hostPath:
-                  path: /tmp
-                  type: Directory
-                name: host-tmp
-              - hostPath:
-                  path: /usr/bin
-                  type: Directory
-                name: host-usr-bin
-              - hostPath:
-                  path: /usr/lib
-                  type: Directory
-                name: host-usr-lib
-              - hostPath:
-                  path: /usr/lib64
-                  type: Directory
-                name: host-usr-lib64
-              - hostPath:
-                  path: /usr/libexec
-                  type: Directory
-                name: host-usr-libexec
-              - hostPath:
-                  path: /usr/share/containers
-                  type: Directory
-                name: host-usr-share-containers
-              - hostPath:
-                  path: /var/lib/cni
-                  type: Directory
-                name: host-var-lib-cni
-              - hostPath:
-                  path: /var/lib/containers
-                  type: Directory
-                name: host-var-lib-containers
-              - hostPath:
-                  path: /var/lib/kubelet
-                  type: Directory
-                name: host-var-lib-kubelet
-              - hostPath:
-                  path: /var/tmp
-                  type: Directory
-                name: host-var-tmp
-              - hostPath:
-                  path: /sys/fs/cgroup
-                  type: Directory
-                name: sys-fs-cgroup
+            - configMap:
+                defaultMode: 420
+                name: pre-cache-spec
+              name: config-volume
+            - emptyDir: {}
+              name: host
+            - hostPath:
+                path: /etc/containers
+                type: Directory
+              name: host-etc-containers
+            - hostPath:
+                path: /etc/pki/ca-trust
+                type: Directory
+              name: host-etc-pki-ca-trust
+            - hostPath:
+                path: /etc/resolv.conf
+                type: File
+              name: host-etc-resolv-conf
+            - hostPath:
+                path: /lib64
+                type: Directory
+              name: host-lib64
+            - hostPath:
+                path: /proc
+                type: Directory
+              name: host-proc
+            - hostPath:
+                path: /run
+                type: Directory
+              name: host-run
+            - hostPath:
+                path: /tmp
+                type: Directory
+              name: host-tmp
+            - hostPath:
+                path: /usr/bin
+                type: Directory
+              name: host-usr-bin
+            - hostPath:
+                path: /usr/lib
+                type: Directory
+              name: host-usr-lib
+            - hostPath:
+                path: /usr/lib64
+                type: Directory
+              name: host-usr-lib64
+            - hostPath:
+                path: /usr/libexec
+                type: Directory
+              name: host-usr-libexec
+            - hostPath:
+                path: /usr/share/containers
+                type: Directory
+              name: host-usr-share-containers
+            - hostPath:
+                path: /var/lib/cni
+                type: Directory
+              name: host-var-lib-cni
+            - hostPath:
+                path: /var/lib/containers
+                type: Directory
+              name: host-var-lib-containers
+            - hostPath:
+                path: /var/lib/kubelet
+                type: Directory
+              name: host-var-lib-kubelet
+            - hostPath:
+                path: /var/tmp
+                type: Directory
+              name: host-var-tmp
+            - hostPath:
+                path: /sys/fs/cgroup
+                type: Directory
+              name: sys-fs-cgroup

--- a/tests/kuttl/tests/pre-caching-with-configs/05-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-with-configs/05-assert.yaml
@@ -6,16 +6,16 @@ metadata:
 spec:
   backup: false
   clusters:
-    - spoke6
-    - spoke2
-    - spoke1
-    - spoke5
+  - spoke6
+  - spoke2
+  - spoke1
+  - spoke5
   enable: false
   managedPolicies:
-    - policy0-common-config-policy
-    - policy2-common-pao-sub-policy
-    - policy3-common-ptp-sub-policy
-    - policy4-common-sriov-sub-policy
+  - policy0-common-config-policy
+  - policy2-common-pao-sub-policy
+  - policy3-common-ptp-sub-policy
+  - policy4-common-sriov-sub-policy
   preCaching: true
   preCachingConfigRef:
     name: pre-caching-config
@@ -26,75 +26,75 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-    - message: All selected clusters are valid
-      reason: ClusterSelectionCompleted
-      status: "True"
-      type: ClustersSelected
-    - message: Completed validation
-      reason: ValidationCompleted
-      status: "True"
-      type: Validated
-    - message: Precaching spec is valid and consistent
-      reason: PrecacheSpecIsWellFormed
-      status: "True"
-      type: PrecacheSpecValid
-    - message: Precaching in progress for 4 clusters
-      reason: InProgress
-      status: "False"
-      type: PrecachingSuceeded
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: 'True'
+    type: ClustersSelected
+  - message: Completed validation
+    reason: ValidationCompleted
+    status: 'True'
+    type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: 'True'
+    type: PrecacheSpecValid
+  - message: Precaching in progress for 4 clusters
+    reason: InProgress
+    status: 'False'
+    type: PrecachingSuceeded
   copiedPolicies:
-    - cgu-policy3-common-ptp-sub-policy-kuttl
-    - cgu-policy4-common-sriov-sub-policy-kuttl
+  - cgu-policy3-common-ptp-sub-policy-kuttl
+  - cgu-policy4-common-sriov-sub-policy-kuttl
   managedPoliciesCompliantBeforeUpgrade:
-    - policy0-common-config-policy
-    - policy2-common-pao-sub-policy
+  - policy0-common-config-policy
+  - policy2-common-pao-sub-policy
   managedPoliciesContent:
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'
     policy4-common-sriov-sub-policy: '[{"kind":"Subscription","name":"sriov-network-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-sriov-network-operator"}]'
   managedPoliciesForUpgrade:
-    - name: policy3-common-ptp-sub-policy
-      namespace: default
-    - name: policy4-common-sriov-sub-policy
-      namespace: default
+  - name: policy3-common-ptp-sub-policy
+    namespace: default
+  - name: policy4-common-sriov-sub-policy
+    namespace: default
   managedPoliciesNs:
     policy3-common-ptp-sub-policy: default
     policy4-common-sriov-sub-policy: default
   placementBindings:
-    - cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   placementRules:
-    - cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   precaching:
     spec:
       platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
       operatorsIndexes:
-        - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+      - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
       operatorsPackagesAndChannels:
-        - performance-addon-operator:stable
-        - ptp-operator:stable
-        - sriov-network-operator:stable
+      - performance-addon-operator:stable
+      - ptp-operator:stable
+      - sriov-network-operator:stable
       excludePrecachePatterns:
-        - aws
-        - azure
+      - aws
+      - azure
       additionalImages:
-        - image1:latest
-        - image2:latest
-      spaceRequired: "40"
+      - image1:latest
+      - image2:latest
+      spaceRequired: '40'
     status:
       spoke1: Active
       spoke2: Active
       spoke5: Active
       spoke6: Active
   remediationPlan:
-    - - spoke6
-      - spoke2
-      - spoke1
-      - spoke5
+  - - spoke6
+    - spoke2
+    - spoke1
+    - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl

--- a/tests/kuttl/tests/pre-caching-with-configs/06-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-with-configs/06-assert.yaml
@@ -6,16 +6,16 @@ metadata:
 spec:
   backup: false
   clusters:
-    - spoke6
-    - spoke2
-    - spoke1
-    - spoke5
+  - spoke6
+  - spoke2
+  - spoke1
+  - spoke5
   enable: false
   managedPolicies:
-    - policy0-common-config-policy
-    - policy2-common-pao-sub-policy
-    - policy3-common-ptp-sub-policy
-    - policy4-common-sriov-sub-policy
+  - policy0-common-config-policy
+  - policy2-common-pao-sub-policy
+  - policy3-common-ptp-sub-policy
+  - policy4-common-sriov-sub-policy
   preCaching: true
   preCachingConfigRef:
     name: pre-caching-config
@@ -26,79 +26,79 @@ spec:
 status:
   computedMaxConcurrency: 4
   conditions:
-    - message: All selected clusters are valid
-      reason: ClusterSelectionCompleted
-      status: "True"
-      type: ClustersSelected
-    - message: Completed validation
-      reason: ValidationCompleted
-      status: "True"
-      type: Validated
-    - message: Precaching spec is valid and consistent
-      reason: PrecacheSpecIsWellFormed
-      status: "True"
-      type: PrecacheSpecValid
-    - message: Precaching is completed for all clusters
-      reason: PrecachingCompleted
-      status: "True"
-      type: PrecachingSuceeded
-    - message: Not enabled
-      reason: NotEnabled
-      status: "False"
-      type: Progressing
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: 'True'
+    type: ClustersSelected
+  - message: Completed validation
+    reason: ValidationCompleted
+    status: 'True'
+    type: Validated
+  - message: Precaching spec is valid and consistent
+    reason: PrecacheSpecIsWellFormed
+    status: 'True'
+    type: PrecacheSpecValid
+  - message: Precaching is completed for all clusters
+    reason: PrecachingCompleted
+    status: 'True'
+    type: PrecachingSuceeded
+  - message: Not enabled
+    reason: NotEnabled
+    status: 'False'
+    type: Progressing
   copiedPolicies:
-    - cgu-policy3-common-ptp-sub-policy-kuttl
-    - cgu-policy4-common-sriov-sub-policy-kuttl
+  - cgu-policy3-common-ptp-sub-policy-kuttl
+  - cgu-policy4-common-sriov-sub-policy-kuttl
   managedPoliciesCompliantBeforeUpgrade:
-    - policy0-common-config-policy
-    - policy2-common-pao-sub-policy
+  - policy0-common-config-policy
+  - policy2-common-pao-sub-policy
   managedPoliciesContent:
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'
     policy4-common-sriov-sub-policy: '[{"kind":"Subscription","name":"sriov-network-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-sriov-network-operator"}]'
   managedPoliciesForUpgrade:
-    - name: policy3-common-ptp-sub-policy
-      namespace: default
-    - name: policy4-common-sriov-sub-policy
-      namespace: default
+  - name: policy3-common-ptp-sub-policy
+    namespace: default
+  - name: policy4-common-sriov-sub-policy
+    namespace: default
   managedPoliciesNs:
     policy3-common-ptp-sub-policy: default
     policy4-common-sriov-sub-policy: default
   placementBindings:
-    - cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   placementRules:
-    - cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    - cgu-policy4-common-sriov-sub-policy-placement-kuttl
+  - cgu-policy3-common-ptp-sub-policy-placement-kuttl
+  - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   precaching:
     spec:
       platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
       operatorsIndexes:
-        - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+      - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
       operatorsPackagesAndChannels:
-        - performance-addon-operator:stable
-        - ptp-operator:stable
-        - sriov-network-operator:stable
+      - performance-addon-operator:stable
+      - ptp-operator:stable
+      - sriov-network-operator:stable
       excludePrecachePatterns:
-        - aws
-        - azure
+      - aws
+      - azure
       additionalImages:
-        - image1:latest
-        - image2:latest
-      spaceRequired: "40"
+      - image1:latest
+      - image2:latest
+      spaceRequired: '40'
     status:
       spoke1: Succeeded
       spoke2: Succeeded
       spoke5: Succeeded
       spoke6: Succeeded
   remediationPlan:
-    - - spoke6
-      - spoke2
-      - spoke1
-      - spoke5
+  - - spoke6
+    - spoke2
+    - spoke1
+    - spoke5
   safeResourceNames:
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl

--- a/tests/kuttl/tests/skip-compliant-policies/00-assert.yaml
+++ b/tests/kuttl/tests/skip-compliant-policies/00-assert.yaml
@@ -23,15 +23,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-policy1-common-cluster-version-policy-kuttl
@@ -67,15 +67,15 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    cgu-common-cluster-version-policy-config: cgu-common-cluster-version-policy-config-kuttl
-    cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    cgu-policy1-common-cluster-version-policy: cgu-policy1-common-cluster-version-policy-kuttl
-    cgu-policy1-common-cluster-version-policy-placement: cgu-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
-    cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
-    cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
+    /cgu-common-cluster-version-policy-config: cgu-common-cluster-version-policy-config-kuttl
+    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
+    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
+    default/cgu-policy1-common-cluster-version-policy: cgu-policy1-common-cluster-version-policy-kuttl
+    default/cgu-policy1-common-cluster-version-policy-placement: cgu-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
+    default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
+    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
+    default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
   status:
     currentBatch: 1
     currentBatchRemediationProgress:

--- a/tests/kuttl/tests/upgrade-batch-timeout/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-batch-timeout/00-assert.yaml
@@ -19,15 +19,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Not enabled
     reason: NotEnabled
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
@@ -52,10 +52,10 @@ status:
   - - spoke1
   - - spoke4
   safeResourceNames:
-    cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
-    cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-upgrade-complete-policy2-common-pao-sub-policy: cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
-    cgu-upgrade-complete-policy2-common-pao-sub-policy-placement: cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-upgrade-complete-policy2-common-pao-sub-policy: cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
+    default/cgu-upgrade-complete-policy2-common-pao-sub-policy-placement: cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
   status: {}

--- a/tests/kuttl/tests/upgrade-batch-timeout/01-assert.yaml
+++ b/tests/kuttl/tests/upgrade-batch-timeout/01-assert.yaml
@@ -17,20 +17,20 @@ spec:
     timeout: 240
 status:
   clusters:
-    - name: spoke6
-      state: complete  
+  - name: spoke6
+    state: complete
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
@@ -55,12 +55,12 @@ status:
   - - spoke1
   - - spoke4
   safeResourceNames:
-    cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
-    cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-upgrade-complete-policy2-common-pao-sub-policy: cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
-    cgu-upgrade-complete-policy2-common-pao-sub-policy-placement: cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-upgrade-complete-policy2-common-pao-sub-policy: cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
+    default/cgu-upgrade-complete-policy2-common-pao-sub-policy-placement: cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
   status:
     currentBatch: 1
     currentBatchRemediationProgress:
@@ -72,19 +72,19 @@ apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-running: ""
+    ztp-running: ''
   name: spoke1
 ---
 apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-running: ""
+    ztp-running: ''
   name: spoke4
 ---
 apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-done: ""
+    ztp-done: ''
   name: spoke6

--- a/tests/kuttl/tests/upgrade-batch-timeout/02-assert.yaml
+++ b/tests/kuttl/tests/upgrade-batch-timeout/02-assert.yaml
@@ -17,21 +17,21 @@ spec:
     timeout: 241
 status:
   clusters:
-    - name: spoke6
-      state: complete  
-    - name: spoke1
-      state: complete        
+  - name: spoke6
+    state: complete
+  - name: spoke1
+    state: complete
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
@@ -56,12 +56,12 @@ status:
   - - spoke1
   - - spoke4
   safeResourceNames:
-    cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
-    cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-upgrade-complete-policy2-common-pao-sub-policy: cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
-    cgu-upgrade-complete-policy2-common-pao-sub-policy-placement: cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-upgrade-complete-policy2-common-pao-sub-policy: cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
+    default/cgu-upgrade-complete-policy2-common-pao-sub-policy-placement: cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
   status:
     currentBatch: 2
     currentBatchRemediationProgress:
@@ -73,19 +73,19 @@ apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-done: ""
+    ztp-done: ''
   name: spoke1
 ---
 apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-running: ""
+    ztp-running: ''
   name: spoke4
 ---
 apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-done: ""
+    ztp-done: ''
   name: spoke6

--- a/tests/kuttl/tests/upgrade-complete/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/00-assert.yaml
@@ -19,15 +19,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Not enabled
     reason: NotEnabled
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
@@ -52,10 +52,10 @@ status:
   - - spoke1
   - - spoke4
   safeResourceNames:
-    cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
-    cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-upgrade-complete-policy2-common-pao-sub-policy: cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
-    cgu-upgrade-complete-policy2-common-pao-sub-policy-placement: cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-upgrade-complete-policy2-common-pao-sub-policy: cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
+    default/cgu-upgrade-complete-policy2-common-pao-sub-policy-placement: cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
   status: {}

--- a/tests/kuttl/tests/upgrade-complete/01-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/01-assert.yaml
@@ -17,20 +17,20 @@ spec:
     timeout: 240
 status:
   clusters:
-    - name: spoke6
-      state: complete  
+  - name: spoke6
+    state: complete
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
@@ -55,12 +55,12 @@ status:
   - - spoke1
   - - spoke4
   safeResourceNames:
-    cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
-    cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-upgrade-complete-policy2-common-pao-sub-policy: cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
-    cgu-upgrade-complete-policy2-common-pao-sub-policy-placement: cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-upgrade-complete-policy2-common-pao-sub-policy: cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
+    default/cgu-upgrade-complete-policy2-common-pao-sub-policy-placement: cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
   status:
     currentBatch: 1
     currentBatchRemediationProgress:
@@ -72,19 +72,19 @@ apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-running: ""
+    ztp-running: ''
   name: spoke1
 ---
 apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-running: ""
+    ztp-running: ''
   name: spoke4
 ---
 apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-done: ""
+    ztp-done: ''
   name: spoke6

--- a/tests/kuttl/tests/upgrade-complete/02-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/02-assert.yaml
@@ -17,21 +17,21 @@ spec:
     timeout: 241
 status:
   clusters:
-    - name: spoke6
-      state: complete        
-    - name: spoke1
-      state: complete    
+  - name: spoke6
+    state: complete
+  - name: spoke1
+    state: complete
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
@@ -56,12 +56,12 @@ status:
   - - spoke1
   - - spoke4
   safeResourceNames:
-    cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
-    cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-upgrade-complete-policy2-common-pao-sub-policy: cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
-    cgu-upgrade-complete-policy2-common-pao-sub-policy-placement: cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-upgrade-complete-policy2-common-pao-sub-policy: cgu-upgrade-complete-policy2-common-pao-sub-polic-kuttl
+    default/cgu-upgrade-complete-policy2-common-pao-sub-policy-placement: cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
   status:
     currentBatch: 2
     currentBatchRemediationProgress:
@@ -73,12 +73,12 @@ apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-done: ""
+    ztp-done: ''
   name: spoke1
 ---
 apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-running: ""
+    ztp-running: ''
   name: spoke4

--- a/tests/kuttl/tests/upgrade-partial-batch-timeout/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-partial-batch-timeout/00-assert.yaml
@@ -19,15 +19,15 @@ status:
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Not enabled
     reason: NotEnabled
-    status: "False"
+    status: 'False'
     type: Progressing
   copiedPolicies:
   - cgu-upgrade-complete-policy0-common-config-policy-kuttl
@@ -50,10 +50,10 @@ status:
   - - spoke1
     - spoke4
   safeResourceNames:
-    cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
-    cgu-upgrade-complete-common-config-policy-config: cgu-upgrade-complete-common-config-policy-config-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-upgrade-complete-policy0-common-config-policy: cgu-upgrade-complete-policy0-common-config-policy-kuttl
-    cgu-upgrade-complete-policy0-common-config-policy-placement: cgu-upgrade-complete-policy0-common-config-policy-placement-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-config-policy-config: cgu-upgrade-complete-common-config-policy-config-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-upgrade-complete-policy0-common-config-policy: cgu-upgrade-complete-policy0-common-config-policy-kuttl
+    default/cgu-upgrade-complete-policy0-common-config-policy-placement: cgu-upgrade-complete-policy0-common-config-policy-placement-kuttl
   status: {}

--- a/tests/kuttl/tests/upgrade-partial-batch-timeout/01-assert.yaml
+++ b/tests/kuttl/tests/upgrade-partial-batch-timeout/01-assert.yaml
@@ -17,20 +17,20 @@ spec:
     timeout: 240
 status:
   clusters:
-    - name: spoke6
-      state: complete  
+  - name: spoke6
+    state: complete
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
     type: ClustersSelected
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
   - cgu-upgrade-complete-policy0-common-config-policy-kuttl
@@ -53,12 +53,12 @@ status:
   - - spoke1
     - spoke4
   safeResourceNames:
-    cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
-    cgu-upgrade-complete-common-config-policy-config: cgu-upgrade-complete-common-config-policy-config-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-upgrade-complete-policy0-common-config-policy: cgu-upgrade-complete-policy0-common-config-policy-kuttl
-    cgu-upgrade-complete-policy0-common-config-policy-placement: cgu-upgrade-complete-policy0-common-config-policy-placement-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-config-policy-config: cgu-upgrade-complete-common-config-policy-config-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-upgrade-complete-policy0-common-config-policy: cgu-upgrade-complete-policy0-common-config-policy-kuttl
+    default/cgu-upgrade-complete-policy0-common-config-policy-placement: cgu-upgrade-complete-policy0-common-config-policy-placement-kuttl
   status:
     currentBatch: 1
     currentBatchRemediationProgress:
@@ -67,25 +67,25 @@ status:
         state: InProgress
       spoke4:
         policyIndex: 0
-        state: InProgress        
+        state: InProgress
 ---
 apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-running: ""
+    ztp-running: ''
   name: spoke1
 ---
 apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-running: ""
+    ztp-running: ''
   name: spoke4
 ---
 apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-done: ""
+    ztp-done: ''
   name: spoke6

--- a/tests/kuttl/tests/upgrade-partial-batch-timeout/02-assert.yaml
+++ b/tests/kuttl/tests/upgrade-partial-batch-timeout/02-assert.yaml
@@ -17,22 +17,22 @@ spec:
     timeout: 241
 status:
   clusters:
-    - name: spoke6
-      state: complete  
+  - name: spoke6
+    state: complete
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
-  - cgu-upgrade-complete-policy0-common-config-policy-kuttl  
+  - cgu-upgrade-complete-policy0-common-config-policy-kuttl
   - cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
   managedPoliciesForUpgrade:
   - name: policy1-common-cluster-version-policy
@@ -52,12 +52,12 @@ status:
   - - spoke1
     - spoke4
   safeResourceNames:
-    cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
-    cgu-upgrade-complete-common-config-policy-config: cgu-upgrade-complete-common-config-policy-config-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-upgrade-complete-policy0-common-config-policy: cgu-upgrade-complete-policy0-common-config-policy-kuttl
-    cgu-upgrade-complete-policy0-common-config-policy-placement: cgu-upgrade-complete-policy0-common-config-policy-placement-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-config-policy-config: cgu-upgrade-complete-common-config-policy-config-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-upgrade-complete-policy0-common-config-policy: cgu-upgrade-complete-policy0-common-config-policy-kuttl
+    default/cgu-upgrade-complete-policy0-common-config-policy-placement: cgu-upgrade-complete-policy0-common-config-policy-placement-kuttl
   status:
     currentBatch: 1
     currentBatchRemediationProgress:
@@ -72,19 +72,19 @@ apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-running: ""
+    ztp-running: ''
   name: spoke1
 ---
 apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-running: ""
+    ztp-running: ''
   name: spoke4
 ---
 apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-done: ""
+    ztp-done: ''
   name: spoke6

--- a/tests/kuttl/tests/upgrade-partial-batch-timeout/03-assert.yaml
+++ b/tests/kuttl/tests/upgrade-partial-batch-timeout/03-assert.yaml
@@ -17,24 +17,24 @@ spec:
     timeout: 240
 status:
   clusters:
-    - name: spoke6
-      state: complete
-    - name: spoke1
-      state: complete  
+  - name: spoke6
+    state: complete
+  - name: spoke1
+    state: complete
   conditions:
   - message: All selected clusters are valid
     reason: ClusterSelectionCompleted
-    status: "True"
+    status: 'True'
   - message: Completed validation
     reason: ValidationCompleted
-    status: "True"
+    status: 'True'
     type: Validated
   - message: Remediating non-compliant policies
     reason: InProgress
-    status: "True"
+    status: 'True'
     type: Progressing
   copiedPolicies:
-  - cgu-upgrade-complete-policy0-common-config-policy-kuttl  
+  - cgu-upgrade-complete-policy0-common-config-policy-kuttl
   - cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
   managedPoliciesForUpgrade:
   - name: policy1-common-cluster-version-policy
@@ -54,12 +54,12 @@ status:
   - - spoke1
     - spoke4
   safeResourceNames:
-    cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
-    cgu-upgrade-complete-common-config-policy-config: cgu-upgrade-complete-common-config-policy-config-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
-    cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
-    cgu-upgrade-complete-policy0-common-config-policy: cgu-upgrade-complete-policy0-common-config-policy-kuttl
-    cgu-upgrade-complete-policy0-common-config-policy-placement: cgu-upgrade-complete-policy0-common-config-policy-placement-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-config-policy-config: cgu-upgrade-complete-common-config-policy-config-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-upgrade-complete-policy0-common-config-policy: cgu-upgrade-complete-policy0-common-config-policy-kuttl
+    default/cgu-upgrade-complete-policy0-common-config-policy-placement: cgu-upgrade-complete-policy0-common-config-policy-placement-kuttl
   status:
     currentBatch: 1
     currentBatchRemediationProgress:
@@ -73,19 +73,19 @@ apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-done: ""
+    ztp-done: ''
   name: spoke1
 ---
 apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-running: ""
+    ztp-running: ''
   name: spoke4
 ---
 apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   labels:
-    ztp-done: ""
+    ztp-done: ''
   name: spoke6


### PR DESCRIPTION
* This commit fixes an issue happening when using policies generated with ACM Policy Generator Plugin.
For ConfigurationPolicy kind, the name of the object and the inner template are the same when generated with ACM Gen.
In comparison the PGT plugin, adds "-config" to the name of the inner template. this leads to overloaded keys in the
clusterGroupUpgrade.Status.SafeResourceNames map.

Changes:
 - namespace+"/"+name key used in the clusterGroupUpgrade.Status.SafeResourceNames map
 - use of namespace instead of namespace length in GetSafeResourceName
 - use of utf8.RuneCountInString() instead of len to support non english characters (see policy web hook at https://github.com/stolostron/governance-policy-propagator/blob/feb9abb241954d7ce64054d7c621b423deece8cf/api/v1/policy_webhook.go#L86-L87 ).
 - adding logs to display the safenames and lenghts

* Addressing Jun's comments

* Addinitonal fixes for map key

* fix kuttl test