### PR TITLE
CNF-12798: Add IBGU propagating OADP configmaps to clusters

### DIFF
--- a/controllers/utils/common.go
+++ b/controllers/utils/common.go
@@ -7,9 +7,16 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/clustergroupupgrades/v1alpha1"
 	ranv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/clustergroupupgrades/v1alpha1"
 	ibguv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/imagebasedgroupupgrades/v1alpha1"
+	lcav1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
+	mwv1alpha1 "open-cluster-management.io/api/work/v1alpha1"
 )
 
 // GetMinOf3 return the minimum of 3 numbers.
@@ -102,6 +109,24 @@ func Difference(a, b []string) []string {
 		}
 	}
 	return diff
+}
+
+func ObjectToJSON(obj runtime.Object) (string, error) {
+	scheme := runtime.NewScheme()
+	mwv1alpha1.AddToScheme(scheme)
+	v1alpha1.AddToScheme(scheme)
+	corev1.AddToScheme(scheme)
+	rbac.AddToScheme(scheme)
+	lcav1.AddToScheme(scheme)
+	outUnstructured := &unstructured.Unstructured{}
+	scheme.Convert(obj, outUnstructured, nil)
+	json, err := outUnstructured.MarshalJSON()
+	return string(json), err
+}
+
+func ObjectToByteArray(obj runtime.Object) ([]byte, error) {
+	json, err := ObjectToJSON(obj)
+	return []byte(json), err
 }
 
 // Contains check if str is in slice

--- a/controllers/utils/manifestworkreplicaset_test.go
+++ b/controllers/utils/manifestworkreplicaset_test.go
@@ -10,6 +10,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	mwv1 "open-cluster-management.io/api/work/v1"
 	mwv1alpha1 "open-cluster-management.io/api/work/v1alpha1"
 )
 
@@ -74,7 +75,7 @@ func TestGenerateCGUForPlanItem(t *testing.T) {
 
 	cgu := GenerateClusterGroupUpgradeForPlanItem("ibu-prep-upgrade-finalize", ibgu, &ibgu.Spec.Plan[0], []string{"ibu-prep", "ibu-upgrade", "ibu-finalize"}, []string{})
 
-	json, _ := objToJSON(cgu)
+	json, _ := ObjectToJSON(cgu)
 	expected := `
     {
   "apiVersion": "ran.openshift.io/v1alpha1",
@@ -253,7 +254,7 @@ func TestUpgradeManifestworkReplicaset(t *testing.T) {
   }
 }
     `
-	json, err := objToJSON(mwrs)
+	json, err := ObjectToJSON(mwrs)
 	if err != nil {
 		panic(err)
 	}
@@ -393,7 +394,7 @@ func TestAbortManifestworkReplicaset(t *testing.T) {
   }
 }
     `
-	json, err := objToJSON(mwrs)
+	json, err := ObjectToJSON(mwrs)
 	if err != nil {
 		panic(err)
 	}
@@ -532,7 +533,7 @@ func TestFinalizeManifestworkReplicaset(t *testing.T) {
   }
 }
     `
-	json, err := objToJSON(mwrs)
+	json, err := ObjectToJSON(mwrs)
 	if err != nil {
 		panic(err)
 	}
@@ -672,7 +673,7 @@ func TestRollbackManifestworkReplicaset(t *testing.T) {
   }
 }
     `
-	json, err := objToJSON(mwrs)
+	json, err := ObjectToJSON(mwrs)
 	if err != nil {
 		panic(err)
 	}
@@ -690,7 +691,7 @@ func TestPrepManifestworkReplicaset(t *testing.T) {
 			},
 		},
 	}
-	mwrs, _ := GeneratePrepManifestWorkReplicaset("ibu-prep", "namespace", ibu)
+	mwrs, _ := GeneratePrepManifestWorkReplicaset("ibu-prep", "namespace", ibu, []mwv1.Manifest{})
 	expectedRaw := `
 {
   "apiVersion": "work.open-cluster-management.io/v1alpha1",
@@ -810,7 +811,7 @@ func TestPrepManifestworkReplicaset(t *testing.T) {
     }
   }
 }`
-	json, err := objToJSON(mwrs)
+	json, err := ObjectToJSON(mwrs)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
IBGU controller reads the configmaps specifed in
`spec.ibuSpec.oadpContent` and propagates them to target clusters. These configmaps are placed first in the Prep manifestwork. If configmaps specified do not exist on the hub cluster the controller will skip them.