### PR TITLE
[OCPBUGS-37466] InspectPolicyObjects logic inverted

### DIFF
--- a/controllers/utils/policy_util.go
+++ b/controllers/utils/policy_util.go
@@ -178,8 +178,6 @@ func InspectPolicyObjects(policy *unstructured.Unstructured) (bool, error) {
 
 		switch {
 		case objectTemplatePresent && objectTemplateRawPresent:
-			return containsStatus, &PolicyErr{policyName, ConfigPlcMissAnyObjTmpl}
-		case !objectTemplatePresent && !objectTemplateRawPresent:
 			return containsStatus, &PolicyErr{policyName, ConfigPlcHasBothObjTmpl}
 		case objectTemplatePresent:
 			configPlcTmpls = plcTmplDefSpec[ObjectTemplates].([]interface{})


### PR DESCRIPTION
the previous logic was working inverted, if the Policy had none of objectTemplatePresent and
objectTemplateRawPresent, was saying that had both.

That would happen if a Policy is created manually (not from the PolicyGenTemplate generator) wrongly. 