### PR TITLE
Disable gomod updates from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,9 @@
             "versioningTemplate": "docker"
         }
     ],
+    "gomod": {
+        "enabled": false
+    },
     "packageRules": [
         {
             "autoApprove": true,


### PR DESCRIPTION
- Gomod updates are proving exceptionally noisey
- As Konflux is backported to more OCP versions it will only get worse
- Disable them for now, pending a re-evaluation later
- Also dependabot is already doing this in this repo anyway