### PR TITLE
Add OWNERS_ALIASES for Konflux, Add owners file to .tektok folder

### DIFF
--- a/.tekton/OWNERS
+++ b/.tekton/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - konflux-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -31,3 +31,6 @@ aliases:
     - fontivan
     - sudomakeinstall2 
     - sakhoury
+  konflux-approvers:
+    - fontivan
+    - rauhersu


### PR DESCRIPTION
We need to be able to easily approve Konflux related PRs without bothering the rest of the approvers
