### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for topology-aware-lifecycle-manager-4-18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,5 @@ COPY --from=builder /workspace/manager .
 
 USER 65532:65532
 
+LABEL "cpe"="cpe:/a:redhat:openshift:4.18::el9"
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
