### PR TITLE
CNF-12076: move aztp to separate image

### DIFF
--- a/Dockerfile.aztp
+++ b/Dockerfile.aztp
@@ -1,4 +1,4 @@
-# Build the manager binary
+# Build the aztp binary
 FROM registry.hub.docker.com/library/golang:1.20 as builder
 
 WORKDIR /workspace
@@ -7,13 +7,10 @@ WORKDIR /workspace
 COPY go.mod go.sum ./
 COPY vendor/ vendor/
 
-# Copy the go source
-COPY main.go main.go
-COPY pkg/api/ pkg/api/
-COPY controllers/ controllers/
+COPY pkg/aztp/ pkg/aztp/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=vendor -a -o aztp pkg/aztp/aztp.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
@@ -21,8 +18,8 @@ FROM gcr.io/distroless/static:nonroot
 
 WORKDIR /
 
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/aztp .
 
 USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/aztp"]

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:$(VERSION)
 IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
 PRECACHE_IMG ?= $(IMAGE_TAG_BASE)-precache:$(VERSION)
 RECOVERY_IMG ?= $(IMAGE_TAG_BASE)-recovery:$(VERSION)
+AZTP_IMG ?= $(IMAGE_TAG_BASE)-aztp:$(VERSION)
 
 CRD_OPTIONS ?= "crd"
 
@@ -219,10 +220,10 @@ build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	PRECACHE_IMG=${PRECACHE_IMG} RECOVERY_IMG=${RECOVERY_IMG} CONTROLLER_IMG=$(IMG) go run ./main.go
+	PRECACHE_IMG=${PRECACHE_IMG} RECOVERY_IMG=${RECOVERY_IMG} AZTP_IMG=$(AZTP_IMG) go run ./main.go
 
 debug: manifests generate fmt vet ## Run a controller from your host that accepts remote attachment.
-	PRECACHE_IMG=${PRECACHE_IMG} RECOVERY_IMG=${RECOVERY_IMG} CONTROLLER_IMG=$(IMG) dlv debug --headless --listen 127.0.0.1:2345 --api-version 2 --accept-multiclient ./main.go
+	PRECACHE_IMG=${PRECACHE_IMG} RECOVERY_IMG=${RECOVERY_IMG} AZTP_IMG=$(AZTP_IMG) dlv debug --headless --listen 127.0.0.1:2345 --api-version 2 --accept-multiclient ./main.go
 
 docker-build: ## Build container image with the manager.
 	${ENGINE} build -t ${IMG} -f Dockerfile .
@@ -242,6 +243,11 @@ docker-build-recovery: ## Build recovery container image
 docker-push-recovery: ## Push recovery container image.
 	${ENGINE} push ${RECOVERY_IMG}
 
+docker-build-aztp: ## Build aztp container image
+	${ENGINE} build -t ${AZTP_IMG} -f Dockerfile.aztp .
+
+docker-push-aztp: ## Push recovery container image.
+	${ENGINE} push ${AZTP_IMG}
 ##@ Deployment
 
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
@@ -251,7 +257,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG) && CONTROLLER_IMG=$(IMG) PRECACHE_IMG=$(PRECACHE_IMG) RECOVERY_IMG=$(RECOVERY_IMG) envsubst < related-images/in.yaml > related-images/patch.yaml 
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG) && AZTP_IMG=$(AZTP_IMG) PRECACHE_IMG=$(PRECACHE_IMG) RECOVERY_IMG=$(RECOVERY_IMG) envsubst < related-images/in.yaml > related-images/patch.yaml 
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
@@ -260,7 +266,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 .PHONY: bundle
 bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests --apis-dir pkg/api/ -q
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG) && CONTROLLER_IMG=$(IMG) PRECACHE_IMG=$(PRECACHE_IMG) RECOVERY_IMG=$(RECOVERY_IMG) envsubst < related-images/in.yaml > related-images/patch.yaml 
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG) && AZTP_IMG=$(AZTP_IMG) PRECACHE_IMG=$(PRECACHE_IMG) RECOVERY_IMG=$(RECOVERY_IMG) envsubst < related-images/in.yaml > related-images/patch.yaml 
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	$(OPERATOR_SDK) bundle validate ./bundle
 

--- a/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml
@@ -422,8 +422,8 @@ spec:
                   value: quay.io/openshift-kni/cluster-group-upgrades-operator-recovery:4.16.0
                 - name: INSECURE_GRAPH_CALL
                   value: "false"
-                - name: CONTROLLER_IMG
-                  value: quay.io/openshift-kni/cluster-group-upgrades-operator:4.16.0
+                - name: AZTP_IMG
+                  value: quay.io/openshift-kni/cluster-group-upgrades-operator-aztp:4.16.0
                 image: quay.io/openshift-kni/cluster-group-upgrades-operator:4.16.0
                 livenessProbe:
                   httpGet:

--- a/config/manager/related-images/in.yaml
+++ b/config/manager/related-images/in.yaml
@@ -15,5 +15,5 @@ spec:
             value: $RECOVERY_IMG
           - name: INSECURE_GRAPH_CALL
             value: "false"
-          - name: CONTROLLER_IMG
-            value: $CONTROLLER_IMG          
+          - name: AZTP_IMG
+            value: $AZTP_IMG                    

--- a/controllers/managedclusterForCGU_controller.go
+++ b/controllers/managedclusterForCGU_controller.go
@@ -361,9 +361,9 @@ func (r *ManagedClusterForCguReconciler) extractAztpPolicies(ctx context.Context
 
 	var data templates.AztpTemplateData
 
-	data.AztpImage = os.Getenv("CONTROLLER_IMG")
+	data.AztpImage = os.Getenv("AZTP_IMG")
 	if strings.Compare(data.AztpImage, "") == 0 {
-		return fmt.Errorf("aztp failure: can't retrieve controller image pull spec")
+		return fmt.Errorf("aztp failure: can't retrieve aztp image pull spec")
 	}
 
 	objects, err = templates.RenderAztpService(data, aztpVariant)


### PR DESCRIPTION
This commit moves AZTP agent to a separate container image.

/cc @jc-rh @rauhersu @fontivan 