### PR TITLE
IBGU: Ensure managed cluster labels before creating CGUs 

### DIFF
--- a/controllers/imagebasedgroupupgrade_test.go
+++ b/controllers/imagebasedgroupupgrade_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -433,6 +434,7 @@ func TestEnsureClusterLabels(t *testing.T) {
 		managedClusters         []clusterv1.ManagedCluster
 		expectedManagedClusters []clusterv1.ManagedCluster
 		clusterStates           []ibguv1alpha1.ClusterState
+		expectedErr             error
 	}{
 		{
 			name: "failed prep, upgrade and abort",
@@ -571,6 +573,83 @@ func TestEnsureClusterLabels(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "two cluster, first throws an error",
+			managedClusters: []clusterv1.ManagedCluster{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "cluster2",
+					},
+				},
+			},
+			clusterStates: []ibguv1alpha1.ClusterState{
+				{
+					Name: "cluster1",
+					CompletedActions: []ibguv1alpha1.ActionMessage{
+						{
+							Action: ibguv1alpha1.Prep,
+						},
+					},
+				},
+				{
+					Name: "cluster2",
+					CompletedActions: []ibguv1alpha1.ActionMessage{
+						{
+							Action: ibguv1alpha1.Prep,
+						},
+					},
+				},
+			},
+			expectedManagedClusters: []clusterv1.ManagedCluster{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "cluster2",
+						Labels: map[string]string{
+							"lcm.openshift.io/ibgu-prep-completed": "",
+						},
+					},
+				},
+			},
+			expectedErr: fmt.Errorf("failed to ensure cluster labels for %v", []string{"cluster-1"}),
+		},
+		{
+			name: "two cluster, first nothing to do",
+			managedClusters: []clusterv1.ManagedCluster{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "cluster1",
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "cluster2",
+					},
+				},
+			},
+			clusterStates: []ibguv1alpha1.ClusterState{
+				{
+					Name: "cluster1",
+				},
+				{
+					Name: "cluster2",
+					CompletedActions: []ibguv1alpha1.ActionMessage{
+						{
+							Action: ibguv1alpha1.Prep,
+						},
+					},
+				},
+			},
+			expectedManagedClusters: []clusterv1.ManagedCluster{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "cluster2",
+						Labels: map[string]string{
+							"lcm.openshift.io/ibgu-prep-completed": "",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	ibgu := &ibguv1alpha1.ImageBasedGroupUpgrade{
@@ -611,7 +690,11 @@ func TestEnsureClusterLabels(t *testing.T) {
 			}
 			reconciler := IBGUReconciler{Client: fakeClient, Scheme: testscheme, Log: logr.Discard()}
 			err = reconciler.ensureClusterLabels(context.TODO(), ibgu)
-			assert.NoError(t, err)
+			if test.expectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, test.expectedErr)
+			}
 			for _, expected := range test.expectedManagedClusters {
 				got := &clusterv1.ManagedCluster{}
 				err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: expected.Namespace, Name: expected.Name}, got)


### PR DESCRIPTION
- Make sure managed cluster labels are synced with ibgu progress before
  creating CGUs.
- Update managed cluster labels in best effort manner.