### PR TITLE
OCPBUGS-29208: Allow configurationpolicy name length up to 253 characters

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -1234,7 +1234,7 @@ func (r *ClusterGroupUpgradeReconciler) updateConfigurationPolicyName(
 
 	metadataContent := metadata.(map[string]interface{})
 	name := utils.GetResourceName(clusterGroupUpgrade, metadataContent["name"].(string))
-	safeName := utils.GetSafeResourceName(name, "", clusterGroupUpgrade, utils.MaxPolicyNameLengthExcludingTheDot)
+	safeName := utils.GetSafeResourceName(name, "", clusterGroupUpgrade, utils.MaxObjectNameLength)
 	metadataContent["name"] = safeName
 }
 

--- a/tests/kuttl/tests/cluster-selector/00-assert.yaml
+++ b/tests/kuttl/tests/cluster-selector/00-assert.yaml
@@ -78,7 +78,7 @@ status:
     - spoke6
   - - spoke4
   safeResourceNames:
-    /cgu-cluster-selector-common-cluster-version-policy-config: cgu-cluster-selector-common-cluster-version-policy-confi-kuttl
+    /cgu-cluster-selector-common-cluster-version-policy-config: cgu-cluster-selector-common-cluster-version-policy-config-kuttl
     /cgu-cluster-selector-common-pao-sub-policy-config: cgu-cluster-selector-common-pao-sub-policy-config-kuttl
     /cgu-cluster-selector-common-ptp-sub-policy-config: cgu-cluster-selector-common-ptp-sub-policy-config-kuttl
     /cgu-cluster-selector-common-sriov-sub-policy-config: cgu-cluster-selector-common-sriov-sub-policy-config-kuttl

--- a/tests/kuttl/tests/upgrade-batch-timeout/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-batch-timeout/00-assert.yaml
@@ -52,7 +52,7 @@ status:
   - - spoke1
   - - spoke4
   safeResourceNames:
-    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
     /cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl

--- a/tests/kuttl/tests/upgrade-batch-timeout/01-assert.yaml
+++ b/tests/kuttl/tests/upgrade-batch-timeout/01-assert.yaml
@@ -55,7 +55,7 @@ status:
   - - spoke1
   - - spoke4
   safeResourceNames:
-    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
     /cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl

--- a/tests/kuttl/tests/upgrade-batch-timeout/02-assert.yaml
+++ b/tests/kuttl/tests/upgrade-batch-timeout/02-assert.yaml
@@ -56,7 +56,7 @@ status:
   - - spoke1
   - - spoke4
   safeResourceNames:
-    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
     /cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl

--- a/tests/kuttl/tests/upgrade-complete/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/00-assert.yaml
@@ -52,7 +52,7 @@ status:
   - - spoke1
   - - spoke4
   safeResourceNames:
-    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
     /cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl

--- a/tests/kuttl/tests/upgrade-complete/01-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/01-assert.yaml
@@ -55,7 +55,7 @@ status:
   - - spoke1
   - - spoke4
   safeResourceNames:
-    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
     /cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl

--- a/tests/kuttl/tests/upgrade-complete/02-assert.yaml
+++ b/tests/kuttl/tests/upgrade-complete/02-assert.yaml
@@ -56,7 +56,7 @@ status:
   - - spoke1
   - - spoke4
   safeResourceNames:
-    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
     /cgu-upgrade-complete-common-pao-sub-policy-config: cgu-upgrade-complete-common-pao-sub-policy-config-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl

--- a/tests/kuttl/tests/upgrade-partial-batch-timeout/00-assert.yaml
+++ b/tests/kuttl/tests/upgrade-partial-batch-timeout/00-assert.yaml
@@ -50,7 +50,7 @@ status:
   - - spoke1
     - spoke4
   safeResourceNames:
-    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
     /cgu-upgrade-complete-common-config-policy-config: cgu-upgrade-complete-common-config-policy-config-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl

--- a/tests/kuttl/tests/upgrade-partial-batch-timeout/01-assert.yaml
+++ b/tests/kuttl/tests/upgrade-partial-batch-timeout/01-assert.yaml
@@ -53,7 +53,7 @@ status:
   - - spoke1
     - spoke4
   safeResourceNames:
-    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
     /cgu-upgrade-complete-common-config-policy-config: cgu-upgrade-complete-common-config-policy-config-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl

--- a/tests/kuttl/tests/upgrade-partial-batch-timeout/02-assert.yaml
+++ b/tests/kuttl/tests/upgrade-partial-batch-timeout/02-assert.yaml
@@ -52,7 +52,7 @@ status:
   - - spoke1
     - spoke4
   safeResourceNames:
-    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
     /cgu-upgrade-complete-common-config-policy-config: cgu-upgrade-complete-common-config-policy-config-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl

--- a/tests/kuttl/tests/upgrade-partial-batch-timeout/03-assert.yaml
+++ b/tests/kuttl/tests/upgrade-partial-batch-timeout/03-assert.yaml
@@ -54,7 +54,7 @@ status:
   - - spoke1
     - spoke4
   safeResourceNames:
-    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-confi-kuttl
+    /cgu-upgrade-complete-common-cluster-version-policy-config: cgu-upgrade-complete-common-cluster-version-policy-config-kuttl
     /cgu-upgrade-complete-common-config-policy-config: cgu-upgrade-complete-common-config-policy-config-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy: cgu-upgrade-complete-policy1-common-cluster-versi-kuttl
     default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl


### PR DESCRIPTION
The Policy config object name is currently limited to 62 characters but should be 253.