### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for topology-aware-lifecycle-manager-*-4-18

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -105,6 +105,10 @@ spec:
       description: Additional tags to apply to the built container image
       name: additional-tags
       type: array
+    - default: []
+      description: Additional labels to apply to the built container image
+      name: additional-labels
+      type: array
   results:
     - description: ''
       name: IMAGE_URL
@@ -250,12 +254,13 @@ spec:
         - name: LABELS
           value:
             - $(tasks.generate-labels.results.labels[*])
+            - $(params.additional-labels[*])
             - com.redhat.component=topology-aware-lifecycle-manager-operator-container
             - description=topology-aware-lifecycle-manager
             - distribution-scope=public
             - io.k8s.description=topology-aware-lifecycle-manager
-            - name=openshift4/topology-aware-lifecycle-manager-rhel9-operator
             - release=4.18
+            - cpe="cpe:/a:redhat:openshift:4.18::el9"
             - url=https://github.com/openshift-kni/cluster-group-upgrades-operator
             - vendor=Red Hat, Inc.
             - io.k8s.display-name=topology-aware-lifecycle-manager

--- a/.tekton/topology-aware-lifecycle-manager-4-18-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-4-18-pull-request.yaml
@@ -60,6 +60,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: []
+    - name: additional-labels
+      value:
+        - name=openshift4/topology-aware-lifecycle-manager-rhel9-operator
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-4-18-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-4-18-push.yaml
@@ -58,6 +58,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: ["latest"]
+    - name: additional-labels
+      value:
+        - name=openshift4/topology-aware-lifecycle-manager-rhel9-operator
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-aztp-4-18-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-aztp-4-18-pull-request.yaml
@@ -57,6 +57,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: []
+    - name: additional-labels
+      value:
+        - name=openshift4/topology-aware-lifecycle-manager-aztp-rhel9
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-aztp-4-18-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-aztp-4-18-push.yaml
@@ -55,6 +55,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: ["latest"]
+    - name: additional-labels
+      value:
+        - name=openshift4/topology-aware-lifecycle-manager-aztp-rhel9
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-bundle-4-18-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-bundle-4-18-pull-request.yaml
@@ -62,6 +62,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: []
+    - name: additional-labels
+      value:
+        - name=openshift4/topology-aware-lifecycle-manager-operator-bundle
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-bundle-4-18-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-bundle-4-18-push.yaml
@@ -60,6 +60,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: ["latest"]
+    - name: additional-labels
+      value:
+        - name=openshift4/topology-aware-lifecycle-manager-operator-bundle
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-precache-4-18-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-precache-4-18-pull-request.yaml
@@ -58,6 +58,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: []
+    - name: additional-labels
+      value:
+        - name=openshift4/topology-aware-lifecycle-manager-precache-rhel9
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-precache-4-18-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-precache-4-18-push.yaml
@@ -56,6 +56,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: ["latest"]
+    - name: additional-labels
+      value:
+        - name=openshift4/topology-aware-lifecycle-manager-precache-rhel9
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-recovery-4-18-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-recovery-4-18-pull-request.yaml
@@ -58,6 +58,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: []
+    - name: additional-labels
+      value:
+        - name=openshift4/topology-aware-lifecycle-manager-recovery-rhel9
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-recovery-4-18-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-recovery-4-18-push.yaml
@@ -56,6 +56,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: ["latest"]
+    - name: additional-labels
+      value:
+        - name=openshift4/topology-aware-lifecycle-manager-recovery-rhel9
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
