### PR TITLE
Remove IBGU `spec.clusters` field

### DIFF
--- a/bundle/manifests/lcm.openshift.io_imagebasedgroupupgrades.yaml
+++ b/bundle/manifests/lcm.openshift.io_imagebasedgroupupgrades.yaml
@@ -97,10 +97,6 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
-              clusters:
-                items:
-                  type: string
-                type: array
               ibuSpec:
                 description: ImageBasedUpgradeSpec defines the desired state of ImageBasedUpgrade
                 properties:

--- a/config/crd/bases/lcm.openshift.io_imagebasedgroupupgrades.yaml
+++ b/config/crd/bases/lcm.openshift.io_imagebasedgroupupgrades.yaml
@@ -100,13 +100,6 @@ spec:
                 x-kubernetes-validations:
                 - message: clusterLabelSelectors is immutable
                   rule: self == oldSelf
-              clusters:
-                items:
-                  type: string
-                type: array
-                x-kubernetes-validations:
-                - message: clusters is immutable
-                  rule: self == oldSelf
               ibuSpec:
                 description: ImageBasedUpgradeSpec defines the desired state of ImageBasedUpgrade
                 properties:

--- a/controllers/utils/manifestworkreplicaset.go
+++ b/controllers/utils/manifestworkreplicaset.go
@@ -287,7 +287,6 @@ func GenerateClusterGroupUpgradeForPlanItem(
 		},
 		Spec: ranv1alpha1.ClusterGroupUpgradeSpec{
 			ClusterLabelSelectors: ibgu.Spec.ClusterLabelSelectors,
-			Clusters:              ibgu.Spec.Clusters,
 			Enable:                &enable,
 			ManifestWorkTemplates: templateNames,
 			RemediationStrategy: &ranv1alpha1.RemediationStrategySpec{

--- a/pkg/api/imagebasedgroupupgrades/v1alpha1/types.go
+++ b/pkg/api/imagebasedgroupupgrades/v1alpha1/types.go
@@ -34,9 +34,6 @@ type ImageBasedGroupUpgradeSpec struct {
 	//+kubebuilder:validation:Required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ibuSpec is immutable"
 	IBUSpec lcav1.ImageBasedUpgradeSpec `json:"ibuSpec"`
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Clusters",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="clusters is immutable"
-	Clusters []string `json:"clusters,omitempty"`
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Cluster Label Selectors",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="clusterLabelSelectors is immutable"
 	ClusterLabelSelectors []metav1.LabelSelector `json:"clusterLabelSelectors,omitempty"`

--- a/pkg/api/imagebasedgroupupgrades/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/imagebasedgroupupgrades/v1alpha1/zz_generated.deepcopy.go
@@ -133,11 +133,6 @@ func (in *ImageBasedGroupUpgradeList) DeepCopyObject() runtime.Object {
 func (in *ImageBasedGroupUpgradeSpec) DeepCopyInto(out *ImageBasedGroupUpgradeSpec) {
 	*out = *in
 	in.IBUSpec.DeepCopyInto(&out.IBUSpec)
-	if in.Clusters != nil {
-		in, out := &in.Clusters, &out.Clusters
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	if in.ClusterLabelSelectors != nil {
 		in, out := &in.ClusterLabelSelectors, &out.ClusterLabelSelectors
 		*out = make([]v1.LabelSelector, len(*in))


### PR DESCRIPTION
This field is not necessary for IBGU. It also complicates things when used in combination of `clusterLabelSelectors`.