### PR TITLE
Add `ran.openshift.io/blocking-cgu-cluster-filtering` annotation.

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -449,7 +449,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 				return
 			}
 
-			if clusterGroupUpgrade.GetAnnotations()[utils.BlockingCGUCompletionModeAnn] == utils.PartialBlockingCGUCompletion {
+			if clusterGroupUpgrade.GetAnnotations()[utils.BlockingCGUCompletionModeAnn] == utils.PartialBlockingCGUCompletion && clusterGroupUpgrade.GetAnnotations()[utils.BlockingCGUClusterFiltering] == "true" {
 				clusters, err = r.filterNonCompletedClustersInBlockingCRs(ctx, clusterGroupUpgrade, clusters)
 				if err != nil {
 					r.Log.Error(err, "filterNonCompletedClustersInBlockingCRs")

--- a/controllers/utils/constants.go
+++ b/controllers/utils/constants.go
@@ -170,6 +170,7 @@ const SoakAnnotation = "ran.openshift.io/soak-seconds"
 // the original CR is only partially completed
 const (
 	BlockingCGUCompletionModeAnn = "ran.openshift.io/blocking-cgu-completion-mode"
+	BlockingCGUClusterFiltering  = "ran.openshift.io/blocking-cgu-cluster-filtering"
 	PartialBlockingCGUCompletion = "partial"
 )
 


### PR DESCRIPTION
This commit introduces the `ran.openshift.io/blocking-cgu-cluster-filtering` annotation. When `ran.openshift.io/blocking-cgu-completion-mode` is set to `partial` and `ran.openshift.io/blocking-cgu-cluster-filtering` is set to `true`, the behavior is modified such that if a (CGU) fails, the subsequent
 CGU continues only on the clusters where the blocking CGU was successful.

If `ran.openshift.io/blocking-cgu-cluster-filtering` is not set to `true`, the next CGU continues on all clusters, regardless of their success status.