### PR TITLE
Update renovate.json configuration

### DIFF
--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -2,7 +2,8 @@
 
 # yq is required for merging the yaml files
 # Run the overlay in a container
-FROM quay.io/konflux-ci/yq:latest@sha256:5ff4dd745c6f4cc67ae4f00fd2a38dd31f7d99c95dd7ad4476d6a6307a0f40a0 AS overlay
+ARG YQ_IMAGE=quay.io/konflux-ci/yq:latest
+FROM ${YQ_IMAGE} AS overlay
 
 # Set work dir
 WORKDIR /tmp

--- a/konflux_build_args.conf
+++ b/konflux_build_args.conf
@@ -1,3 +1,4 @@
 BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23@sha256:2d5976ded2a3abda6966949c4d545d0cdd88a4d6a15989af38ca5e30e430a619
 RUNTIME_IMAGE=registry.redhat.io/rhel9-4-els/rhel-minimal:9.4@sha256:5e1be69fd81a9fe2f58df325ac15fc7e0812d34e6345f5feaf50df38e16d52e3
+YQ_IMAGE=quay.io/konflux-ci/yq:latest@sha256:5ff4dd745c6f4cc67ae4f00fd2a38dd31f7d99c95dd7ad4476d6a6307a0f40a0
 KONFLUX=true

--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,12 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "docker": {
-        "_comment": "We want to make sure all the docker/container files including the build args get digest upates",
+        "_comment": "We want to make sure the image digests in the build args get updates",
         "fileMatch": [
-            "\\.*Dockerfile\\.*",
-            "\\.*Containerfile\\.*",
-            "\\.*konflux_build_args.conf\\.*"
+            "\\.conf$"
         ],
         "includePaths": [
-            "."
+            "./konflux_build_args.conf"
         ]
     },
     "extends": [


### PR DESCRIPTION
- Configure `docker` for all Containerfiles, Dockerfiles, and the build args file
- Configure `tekton` to merge updates automatically from mintmaker
- Explicitly extend the konflux renovate configuration