### PR TITLE
Convert TALM to Trusted Artifacts Pipeline

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -4,10 +4,10 @@ metadata:
   name: build-pipeline
 spec:
   description: |
-    This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
+    This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
 
-    _Uses `buildah` to create a container image. It also optionally creates a source image and runs some build-time tests. EC will flag a violation for [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) if any tasks are added to the pipeline.
-    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build?tab=tags)_
+    _Uses `buildah` to create a multi-platform container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. This pipeline requires that the [multi platform controller](https://github.com/konflux-ci/multi-platform-controller) is deployed and configured on your Konflux instance. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta?tab=tags)_
   finally:
     - name: show-sbom
       params:
@@ -22,28 +22,6 @@ spec:
           - name: kind
             value: task
         resolver: bundles
-    - name: show-summary
-      params:
-        - name: pipelinerun-name
-          value: $(context.pipelineRun.name)
-        - name: git-url
-          value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
-        - name: image-url
-          value: $(params.output-image)
-        - name: build-task-status
-          value: $(tasks.build-image-index.status)
-      taskRef:
-        params:
-          - name: name
-            value: summary
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:870d9a04d9784840a90b7bf6817cd0d0c4edfcda04b1ba1868cae625a3c3bfcc
-          - name: kind
-            value: task
-        resolver: bundles
-      workspaces:
-        - name: workspace
-          workspace: workspace
   params:
     - description: Source Repository URL
       name: git-url
@@ -83,6 +61,10 @@ spec:
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string
+    - default: "false"
+      description: Enable dev-package-manager within prefetching task
+      name: dev-package-managers
+      type: string
     - default: ""
       description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
@@ -90,7 +72,7 @@ spec:
       description: Build a source image.
       name: build-source-image
       type: string
-    - default: "false"
+    - default: "true"
       description: Add built image into an OCI image index
       name: build-image-index
       type: string
@@ -102,6 +84,15 @@ spec:
       description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
       name: build-args-file
       type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote VMs
+      name: privileged-nested
+      type: string
+    - default:
+        - linux/x86_64
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
+      name: build-platforms
+      type: array
   results:
     - description: ""
       name: IMAGE_URL
@@ -129,7 +120,7 @@ spec:
           - name: name
             value: init
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:737682d073a65a486d59b2b30e3104b93edd8490e0cd5e9b4a39703e47363f0f
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:38660e69f8a8b8bedc0264964d8811e1faaaaaa03a9fc908e811bf8f705f393a
           - name: kind
             value: task
         resolver: bundles
@@ -139,14 +130,18 @@ spec:
           value: $(params.git-url)
         - name: revision
           value: $(params.revision)
+        - name: ociStorage
+          value: $(params.output-image).git
+        - name: ociArtifactExpiresAfter
+          value: $(params.image-expires-after)
       runAfter:
         - init
       taskRef:
         params:
           - name: name
-            value: git-clone
+            value: git-clone-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:92cf275b60f7bd23472acc4bc6e9a4bc9a9cbd78a680a23087fa4df668b85a34
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:9709088bf3c581d4763e9804d9ee3a1f06ad6a61c23237277057c4f0cdc4f9c3
           - name: kind
             value: task
         resolver: bundles
@@ -156,8 +151,6 @@ spec:
           values:
             - "true"
       workspaces:
-        - name: output
-          workspace: workspace
         - name: basic-auth
           workspace: git-auth
     - name: generate-labels
@@ -184,25 +177,36 @@ spec:
       params:
         - name: input
           value: $(params.prefetch-input)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        - name: ociStorage
+          value: $(params.output-image).prefetch
+        - name: ociArtifactExpiresAfter
+          value: $(params.image-expires-after)
+        - name: dev-package-managers
+          value: $(params.dev-package-managers)
       runAfter:
         - clone-repository
       taskRef:
         params:
           - name: name
-            value: prefetch-dependencies
+            value: prefetch-dependencies-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.2@sha256:6a4e6606ac3fa18ca6980f87a135526042833d4b7aaec2e1723272aa70a1d4c1
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:153ef0382deef840d155f5146f134f39b480523a7d5c38ba9fea2b58792dd4b5
           - name: kind
             value: task
         resolver: bundles
       workspaces:
-        - name: source
-          workspace: workspace
         - name: git-basic-auth
           workspace: git-auth
         - name: netrc
           workspace: netrc
-    - name: build-container
+    - matrix:
+        params:
+          - name: PLATFORM
+            value:
+              - $(params.build-platforms)
+      name: build-images
       params:
         - name: IMAGE
           value: $(params.output-image)
@@ -223,6 +227,14 @@ spec:
             - $(params.build-args[*])
         - name: BUILD_ARGS_FILE
           value: $(params.build-args-file)
+        - name: PRIVILEGED_NESTED
+          value: $(params.privileged-nested)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        - name: IMAGE_APPEND_PLATFORM
+          value: "true"
         - name: LABELS
           value:
             - $(tasks.generate-labels.results.labels[*])
@@ -240,13 +252,12 @@ spec:
             - maintainer=rauherna@redhat.com,sskeard@redhat.com
       runAfter:
         - prefetch-dependencies
-        - generate-labels
       taskRef:
         params:
           - name: name
-            value: buildah
+            value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.4@sha256:c84e35a51c847af65e20e3c5c5b364d7e8ef03be8057a8a02fc2a1f6e86cfaf5
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:aae811deb8ec1b1c8396da243896c88cfd6b58bd17a3df2dfeb861b1f1bb8751
           - name: kind
             value: task
         resolver: bundles
@@ -255,9 +266,6 @@ spec:
           operator: in
           values:
             - "true"
-      workspaces:
-        - name: source
-          workspace: workspace
     - name: build-image-index
       params:
         - name: IMAGE
@@ -270,15 +278,15 @@ spec:
           value: $(params.build-image-index)
         - name: IMAGES
           value:
-            - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+            - $(tasks.build-images.results.IMAGE_REF[*])
       runAfter:
-        - build-container
+        - build-images
       taskRef:
         params:
           - name: name
             value: build-image-index
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:95be274b6d0432d4671e2c41294ec345121bdf01284b1c6c46b5537dc6b37e15
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:4d5ab47286c1c7ac525786c9a4d0cce9fc73f22635cd623f1d2d12ebc76d83e5
           - name: kind
             value: task
         resolver: bundles
@@ -291,14 +299,18 @@ spec:
       params:
         - name: BINARY_IMAGE
           value: $(params.output-image)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
         - build-image-index
       taskRef:
         params:
           - name: name
-            value: source-build
+            value: source-build-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-source-build:0.2@sha256:e8c321b8a67e421a9c3975fd9a938ca4e838976064e14c7c0eb4e1f261900b1c
+            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:f0e6c6fc5f101ecc660f744757f30ddcb5856d63299d86be5f1a772b85326f48
           - name: kind
             value: task
         resolver: bundles
@@ -311,9 +323,6 @@ spec:
           operator: in
           values:
             - "true"
-      workspaces:
-        - name: workspace
-          workspace: workspace
     - name: deprecated-base-image-check
       params:
         - name: IMAGE_URL
@@ -369,7 +378,7 @@ spec:
           - name: name
             value: ecosystem-cert-preflight-checks
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:00b13d06d17328e105b11619ee4db98b215ca6ac02314a4776aa5fc2a974f9c1
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:7c2438c6201ee803de361fa2e9182fdc759126d5bc010abbbddf5aa40c7adc3c
           - name: kind
             value: task
         resolver: bundles
@@ -388,14 +397,18 @@ spec:
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)
         - name: image-url
           value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
         - build-image-index
       taskRef:
         params:
           - name: name
-            value: sast-snyk-check
+            value: sast-snyk-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.3@sha256:e0c1675c9813618910115f04fd6b3a9ff32d1bd4e2b9c975f1112aa1eae0d149
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.3@sha256:a1cb59ed66a7be1949c9720660efb0a006e95ef05b3f67929dd8e310e1d7baef
           - name: kind
             value: task
         resolver: bundles
@@ -404,9 +417,6 @@ spec:
           operator: in
           values:
             - "false"
-      workspaces:
-        - name: workspace
-          workspace: workspace
     - name: clamav-scan
       params:
         - name: image-digest
@@ -454,14 +464,18 @@ spec:
             - $(params.build-args[*])
         - name: BUILD_ARGS_FILE
           value: $(params.build-args-file)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
         - coverity-availability-check
       taskRef:
         params:
           - name: name
-            value: sast-coverity-check
+            value: sast-coverity-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check:0.2@sha256:55e4c13c195034a3c86cb536de2500f8d2faedb907adf5065a772ced2b7cad45
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:9e5b3e62a79a15b55423df5e5c12192cebcefddfbb8cbeb0d6368550415bc971
           - name: kind
             value: task
         resolver: bundles
@@ -474,9 +488,6 @@ spec:
           operator: in
           values:
             - success
-      workspaces:
-        - name: source
-          workspace: workspace
     - name: coverity-availability-check
       runAfter:
         - build-image-index
@@ -485,7 +496,7 @@ spec:
           - name: name
             value: coverity-availability-check
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:0b35292eed661c5e3ca307c0ba7f594d17555db2a1da567903b0b47697fa23ed
+            value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:aeb4ecc32ed4012686ab370b3417902082b894a9b1e27aa4f6e35a301c50f4cb
           - name: kind
             value: task
         resolver: bundles
@@ -500,14 +511,18 @@ spec:
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)
         - name: image-url
           value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
         - build-image-index
       taskRef:
         params:
           - name: name
-            value: sast-shell-check
+            value: sast-shell-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check:0.1@sha256:1b3d68c33a92dfc3da3975581cae80c99c8d1995cab519ae98c6331b5677ded0
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:a591675c72f06fb9c5b1a3d60e6e4c58e4df5f7da180c7a4691a692a6e7e6496
           - name: kind
             value: task
         resolver: bundles
@@ -516,21 +531,22 @@ spec:
           operator: in
           values:
             - "false"
-      workspaces:
-        - name: workspace
-          workspace: workspace
     - name: sast-unicode-check
       params:
         - name: image-url
           value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
         - build-image-index
       taskRef:
         params:
           - name: name
-            value: sast-unicode-check
+            value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check:0.1@sha256:b1a9af196a79baa75632ef494eb6db987f57e870d882d47f5b495e1441c01e3b
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.1@sha256:424f2f659c02998dc3a43e1ce869e3148982c59adb74f953f8fa91ff1c9ab86e
           - name: kind
             value: task
         resolver: bundles
@@ -539,9 +555,6 @@ spec:
           operator: in
           values:
             - "false"
-      workspaces:
-        - name: workspace
-          workspace: workspace
     - name: apply-tags
       params:
         - name: IMAGE
@@ -553,7 +566,7 @@ spec:
           - name: name
             value: apply-tags
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:61c90b1c94a2a11cb11211a0d65884089b758c34254fcec164d185a402beae22
+            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:4973fa42a8f06238613447fbdb3d0c55eb2d718fd16f2f2591a577c29c1edb17
           - name: kind
             value: task
         resolver: bundles
@@ -567,20 +580,19 @@ spec:
           value: $(params.dockerfile)
         - name: CONTEXT
           value: $(params.path-context)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       runAfter:
         - build-image-index
       taskRef:
         params:
           - name: name
-            value: push-dockerfile
+            value: push-dockerfile-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile:0.1@sha256:734dfcd63cc6f28ad022294497906bc6639926d8208cccd83f772690e3951050
+            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:6ad0ae81269fdc4008363993b4d140f98c3e8ff8336be4b6fbacb5005cf7092e
           - name: kind
             value: task
         resolver: bundles
-      workspaces:
-        - name: workspace
-          workspace: workspace
     - name: rpms-signature-scan
       params:
         - name: image-url
@@ -594,7 +606,7 @@ spec:
           - name: name
             value: rpms-signature-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7b80f5a319d4ff1817fa097cbdbb9473635562f8ea3022e64933e387d3b68715
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:998b5466417c324aea94d3e8b302c558aeb13f746976d89a4ff85f1b84a42c2b
           - name: kind
             value: task
         resolver: bundles
@@ -604,7 +616,6 @@ spec:
           values:
             - "false"
   workspaces:
-    - name: workspace
     - name: git-auth
       optional: true
     - name: netrc

--- a/.tekton/topology-aware-lifecycle-manager-4-19-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-4-19-pull-request.yaml
@@ -26,6 +26,9 @@ spec:
       value: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-4-19:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
+    - name: build-platforms
+      value:
+        - linux/x86_64
     - name: dockerfile
       value: Dockerfile
     - name: build-args-file
@@ -40,17 +43,6 @@ spec:
     name: build-pipeline
   taskRunTemplate: {}
   workspaces:
-    - name: workspace
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-        status: {}
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'

--- a/.tekton/topology-aware-lifecycle-manager-4-19-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-4-19-push.yaml
@@ -24,6 +24,9 @@ spec:
       value: '{{revision}}'
     - name: output-image
       value: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-4-19:{{revision}}
+    - name: build-platforms
+      value:
+        - linux/x86_64
     - name: dockerfile
       value: Dockerfile
     - name: build-args-file
@@ -38,17 +41,6 @@ spec:
     name: build-pipeline
   taskRunTemplate: {}
   workspaces:
-    - name: workspace
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-        status: {}
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'

--- a/.tekton/topology-aware-lifecycle-manager-aztp-4-19-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-aztp-4-19-pull-request.yaml
@@ -26,6 +26,9 @@ spec:
       value: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-aztp-4-19:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
+    - name: build-platforms
+      value:
+        - linux/x86_64
     - name: dockerfile
       value: Dockerfile.aztp
     - name: build-args-file
@@ -40,17 +43,6 @@ spec:
     name: build-pipeline
   taskRunTemplate: {}
   workspaces:
-    - name: workspace
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-        status: {}
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'

--- a/.tekton/topology-aware-lifecycle-manager-aztp-4-19-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-aztp-4-19-push.yaml
@@ -24,6 +24,9 @@ spec:
       value: '{{revision}}'
     - name: output-image
       value: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-aztp-4-19:{{revision}}
+    - name: build-platforms
+      value:
+        - linux/x86_64
     - name: dockerfile
       value: Dockerfile.aztp
     - name: build-args-file
@@ -38,17 +41,6 @@ spec:
     name: build-pipeline
   taskRunTemplate: {}
   workspaces:
-    - name: workspace
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-        status: {}
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'

--- a/.tekton/topology-aware-lifecycle-manager-bundle-4-19-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-bundle-4-19-pull-request.yaml
@@ -26,6 +26,9 @@ spec:
       value: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-19:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
+    - name: build-platforms
+      value:
+        - linux/x86_64
     - name: dockerfile
       value: bundle.konflux.Dockerfile
     - name: build-args-file
@@ -42,17 +45,6 @@ spec:
     name: build-pipeline
   taskRunTemplate: {}
   workspaces:
-    - name: workspace
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-        status: {}
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'

--- a/.tekton/topology-aware-lifecycle-manager-bundle-4-19-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-bundle-4-19-push.yaml
@@ -24,6 +24,9 @@ spec:
       value: '{{revision}}'
     - name: output-image
       value: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-19:{{revision}}
+    - name: build-platforms
+      value:
+        - linux/x86_64
     - name: dockerfile
       value: bundle.konflux.Dockerfile
     - name: build-args-file
@@ -40,17 +43,6 @@ spec:
     name: build-pipeline
   taskRunTemplate: {}
   workspaces:
-    - name: workspace
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-        status: {}
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'

--- a/.tekton/topology-aware-lifecycle-manager-precache-4-19-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-precache-4-19-pull-request.yaml
@@ -26,6 +26,9 @@ spec:
       value: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-precache-4-19:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
+    - name: build-platforms
+      value:
+        - linux/x86_64
     - name: dockerfile
       value: Dockerfile.precache
     - name: build-args-file
@@ -40,17 +43,6 @@ spec:
     name: build-pipeline
   taskRunTemplate: {}
   workspaces:
-    - name: workspace
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-        status: {}
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'

--- a/.tekton/topology-aware-lifecycle-manager-precache-4-19-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-precache-4-19-push.yaml
@@ -24,6 +24,9 @@ spec:
       value: '{{revision}}'
     - name: output-image
       value: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-precache-4-19:{{revision}}
+    - name: build-platforms
+      value:
+        - linux/x86_64
     - name: dockerfile
       value: Dockerfile.precache
     - name: build-args-file
@@ -38,17 +41,6 @@ spec:
     name: build-pipeline
   taskRunTemplate: {}
   workspaces:
-    - name: workspace
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-        status: {}
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'

--- a/.tekton/topology-aware-lifecycle-manager-recovery-4-19-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-recovery-4-19-pull-request.yaml
@@ -26,6 +26,9 @@ spec:
       value: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-recovery-4-19:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
+    - name: build-platforms
+      value:
+        - linux/x86_64
     - name: dockerfile
       value: Dockerfile.recovery
     - name: build-args-file
@@ -40,17 +43,6 @@ spec:
     name: build-pipeline
   taskRunTemplate: {}
   workspaces:
-    - name: workspace
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-        status: {}
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'

--- a/.tekton/topology-aware-lifecycle-manager-recovery-4-19-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-recovery-4-19-push.yaml
@@ -24,6 +24,9 @@ spec:
       value: '{{revision}}'
     - name: output-image
       value: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-recovery-4-19:{{revision}}
+    - name: build-platforms
+      value:
+        - linux/x86_64
     - name: dockerfile
       value: Dockerfile.recovery
     - name: build-args-file
@@ -38,17 +41,6 @@ spec:
     name: build-pipeline
   taskRunTemplate: {}
   workspaces:
-    - name: workspace
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-        status: {}
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
- By copying the new TA pipeline in LCA and changing a few things, we can convert this without onboarding