### PR TITLE
Remove fips check in fbc pipeline

### DIFF
--- a/.tekton/fbc-pipeline.yaml
+++ b/.tekton/fbc-pipeline.yaml
@@ -340,30 +340,31 @@ spec:
       operator: in
       values:
       - "false"
-  - name: fbc-fips-check-oci-ta
-    params:
-    - name: image-digest
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    - name: image-url
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-    runAfter:
-    - build-image-index
-    taskRef:
-      params:
-      - name: name
-        value: fbc-fips-check-oci-ta
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:479d93d8ff93e8e40025608fda6fc5049a556c88272e8391ddab39d95d04e307
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values:
-      - "false"
+  # This release pre-dates fips, but the check will still run unless it is removed here
+  # - name: fbc-fips-check-oci-ta
+  #   params:
+  #   - name: image-digest
+  #     value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+  #   - name: image-url
+  #     value: $(tasks.build-image-index.results.IMAGE_URL)
+  #   - name: SOURCE_ARTIFACT
+  #     value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+  #   runAfter:
+  #   - build-image-index
+  #   taskRef:
+  #     params:
+  #     - name: name
+  #       value: fbc-fips-check-oci-ta
+  #     - name: bundle
+  #       value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:479d93d8ff93e8e40025608fda6fc5049a556c88272e8391ddab39d95d04e307
+  #     - name: kind
+  #       value: task
+  #     resolver: bundles
+  #   when:
+  #   - input: $(params.skip-checks)
+  #     operator: in
+  #     values:
+  #     - "false"
   workspaces:
     - name: git-auth
       optional: true


### PR DESCRIPTION
- This release is too old to be fips compliant, but the check is still running
- Remove the task from the pipeline to prevent it from running entirely