### PR TITLE
OCPBUGS-41679: Skip clean up if resource already deleted

### DIFF
--- a/controllers/policy.go
+++ b/controllers/policy.go
@@ -753,7 +753,7 @@ func (r *ClusterGroupUpgradeReconciler) checkDuplicateChildResources(ctx context
 				// Remove it as we have created a new one and updated the map
 				r.Log.Info("[checkDuplicateChildResources] clean up stale child resource", "name", newResource.GetName(), "kind", newResource.GetKind())
 				err := r.Client.Delete(ctx, newResource)
-				if err != nil {
+				if !errors.IsNotFound(err) {
 					return childResourceNames, err
 				}
 				return childResourceNames, nil


### PR DESCRIPTION
During IBI scale test, CGU processing often has to retry due to managed cluster label update conflicts. This triggers resource name regeneration and stale resource cleanup multiple times. When resource is already deleted and CGU resource names update failed, it gets stuck and repeats the same error as shown in the log from the bug.
