### PR TITLE
IBGU: Delay creation of CGU for plan items if previous items are

### DIFF
--- a/controllers/imagebasedgroupupgrade_test.go
+++ b/controllers/imagebasedgroupupgrade_test.go
@@ -729,6 +729,13 @@ func TestEnsureManifests(t *testing.T) {
 							"name-prep",
 						},
 					},
+					Status: v1alpha1.ClusterGroupUpgradeStatus{
+						Conditions: []v1.Condition{
+							{
+								Type: string(utils.ConditionTypes.Succeeded),
+							},
+						},
+					},
 				},
 			},
 			expectedCGUJsons: []string{
@@ -828,6 +835,13 @@ func TestEnsureManifests(t *testing.T) {
 					Spec: v1alpha1.ClusterGroupUpgradeSpec{
 						ManifestWorkTemplates: []string{
 							"name-prep",
+						},
+					},
+					Status: v1alpha1.ClusterGroupUpgradeStatus{
+						Conditions: []v1.Condition{
+							{
+								Type: string(utils.ConditionTypes.Succeeded),
+							},
 						},
 					},
 				},

--- a/controllers/utils/manifestworkreplicaset.go
+++ b/controllers/utils/manifestworkreplicaset.go
@@ -352,12 +352,20 @@ func GetConditionMessageFromManifestWorkStatus(status *ranv1alpha1.ManifestWorkS
 	if len(status.Status.Manifests) == 0 {
 		return ""
 	}
-	for _, value := range status.Status.Manifests[0].StatusFeedbacks.Values {
-		if strings.Contains(value.Name, "CompletedConditionMessages") {
-			if value.Value.String != nil {
-				return *value.Value.String
+	msgs := []string{}
+	for _, manifest := range status.Status.Manifests {
+		for _, value := range manifest.StatusFeedbacks.Values {
+			if strings.Contains(value.Name, "ConditionMessage") {
+				if value.Value.String != nil {
+					msgs = append(msgs, *value.Value.String)
+				}
+			}
+			if strings.Contains(value.Name, "ConditionReason") {
+				if value.Value.String != nil {
+					msgs = append(msgs, *value.Value.String)
+				}
 			}
 		}
 	}
-	return ""
+	return strings.Join(msgs, "\n")
 }


### PR DESCRIPTION
incomplete

- Introduces logic to skip creating a CGU for subsequent plan items if the CGU for the current item is incomplete. This change ensures more accurate timeout handling for each plan item.

- Added handling to gather 'InProgress' error messages for failed actions.