### PR TITLE
IBGU: remove blocking cgu annotations

### DIFF
--- a/controllers/imagebasedgroupupgrade_test.go
+++ b/controllers/imagebasedgroupupgrade_test.go
@@ -747,10 +747,6 @@ func TestEnsureManifests(t *testing.T) {
     "labels": {
       "ibgu": "name"
     },
-    "annotations" : {
-      "ran.openshift.io/blocking-cgu-cluster-filtering": "false",
-      "ran.openshift.io/blocking-cgu-completion-mode": "partial"
-    },
     "name": "name-abort",
     "namespace": "namespace",
     "ownerReferences": [
@@ -778,12 +774,6 @@ func TestEnsureManifests(t *testing.T) {
         }
       }
     },
-    "blockingCRs": [
-      {
-        "name": "name-prep",
-        "namespace": "namespace"
-      }
-    ],
     "clusterLabelSelectors": [
       {
         "matchLabels": {
@@ -855,10 +845,6 @@ func TestEnsureManifests(t *testing.T) {
     "labels": {
       "ibgu": "name"
     },
-    "annotations" : {
-      "ran.openshift.io/blocking-cgu-cluster-filtering": "true",
-      "ran.openshift.io/blocking-cgu-completion-mode": "partial"
-    },
     "name": "name-upgrade-finalizeupgrade",
     "namespace": "namespace",
     "ownerReferences": [
@@ -886,12 +872,6 @@ func TestEnsureManifests(t *testing.T) {
         }
       }
     },
-    "blockingCRs": [
-      {
-        "name": "name-prep",
-        "namespace": "namespace"
-      }
-    ],
     "clusterLabelSelectors": [
       {
         "matchLabels": {

--- a/controllers/utils/manifestworkreplicaset.go
+++ b/controllers/utils/manifestworkreplicaset.go
@@ -311,15 +311,8 @@ func getLabelSelectorForPlanItem(
 // GenerateClusterGroupUpgradeForPlanItem returns a populated CGU for a PlanItem
 func GenerateClusterGroupUpgradeForPlanItem(
 	name string, ibgu *ibguv1alpha1.ImageBasedGroupUpgrade, planItem *ibguv1alpha1.PlanItem,
-	templateNames, blockingCGUs []string, annotations map[string]string,
+	templateNames []string, annotations map[string]string,
 ) *ranv1alpha1.ClusterGroupUpgrade {
-	blockingCRs := []ranv1alpha1.BlockingCR{}
-	for _, cguName := range blockingCGUs {
-		blockingCRs = append(blockingCRs, ranv1alpha1.BlockingCR{
-			Name:      cguName,
-			Namespace: ibgu.GetNamespace(),
-		})
-	}
 	enable := true
 	beforeEnable := ranv1alpha1.BeforeEnable{
 		AddClusterAnnotations: map[string]string{
@@ -332,9 +325,8 @@ func GenerateClusterGroupUpgradeForPlanItem(
 
 	return &ranv1alpha1.ClusterGroupUpgrade{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        name,
-			Namespace:   ibgu.GetNamespace(),
-			Annotations: annotations,
+			Name:      name,
+			Namespace: ibgu.GetNamespace(),
 			Labels: map[string]string{
 				CGUOwnerIBGULabel: ibgu.GetName(),
 			},
@@ -347,7 +339,6 @@ func GenerateClusterGroupUpgradeForPlanItem(
 				MaxConcurrency: planItem.RolloutStrategy.MaxConcurrency,
 				Timeout:        planItem.RolloutStrategy.Timeout,
 			},
-			BlockingCRs: blockingCRs,
 			Actions: ranv1alpha1.Actions{
 				BeforeEnable:    &beforeEnable,
 				AfterCompletion: &afterCompletion,

--- a/controllers/utils/manifestworkreplicaset_test.go
+++ b/controllers/utils/manifestworkreplicaset_test.go
@@ -61,7 +61,7 @@ func TestGenerateCGUForPlanItem(t *testing.T) {
 		},
 	}
 
-	cgu := GenerateClusterGroupUpgradeForPlanItem("ibu-prep-upgrade-finalize", ibgu, &ibgu.Spec.Plan[0], []string{"ibu-prep", "ibu-upgrade", "ibu-finalize"}, []string{}, map[string]string{})
+	cgu := GenerateClusterGroupUpgradeForPlanItem("ibu-prep-upgrade-finalize", ibgu, &ibgu.Spec.Plan[0], []string{"ibu-prep", "ibu-upgrade", "ibu-finalize"}, map[string]string{})
 
 	json, _ := ObjectToJSON(cgu)
 	expected := `


### PR DESCRIPTION
Since we are using label selectors, we no longer need blocking cgu annotations to filter clusters.