### PR TITLE
CNF-13181: Allow partial completion before moving to next CGU

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -395,9 +395,6 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 			)
 			nextReconcile = requeueWithMediumInterval()
 		} else {
-			// There are no blocking CRs, continue with the upgrade process.
-			// create backup
-
 			err = r.reconcileBackup(ctx, clusterGroupUpgrade, clusters)
 			if err != nil {
 				r.Log.Error(err, "reconcileBackup error")
@@ -444,6 +441,33 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 				nextReconcile = requeueImmediately()
 				r.updateStatus(ctx, clusterGroupUpgrade)
 				return
+			}
+
+			if clusterGroupUpgrade.GetAnnotations()[utils.BlockingCGUCompletionModeAnn] == utils.PartialBlockingCGUCompletion {
+				clusters, err = r.filterNonCompletedClustersInBlockingCRs(ctx, clusterGroupUpgrade, clusters)
+				if err != nil {
+					r.Log.Error(err, "filterNonCompletedClustersInBlockingCRs")
+					return
+				}
+				if len(clusters) == 0 {
+					utils.SetStatusCondition(
+						&clusterGroupUpgrade.Status.Conditions,
+						utils.ConditionTypes.Progressing,
+						utils.ConditionReasons.Completed,
+						metav1.ConditionFalse,
+						"No clusters available for remediation after filtering out non-completed clusters from blocking CGUs",
+					)
+					utils.SetStatusCondition(
+						&clusterGroupUpgrade.Status.Conditions,
+						utils.ConditionTypes.Succeeded,
+						utils.ConditionReasons.Failed,
+						metav1.ConditionFalse,
+						"No clusters available for remediation after filtering out non-completed clusters from blocking CGUs",
+					)
+					nextReconcile = requeueWithShortInterval()
+					r.updateStatus(ctx, clusterGroupUpgrade)
+					return
+				}
 			}
 
 			// Rebuild remediation plan since we are about to start the upgrade and want to make sure the non-successful clusters were filtered out
@@ -1098,6 +1122,29 @@ func (r *ClusterGroupUpgradeReconciler) updateStatus(ctx context.Context, cluste
 	return nil
 }
 
+func (r *ClusterGroupUpgradeReconciler) filterNonCompletedClustersInBlockingCRs(ctx context.Context, cgu *ranv1alpha1.ClusterGroupUpgrade, clusters []string) ([]string, error) {
+	completedCGUs := make(map[string]int)
+	for _, blockingCR := range cgu.Spec.BlockingCRs {
+		blockingCGU := &ranv1alpha1.ClusterGroupUpgrade{}
+		err := r.Get(ctx, types.NamespacedName{Name: blockingCR.Name, Namespace: blockingCR.Namespace}, blockingCGU)
+		if err != nil {
+			return []string{}, fmt.Errorf("failed to get blocking CR: %w", err)
+		}
+		for _, clusterState := range blockingCGU.Status.Clusters {
+			if clusterState.State == utils.ClusterRemediationComplete {
+				completedCGUs[clusterState.Name]++
+			}
+		}
+	}
+	filteredClusters := make([]string, 0)
+	for clusterName, numberCompleted := range completedCGUs {
+		if numberCompleted == len(cgu.Spec.BlockingCRs) && utils.Contains(clusters, clusterName) {
+			filteredClusters = append(filteredClusters, clusterName)
+		}
+	}
+	return filteredClusters, nil
+}
+
 func (r *ClusterGroupUpgradeReconciler) blockingCRsNotCompleted(ctx context.Context, clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) ([]string, []string, error) {
 
 	var blockingCRsNotCompleted []string
@@ -1125,13 +1172,16 @@ func (r *ClusterGroupUpgradeReconciler) blockingCRsNotCompleted(ctx context.Cont
 			continue
 		}
 
-		// If we find a blocking CR that does not contain a true succeeded condition then we add it to the list.
-		if !meta.IsStatusConditionTrue(cgu.Status.Conditions, string(utils.ConditionTypes.Succeeded)) {
+		if clusterGroupUpgrade.GetAnnotations()[utils.BlockingCGUCompletionModeAnn] == utils.PartialBlockingCGUCompletion {
+			if !utils.IsStatusConditionPresent(cgu.Status.Conditions, string(utils.ConditionTypes.Succeeded)) {
+				blockingCRsNotCompleted = append(blockingCRsNotCompleted, cgu.Name)
+			}
+		} else if !meta.IsStatusConditionTrue(cgu.Status.Conditions, string(utils.ConditionTypes.Succeeded)) {
 			blockingCRsNotCompleted = append(blockingCRsNotCompleted, cgu.Name)
 		}
 	}
 
-	r.Log.Info("[blockingCRsNotCompleted]", "blockingCRs", blockingCRsNotCompleted)
+	r.Log.Info("[blockingCRsNotCompleted]", "blockingCRsNotCompleted", blockingCRsNotCompleted)
 	return blockingCRsNotCompleted, blockingCRsMissing, nil
 }
 

--- a/controllers/utils/common.go
+++ b/controllers/utils/common.go
@@ -104,6 +104,18 @@ func Difference(a, b []string) []string {
 	return diff
 }
 
+// Contains check if str is in slice
+// can be replaced by slices.Contains when golang is updated to 1.21
+func Contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}
+
 // SortCGUListByIBUAction orders the CGUs by the last action in the name of cgu
 // with following order prep-upgrade-rollback-finalize-abort
 func SortCGUListByIBUAction(cguList *ranv1alpha1.ClusterGroupUpgradeList) {

--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -120,3 +120,13 @@ func SetStatusCondition(existingConditions *[]metav1.Condition, conditionType Co
 		},
 	)
 }
+
+// IsStatusConditionPresent checks whether conditionType is present in the list of conditions
+func IsStatusConditionPresent(conditions []metav1.Condition, conditionType string) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return true
+		}
+	}
+	return false
+}

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -166,6 +166,13 @@ const SpaceRequiredForPrecache = "35 GiB"
 // which policies should be compliant before the cgu moves on from that policy
 const SoakAnnotation = "ran.openshift.io/soak-seconds"
 
+// BlockingCGUCompletionModeAnn is an annotation that can be set on CGU, in order to continue with dependent CGU even if
+// the original CR is only partially completed
+const (
+	BlockingCGUCompletionModeAnn = "ran.openshift.io/blocking-cgu-completion-mode"
+	PartialBlockingCGUCompletion = "partial"
+)
+
 // CGUOwnerIBGULabel is a label that is set on CGUs that are created for IBGUs. It denotes which IBGU is the
 // owner of this CGU
 const CGUOwnerIBGULabel = "ibgu"


### PR DESCRIPTION
Before this change, when multiple CGUs were chained together, the first CGU had to completely finish before the next CGU was allowed to start. This meant that if one cluster failed, the next CGU could not start for the remaining clusters.

Now, by setting the blockingCRCompletionMode annotation to partial, dependent CGUs start for clusters that are compliant with the previous CGUs.

/cc @jc-rh 