### PR TITLE
Disable minor updates from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,6 +38,10 @@
                 "digest"
             ],
             "platformAutomerge": true
+        },
+        {
+            "matchUpdateTypes": ["minor"],
+            "enabled": false
         }
     ],
     "prConcurrentLimit": 0,


### PR DESCRIPTION
- We don't need automatic updates for these, as we generally keep them synced with OCP
- Denying the automatic PRs repeatedly is getting annoying