### PR TITLE
Add missing SHA256 digests for Konflux containers images

### DIFF
--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -2,7 +2,7 @@
 
 # yq is required for merging the yaml files
 # Run the overlay in a container
-FROM quay.io/konflux-ci/yq:7861165 AS overlay
+FROM quay.io/konflux-ci/yq:latest@sha256:249e59f8f21b62949c44535450da1ad6a366343fb6d477207b92e702eba7eb08 AS overlay
 
 # Set work dir
 WORKDIR /tmp

--- a/konflux_build_args.conf
+++ b/konflux_build_args.conf
@@ -1,3 +1,3 @@
-BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23.2
-RUNTIME_IMAGE=registry.redhat.io/rhel9-4-els/rhel-minimal:9.4-149
+BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23@sha256:2d5976ded2a3abda6966949c4d545d0cdd88a4d6a15989af38ca5e30e430a619
+RUNTIME_IMAGE=registry.redhat.io/rhel9-4-els/rhel-minimal:9.4@sha256:5e1be69fd81a9fe2f58df325ac15fc7e0812d34e6345f5feaf50df38e16d52e3
 KONFLUX=true


### PR DESCRIPTION
- golang-builder:v1.23
- rhel-minimal:9.4
- yq:latest