### PR TITLE
[release-4.15] Add `latest` tag to quay builds

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -101,6 +101,10 @@ spec:
       description: Whether to append the platform string to the end of the build image tag
       name: image-append-platform
       type: string
+    - default: []
+      description: Additional tags to apply to the built container image
+      name: additional-tags
+      type: array
   results:
     - description: ""
       name: IMAGE_URL
@@ -579,6 +583,8 @@ spec:
       params:
         - name: IMAGE
           value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: ADDITIONAL_TAGS
+          value: $(params.additional-tags[*])
       runAfter:
         - build-image-index
       taskRef:

--- a/.tekton/topology-aware-lifecycle-manager-4-15-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-4-15-pull-request.yaml
@@ -58,6 +58,8 @@ spec:
       value: "true"
     - name: skip-sast-coverity
       value: "true"
+    - name: additional-tags
+      value: []
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-4-15-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-4-15-push.yaml
@@ -56,6 +56,8 @@ spec:
       value: "true"
     - name: skip-sast-coverity
       value: "true"
+    - name: additional-tags
+      value: ["latest"]
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-bundle-4-15-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-bundle-4-15-pull-request.yaml
@@ -60,6 +60,8 @@ spec:
       value: "false"
     - name: skip-sast-coverity
       value: "true"
+    - name: additional-tags
+      value: []
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-bundle-4-15-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-bundle-4-15-push.yaml
@@ -58,6 +58,8 @@ spec:
       value: "false"
     - name: skip-sast-coverity
       value: "true"
+    - name: additional-tags
+      value: ["latest"]
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-precache-4-15-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-precache-4-15-pull-request.yaml
@@ -56,6 +56,8 @@ spec:
       value: "true"
     - name: skip-sast-coverity
       value: "true"
+    - name: additional-tags
+      value: []
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-precache-4-15-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-precache-4-15-push.yaml
@@ -54,6 +54,8 @@ spec:
       value: "true"
     - name: skip-sast-coverity
       value: "true"
+    - name: additional-tags
+      value: ["latest"]
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-recovery-4-15-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-recovery-4-15-pull-request.yaml
@@ -56,6 +56,8 @@ spec:
       value: "true"
     - name: skip-sast-coverity
       value: "true"
+    - name: additional-tags
+      value: []
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-recovery-4-15-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-recovery-4-15-push.yaml
@@ -54,6 +54,8 @@ spec:
       value: "true"
     - name: skip-sast-coverity
       value: "true"
+    - name: additional-tags
+      value: ["latest"]
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:


### PR DESCRIPTION
- Manual cherry pick was required because the aztp component don't exist in 4.15 and older releases
