### PR TITLE
Fix tag used for golang builder

### DIFF
--- a/.konflux/konflux_build_args.conf
+++ b/.konflux/konflux_build_args.conf
@@ -3,7 +3,7 @@ KONFLUX=true
 #
 
 # The builder image is used to compile golang code
-BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23@sha256:8c881edc745eeb6ea246f1bac55b09b5ae5dc16f7ed9d0d73b5ffda28e582bab
+BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88
 #
 
 # The runtime image is used to run the binaries


### PR DESCRIPTION
- The previous tag is not necessarily rhel9, we need to use a more specific tag
- Update digest to latest version of the new tag