### PR TITLE
CNF-18555: Replace brew version of opm image with released version

### DIFF
--- a/.konflux/Dockerfile.catalog
+++ b/.konflux/Dockerfile.catalog
@@ -1,5 +1,6 @@
 # The opm image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-ARG OPM_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20
+ARG OPM_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20
+# CNF-18555: When there is a Konflux build available for this then we need to update from the brew image
 ARG BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24
 
 # build the catalog

--- a/.konflux/container_build_args.conf
+++ b/.konflux/container_build_args.conf
@@ -3,12 +3,13 @@ KONFLUX=true
 #
 
 # The builder image is used to compile golang code
+# CNF-18555: When there is a Konflux build available for this then we need to update from the brew image
 BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24@sha256:b91431604c435f3cabec20ddb653c0537c8ba8097ada57960d54a1266f95a7c3
 #
 
 # The opm image is used to serve the FBC
 # There is a metadata processing bug preventing us from pinning this particular image for now
-# OPM_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20@sha256:3c89f04f5299307eda4a6d732aab8529ff15fb4fc081e1296f165f6360e418be
+# OPM_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20@sha256:a7ce355c287b89aa5565d3c9d0e6e9913fac9fa7819759ac4acf0a32dcb4a27a
 #
 
 # The runtime image is used to run the binaries


### PR DESCRIPTION
[CNF-18555](https://issues.redhat.com//browse/CNF-18555): Replace brew version of opm image with released version
- Add some clarifying comments on the remaining brew references