### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for topology-aware-lifecycle-manager-precache-4-18

### DIFF
--- a/Dockerfile.precache
+++ b/Dockerfile.precache
@@ -4,6 +4,9 @@ ARG RUNTIME_IMAGE=registry.access.redhat.com/ubi9-minimal:9.4
 # Create the runtime image
 FROM ${RUNTIME_IMAGE}
 
+LABEL name="openshift4/topology-aware-lifecycle-manager-precache-rhel9" \
+      cpe="cpe:/a:redhat:openshift:4.18::el9"
+
 RUN mkdir /opt/precache
 
 COPY pre-cache/release.sh \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
