### PR TITLE
OCPBUGS-54738: Fix panic when cluster is not in current batch

### DIFF
--- a/deploy/acm/policies/upgrade_complete/patch-policies-status-batch3.sh
+++ b/deploy/acm/policies/upgrade_complete/patch-policies-status-batch3.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+curl -k -s -X PATCH -H "Accept: application/json, */*" \
+-H "Content-Type: application/merge-patch+json" \
+http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$1/policies/policy1-common-cluster-version-policy/status \
+--data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"}, {"clustername":"spoke4","clusternamespace":"spoke4","compliant":"Compliant"}, {"clustername":"spoke6","clusternamespace":"spoke6","compliant":"NonCompliant"}]}}'
+
+curl -k -s -X PATCH -H "Accept: application/json, */*" \
+-H "Content-Type: application/merge-patch+json" \
+http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/$2/policies/policy2-common-pao-sub-policy/status \
+--data '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"}, {"clustername":"spoke2","clusternamespace":"spoke2","compliant":"Compliant"}, {"clustername":"spoke4","clusternamespace":"spoke4","compliant":"Compliant"}]}}'
+

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -11,7 +11,7 @@ testDirs:
 - tests/kuttl/cgu/
 - tests/kuttl/ibgu/
 crdDir: ./config/crd/bases/
-timeout: 25
+timeout: 40
 parallel: 1
 namespace: default
 

--- a/tests/kuttl/cgu/timeout-not-block-next-batch/00-assert.yaml
+++ b/tests/kuttl/cgu/timeout-not-block-next-batch/00-assert.yaml
@@ -1,0 +1,54 @@
+apiVersion: ran.openshift.io/v1alpha1
+kind: ClusterGroupUpgrade
+metadata:
+  name: cgu-upgrade-complete
+  namespace: default
+spec:
+  clusters:
+  - spoke1
+  - spoke4
+  - spoke6
+  enable: false
+  managedPolicies:
+  - policy1-common-cluster-version-policy
+  - policy2-common-pao-sub-policy
+  remediationStrategy:
+    maxConcurrency: 1
+    timeout: 240
+status:
+  conditions:
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: 'True'
+    type: ClustersSelected
+  - message: Completed validation
+    reason: ValidationCompleted
+    status: 'True'
+    type: Validated
+  - message: Not enabled
+    reason: NotEnabled
+    status: 'False'
+    type: Progressing
+  managedPoliciesContent:
+    policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-performance-addon-operator"}]'
+  managedPoliciesForUpgrade:
+  - name: policy1-common-cluster-version-policy
+    namespace: default
+  - name: policy2-common-pao-sub-policy
+    namespace: default
+  managedPoliciesNs:
+    policy1-common-cluster-version-policy: default
+    policy2-common-pao-sub-policy: default
+  placementBindings:
+  - cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
+  - cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
+  placementRules:
+  - cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
+  - cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
+  remediationPlan:
+  - - spoke1
+  - - spoke4
+  safeResourceNames:
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-upgrade-complete-policy2-common-pao-sub-policy-placement: cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
+  status: {}

--- a/tests/kuttl/cgu/timeout-not-block-next-batch/00-setup.yaml
+++ b/tests/kuttl/cgu/timeout-not-block-next-batch/00-setup.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+
+commands:
+  # Create all the managed inform policies
+  - command: oc apply -f ../../../../deploy/acm/policies/all_policies/policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc apply -f ../../../../deploy/acm/policies/all_policies/policy2-common-pao-sub-policy.yaml
+    namespaced: true
+
+  # Patch the inform policies to reflect the compliance status.
+  - command: ../../../../deploy/acm/policies/patch-policies-status.sh default default
+    ignoreFailure: false
+
+  # Create all the child policies to map the inform policies above.
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+
+  # Apply the UOCR.
+  - command: oc apply -f ../../../../deploy/upgrades/upgrade-complete/cgu-upgrade-complete.yaml
+    namespaced: true

--- a/tests/kuttl/cgu/timeout-not-block-next-batch/01-assert.yaml
+++ b/tests/kuttl/cgu/timeout-not-block-next-batch/01-assert.yaml
@@ -1,0 +1,83 @@
+apiVersion: ran.openshift.io/v1alpha1
+kind: ClusterGroupUpgrade
+metadata:
+  name: cgu-upgrade-complete
+  namespace: default
+spec:
+  clusters:
+  - spoke1
+  - spoke4
+  - spoke6
+  enable: true
+  managedPolicies:
+  - policy1-common-cluster-version-policy
+  - policy2-common-pao-sub-policy
+  remediationStrategy:
+    maxConcurrency: 1
+    timeout: 240
+status:
+  clusters:
+  - name: spoke6
+    state: complete
+  conditions:
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: 'True'
+    type: ClustersSelected
+  - message: Completed validation
+    reason: ValidationCompleted
+    status: 'True'
+    type: Validated
+  - message: Remediating non-compliant policies
+    reason: InProgress
+    status: 'True'
+    type: Progressing
+  managedPoliciesContent:
+    policy2-common-pao-sub-policy: '[{"kind":"Subscription","name":"performance-addon-operator","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-performance-addon-operator"}]'
+  managedPoliciesForUpgrade:
+  - name: policy1-common-cluster-version-policy
+    namespace: default
+  - name: policy2-common-pao-sub-policy
+    namespace: default
+  managedPoliciesNs:
+    policy1-common-cluster-version-policy: default
+    policy2-common-pao-sub-policy: default
+  placementBindings:
+  - cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
+  - cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
+  placementRules:
+  - cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
+  - cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
+  remediationPlan:
+  - - spoke1
+  - - spoke4
+  safeResourceNames:
+    default/cgu-upgrade-complete-policy1-common-cluster-version-policy-placement: cgu-upgrade-complete-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-upgrade-complete-policy2-common-pao-sub-policy-placement: cgu-upgrade-complete-policy2-common-pao-sub-policy-placement-kuttl
+  status:
+    currentBatch: 1
+    currentBatchRemediationProgress:
+      spoke1:
+        policyIndex: 0
+        state: InProgress
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-running: ''
+  name: spoke1
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-running: ''
+  name: spoke4
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-done: ''
+  name: spoke6

--- a/tests/kuttl/cgu/timeout-not-block-next-batch/01-start-upgrade.yaml
+++ b/tests/kuttl/cgu/timeout-not-block-next-batch/01-start-upgrade.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+
+commands:
+  # Start the upgrade by enabling the UOCR.
+  - command: oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu-upgrade-complete --patch '{"spec":{"enable":true}}' --type=merge
+    ignoreFailure: false

--- a/tests/kuttl/cgu/timeout-not-block-next-batch/02-assert.yaml
+++ b/tests/kuttl/cgu/timeout-not-block-next-batch/02-assert.yaml
@@ -1,0 +1,49 @@
+apiVersion: ran.openshift.io/v1alpha1
+kind: ClusterGroupUpgrade
+metadata:
+  name: cgu-upgrade-complete
+  namespace: default
+spec:
+  clusters:
+  - spoke1
+  - spoke4
+  - spoke6
+  enable: true
+  managedPolicies:
+  - policy1-common-cluster-version-policy
+  - policy2-common-pao-sub-policy
+  remediationStrategy:
+    maxConcurrency: 0
+    timeout: 1
+status:
+  clusters:
+  - name: spoke6
+    state: complete
+  - currentPolicy:
+      name: policy1-common-cluster-version-policy
+      status: NonCompliant
+    name: spoke1
+    state: timedout
+  - name: spoke4
+    state: complete
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-running: ''
+  name: spoke1
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-done: ''
+  name: spoke4
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-done: ''
+  name: spoke6

--- a/tests/kuttl/cgu/timeout-not-block-next-batch/02-force-timeout.yaml
+++ b/tests/kuttl/cgu/timeout-not-block-next-batch/02-force-timeout.yaml
@@ -1,0 +1,13 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+
+commands:
+  - command: ../../../../deploy/acm/policies/upgrade_complete/patch-policies-status-batch3.sh default default
+    ignoreFailure: false
+
+  - command: oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu-upgrade-complete --patch '{"spec":{"remediationStrategy":{"timeout":1}}}' --type=merge
+
+  - command: sleep 30
+
+  - command: oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu-upgrade-complete --patch '{"spec":{"remediationStrategy":{"maxConcurrency":0}}}' --type=merge
+  

--- a/tests/kuttl/cgu/timeout-not-block-next-batch/03-cleanup.yaml
+++ b/tests/kuttl/cgu/timeout-not-block-next-batch/03-cleanup.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+
+commands:
+  - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  # Delete all the child policies to map the inform policies above.
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  # Delete the UOCR
+  - command: oc delete -f ../../../../deploy/upgrades/upgrade-complete/cgu-upgrade-complete.yaml
+    namespaced: true


### PR DESCRIPTION
after all batches are finished, controller goes
through all previous batches to see
if policies are still compliant; in this case some clusters will not be present in
CurrentBatchRemediationProgress and there is no need to check soaking or modify FirstCompliantAt