### PR TITLE
Add soak ability for ManifestWork

### DIFF
--- a/controllers/utils/common.go
+++ b/controllers/utils/common.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
+	mwv1 "open-cluster-management.io/api/work/v1"
 	mwv1alpha1 "open-cluster-management.io/api/work/v1alpha1"
 )
 
@@ -111,15 +112,24 @@ func Difference(a, b []string) []string {
 	return diff
 }
 
-func ObjectToJSON(obj runtime.Object) (string, error) {
+func ObjectToUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
 	scheme := runtime.NewScheme()
 	mwv1alpha1.AddToScheme(scheme)
+	mwv1.AddToScheme(scheme)
 	v1alpha1.AddToScheme(scheme)
 	corev1.AddToScheme(scheme)
 	rbac.AddToScheme(scheme)
 	lcav1.AddToScheme(scheme)
 	outUnstructured := &unstructured.Unstructured{}
-	scheme.Convert(obj, outUnstructured, nil)
+	err := scheme.Convert(obj, outUnstructured, nil)
+	return outUnstructured, err
+}
+
+func ObjectToJSON(obj runtime.Object) (string, error) {
+	outUnstructured, err := ObjectToUnstructured(obj)
+	if err != nil {
+		return "", err
+	}
 	json, err := outUnstructured.MarshalJSON()
 	return string(json), err
 }

--- a/controllers/utils/manifestwork.go
+++ b/controllers/utils/manifestwork.go
@@ -148,9 +148,7 @@ func CreateManifestWorkForCluster(ctx context.Context, client client.Client, clu
 				"openshift-cluster-group-upgrades/clusterGroupUpgrade":          clusterGroupUpgrade.Name,
 				"openshift-cluster-group-upgrades/clusterGroupUpgradeNamespace": clusterGroupUpgrade.Namespace,
 			},
-			Annotations: map[string]string{
-				manifestWorkExpectedValuesAnnotation: mwrs.Annotations[manifestWorkExpectedValuesAnnotation],
-			},
+			Annotations: mwrs.GetAnnotations(),
 		},
 		Spec: mwrs.Spec.ManifestWorkTemplate,
 	}


### PR DESCRIPTION
ManifestWorks that have soaking annotation have to be compliant for specified amount of seconds, before controller moves on.