### PR TITLE
Update renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,17 @@
                 "(?<depName>registry\\.redhat\\.io/openshift4/ose-kube-rbac-proxy-rhel9):(?<currentValue>[^@]+)@(?<currentDigest>sha256:[a-f0-9]+)"
             ],
             "versioningTemplate": "docker"
+        },
+        {
+            "customType": "regex",
+            "datasourceTemplate": "docker",
+            "managerFilePatterns": [
+                "/^\\.konflux/overlay/pin_images\\.in\\.yaml$/"
+            ],
+            "matchStrings": [
+                "(?<depName>registry\\.redhat\\.io/openshift4/ose-kube-rbac-proxy-rhel8):(?<currentValue>[^@]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+            ],
+            "versioningTemplate": "docker"
         }
     ],
     "gomod": {


### PR DESCRIPTION
- Add regex for the rhel8 version of the kube rbac proxy
- This is required so 4.12 through 4.15 update correctly