### PR TITLE
IBGU: Update IBGU status with index of plan step

### DIFF
--- a/controllers/utils/conditions.go
+++ b/controllers/utils/conditions.go
@@ -19,9 +19,6 @@ var ConditionTypes = struct {
 	Progressing        ConditionType
 	Succeeded          ConditionType
 	Validated          ConditionType
-
-	// IBGU
-	ManifestsCreated ConditionType
 }{
 	BackupSuceeded:     "BackupSuceeded",
 	ClustersSelected:   "ClustersSelected",
@@ -30,7 +27,6 @@ var ConditionTypes = struct {
 	Progressing:        "Progressing",
 	Succeeded:          "Succeeded",
 	Validated:          "Validated",
-	ManifestsCreated:   "ManifestsCreated",
 }
 
 // ConditionReason is a string representing the condition's reason

--- a/tests/kuttl/ibgu/prep-abort-upgrade-abort-finalize/00-assert.yaml
+++ b/tests/kuttl/ibgu/prep-abort-upgrade-abort-finalize/00-assert.yaml
@@ -33,10 +33,10 @@ status:
       action: Prep
     name: spoke4
   conditions:
-  - message: All manifests are created
-    reason: Completed
+  - message: Waiting for plan step 0 to be completed
+    reason: InProgress
     status: "True"
-    type: ManifestsCreated
+    type: Progressing
 ---
 apiVersion: ran.openshift.io/v1alpha1
 kind: ClusterGroupUpgrade

--- a/tests/kuttl/ibgu/prep-abort-upgrade-abort-finalize/01-assert.yaml
+++ b/tests/kuttl/ibgu/prep-abort-upgrade-abort-finalize/01-assert.yaml
@@ -36,7 +36,7 @@ status:
     - action: Prep
     name: spoke6
   conditions:
-  - message: All manifests are created
+  - message: All plan steps are completed
     reason: Completed
-    status: "True"
-    type: ManifestsCreated
+    status: "False"
+    type: Progressing

--- a/tests/kuttl/ibgu/prep-abort-upgrade-abort-finalize/02-assert.yaml
+++ b/tests/kuttl/ibgu/prep-abort-upgrade-abort-finalize/02-assert.yaml
@@ -43,10 +43,10 @@ status:
     - action: Prep
     name: spoke6
   conditions:
-  - message: All manifests are created
-    reason: Completed
+  - message: Waiting for plan step 1 to be completed
+    reason: InProgress
     status: "True"
-    type: ManifestsCreated
+    type: Progressing
   observedGeneration: 2
 ---
 apiVersion: ran.openshift.io/v1alpha1

--- a/tests/kuttl/ibgu/prep-abort-upgrade-abort-finalize/03-assert.yaml
+++ b/tests/kuttl/ibgu/prep-abort-upgrade-abort-finalize/03-assert.yaml
@@ -42,5 +42,9 @@ status:
     failedActions:
     - action: Prep
     name: spoke6
-
+  conditions:
+  - message: All plan steps are completed
+    reason: Completed
+    status: "False"
+    type: Progressing
 

--- a/tests/kuttl/ibgu/prep-abort-upgrade-abort-finalize/08-assert.yaml
+++ b/tests/kuttl/ibgu/prep-abort-upgrade-abort-finalize/08-assert.yaml
@@ -63,6 +63,12 @@ status:
     failedActions:
     - action: Prep
     name: spoke6
+  conditions:
+  - message: Waiting for plan step 4 to be completed 
+    reason: InProgress
+    status: "True"
+    type: Progressing
+
 ---
 apiVersion: ran.openshift.io/v1alpha1
 kind: ClusterGroupUpgrade


### PR DESCRIPTION
- If all steps in the plan are completed, set the Progressing condition to false.
- If any steps remain incomplete, update the Progressing condition to indicate the index of the first incomplete step.