### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for topology-aware-lifecycle-manager-bundle-4-18

### DIFF
--- a/.konflux/Dockerfile.bundle
+++ b/.konflux/Dockerfile.bundle
@@ -42,6 +42,8 @@ LABEL operators.operatorframework.io.bundle.channels.default.v1=stable
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.28.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+LABEL name="openshift4/topology-aware-lifecycle-manager-operator-bundle"
+LABEL cpe="cpe:/a:redhat:openshift:4.18::el9"
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
