### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for topology-aware-lifecycle-manager-recovery-4-16

### DIFF
--- a/Dockerfile.recovery
+++ b/Dockerfile.recovery
@@ -37,6 +37,9 @@ RUN if [[ "${KONFLUX}" == "true" ]]; then \
 # Create the runtime image
 FROM ${RUNTIME_IMAGE}
 
+LABEL name="openshift4/topology-aware-lifecycle-manager-recovery-rhel9" \
+      cpe="cpe:/a:redhat:openshift:4.16::el9"
+
 COPY --from=builder /workspace/upgrade-recovery /usr/bin/
 
 ENTRYPOINT ["/usr/bin/upgrade-recovery"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
