### PR TITLE
Update to use released opm image for 4.19

### DIFF
--- a/.konflux/Dockerfile.catalog
+++ b/.konflux/Dockerfile.catalog
@@ -1,5 +1,5 @@
 # The opm image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-ARG OPM_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
+ARG OPM_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
 ARG BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.23
 
 # build the catalog

--- a/.konflux/container_build_args.conf
+++ b/.konflux/container_build_args.conf
@@ -8,7 +8,7 @@ BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_go
 
 # The opm image is used to serve the FBC
 # There is a metadata processing bug preventing us from pinning this particular image for now
-# OPM_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19@sha256:ee2c2e22209cb0ad24edd0f116b1b79e46e47fdf06b4e7fac995546c9d34422a
+# OPM_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19@sha256:80525c2491d963ccb43a7d394d5e4ee0cf9e7fc69f525dbf7e704f981e511b5f
 #
 
 # The runtime image is used to run the binaries


### PR DESCRIPTION
- We don't want to use an unreleased build for the next z stream ship