### PR TITLE
Replace docker hub image references with projectquay image references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.hub.docker.com/library/golang:1.23 as builder
+FROM quay.io/projectquay/golang:1.23 as builder
 
 WORKDIR /workspace
 

--- a/Dockerfile.aztp
+++ b/Dockerfile.aztp
@@ -1,5 +1,5 @@
 # Build the aztp binary
-FROM registry.hub.docker.com/library/golang:1.23 as builder
+FROM quay.io/projectquay/golang:1.23 as builder
 
 WORKDIR /workspace
 

--- a/Dockerfile.recovery
+++ b/Dockerfile.recovery
@@ -1,4 +1,4 @@
-FROM registry.hub.docker.com/library/golang:1.23 as builder
+FROM quay.io/projectquay/golang:1.23 as builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
- Docker hub is rate limited
- The projectquay image tracks the upstream docker hub image with CLAIR dependencies added