### PR TITLE
CNF-17432: IBGU: Cache only ManifestWorks that are created by TALM

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,10 +25,14 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -96,6 +100,14 @@ func main() {
 		c.NextProtos = []string{"http/1.1"}
 	}
 
+	ibguLabelReq, err := labels.NewRequirement(
+		"openshift-cluster-group-upgrades/clusterGroupUpgrade", selection.Exists, []string{})
+	if err != nil {
+		setupLog.Error(err, "bad label selector")
+		os.Exit(1)
+	}
+	selector := labels.NewSelector().Add(*ibguLabelReq)
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		HealthProbeBindAddress: probeAddr,
@@ -108,6 +120,13 @@ func main() {
 			Port:    9443,
 			TLSOpts: []func(config *tls.Config){disableHTTP2},
 		}),
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&mwv1.ManifestWork{}: {
+					Label: selector,
+				},
+			},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
To reduce memory usage only cache ManifestWorks that are created by TALM. This is done by adding a label selector manager's cache options