### PR TITLE
[release-4.15] Update owners configuration

### DIFF
--- a/.konflux/OWNERS
+++ b/.konflux/OWNERS
@@ -1,2 +1,0 @@
-approvers:
-  - konflux-approvers

--- a/.tekton/OWNERS
+++ b/.tekton/OWNERS
@@ -1,2 +1,0 @@
-approvers:
-  - konflux-approvers

--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,37 @@
+---
 # See the OWNERS docs at https://go.k8s.io/owners
 
 component: "Telco Edge"
-subcomponent: "TALO"
-
 filters:
   ".*":
-    reviewers:
-      - upgrades-operator-reviewers
     approvers:
       - upgrades-operator-approvers
-
+    reviewers:
+      - upgrades-operator-reviewers
+  ".konflux/*":
+    approvers:
+      - konflux-approvers
+    reviewers:
+      - konflux-reviewers
+  ".tekton/*":
+    approvers:
+      - konflux-approvers
+    reviewers:
+      - konflux-reviewers
+  ^Dockerfile:
+    reviewers:
+      - rauhersu
+  ^bundle/manifests/cluster-group-upgrades-operator.clusterserviceversion.yaml:
+    reviewers:
+      - rauhersu
+  "renovate.json":
+    approvers:
+      - konflux-approvers
+    reviewers:
+      - konflux-reviewers
+  "telco5g-konflux/":
+    approvers:
+      - konflux-approvers
+    reviewers:
+      - konflux-reviewers
+subcomponent: "TALO"

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,31 @@
+---
 # See the OWNERS docs at https://go.k8s.io/owners
 
 aliases:
+  konflux-approvers:
+    - abraham2512
+    - fontivan
+    - rauhersu
+    - sabbir-47
+    - shajmakh
+    - yanirq
+  konflux-reviewers:
+    - fontivan
+    - rauhersu
+  upgrades-operator-approvers:
+    - browsell
+    - donpenney
+    - sabbir-47
+    - irinamihai
+    - imiller0
+    - nishant-parekh
+    - serngawy
+    - vitus133
+    - jc-rh
+    - Missxiaoguo
+    - fontivan
+    - sudomakeinstall2
+    - sakhoury
   upgrades-operator-reviewers:
     - browsell
     - donpenney
@@ -15,22 +40,5 @@ aliases:
     - Missxiaoguo
     - fontivan
     - pixelsoccupied
-    - sudomakeinstall2 
+    - sudomakeinstall2
     - sakhoury
-  upgrades-operator-approvers:
-    - browsell
-    - donpenney
-    - sabbir-47
-    - irinamihai
-    - imiller0
-    - nishant-parekh
-    - serngawy
-    - vitus133
-    - jc-rh
-    - Missxiaoguo
-    - fontivan
-    - sudomakeinstall2 
-    - sakhoury
-  konflux-approvers:
-    - fontivan
-    - rauhersu


### PR DESCRIPTION
- Move .tekton and .konflux configuration into top level OWNERS File instead of having separate files
- Add telco5g-konflux submodule folder to OWNERS file
- Add renovate.json file to OWNERS file
- Add additional konflux approvers
- Format OWNERS and OWNERS_ALISES to yamllint standard