### PR TITLE
Sort on-cel-expression file paths && add telco5g-konflux to it

### DIFF
--- a/.tekton/topology-aware-lifecycle-manager-4-20-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-4-20-pull-request.yaml
@@ -12,19 +12,21 @@ metadata:
       event == "pull_request" &&
       target_branch == "main" &&
       (
-        '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.konflux/container_build_args.conf'.pathChanged() ||
+        '.tekton/build-pipeline.yaml'.pathChanged() ||
+        '.tekton/topology-aware-lifecycle-manager-4-20-pull-request.yaml'.pathChanged() ||
         'config/***'.pathChanged() ||
         'controllers/***'.pathChanged() ||
         'deploy/***'.pathChanged() ||
-        'hack/***'.pathChanged() ||
-        'pkg/***'.pathChanged() ||
-        'vendor/***'.pathChanged() ||
+        'Dockerfile'.pathChanged() ||
         'go.mod'.pathChanged() ||
         'go.sum'.pathChanged() ||
+        'hack/***'.pathChanged() ||
         'main.go'.pathChanged() ||
-        '.tekton/topology-aware-lifecycle-manager-4-20-pull-request.yaml'.pathChanged() ||
-        'Dockerfile'.pathChanged()
+        'pkg/***'.pathChanged() ||
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged() ||
+        'vendor/***'.pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/topology-aware-lifecycle-manager-4-20-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-4-20-push.yaml
@@ -12,19 +12,21 @@ metadata:
       event == "push" &&
       target_branch == "main" &&
       (
-        '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.konflux/container_build_args.conf'.pathChanged() ||
+        '.tekton/build-pipeline.yaml'.pathChanged() ||
+        '.tekton/topology-aware-lifecycle-manager-4-20-push.yaml'.pathChanged() ||
         'config/***'.pathChanged() ||
         'controllers/***'.pathChanged() ||
         'deploy/***'.pathChanged() ||
-        'hack/***'.pathChanged() ||
-        'pkg/***'.pathChanged() ||
-        'vendor/***'.pathChanged() ||
+        'Dockerfile'.pathChanged() ||
         'go.mod'.pathChanged() ||
         'go.sum'.pathChanged() ||
+        'hack/***'.pathChanged() ||
         'main.go'.pathChanged() ||
-        '.tekton/topology-aware-lifecycle-manager-4-20-push.yaml'.pathChanged() ||
-        'Dockerfile'.pathChanged()
+        'pkg/***'.pathChanged() ||
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged() ||
+        'vendor/***'.pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/topology-aware-lifecycle-manager-aztp-4-20-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-aztp-4-20-pull-request.yaml
@@ -12,16 +12,18 @@ metadata:
       event == "pull_request" &&
       target_branch == "main" &&
       (
-        '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.konflux/container_build_args.conf'.pathChanged() ||
+        '.tekton/build-pipeline.yaml'.pathChanged() ||
+        '.tekton/topology-aware-lifecycle-manager-aztp-4-20-pull-request.yaml'.pathChanged() ||
         'config/***'.pathChanged() ||
-        'hack/***'.pathChanged() ||
-        'pkg/***'.pathChanged() ||
-        'vendor/***'.pathChanged() ||
+        'Dockerfile.aztp'.pathChanged() ||
         'go.mod'.pathChanged() ||
         'go.sum'.pathChanged() ||
-        '.tekton/topology-aware-lifecycle-manager-aztp-4-20-pull-request.yaml'.pathChanged() ||
-        'Dockerfile.aztp'.pathChanged()
+        'hack/***'.pathChanged() ||
+        'pkg/***'.pathChanged() ||
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged() ||
+        'vendor/***'.pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/topology-aware-lifecycle-manager-aztp-4-20-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-aztp-4-20-push.yaml
@@ -12,16 +12,18 @@ metadata:
       event == "push" &&
       target_branch == "main" &&
       (
-        '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.konflux/container_build_args.conf'.pathChanged() ||
+        '.tekton/build-pipeline.yaml'.pathChanged() ||
+        '.tekton/topology-aware-lifecycle-manager-aztp-4-20-push.yaml'.pathChanged() ||
         'config/***'.pathChanged() ||
-        'hack/***'.pathChanged() ||
-        'pkg/***'.pathChanged() ||
-        'vendor/***'.pathChanged() ||
+        'Dockerfile.aztp'.pathChanged() ||
         'go.mod'.pathChanged() ||
         'go.sum'.pathChanged() ||
-        '.tekton/topology-aware-lifecycle-manager-aztp-4-20-push.yaml'.pathChanged() ||
-        'Dockerfile.aztp'.pathChanged()
+        'hack/***'.pathChanged() ||
+        'pkg/***'.pathChanged() ||
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged() ||
+        'vendor/***'.pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/topology-aware-lifecycle-manager-bundle-4-20-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-bundle-4-20-pull-request.yaml
@@ -12,15 +12,17 @@ metadata:
       event == "pull_request" &&
       target_branch == "main" &&
       (
-        '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.konflux/container_build_args.conf'.pathChanged() ||
+        '.konflux/Dockerfile.bundle'.pathChanged() ||
+        '.konflux/overlay/***'.pathChanged() ||
+        '.tekton/build-pipeline.yaml'.pathChanged() ||
+        '.tekton/topology-aware-lifecycle-manager-bundle-4-20-pull-request.yaml'.pathChanged() ||
         'bundle/***'.pathChanged() ||
         'config/***'.pathChanged() ||
         'hack/***'.pathChanged() ||
         'manifests/***'.pathChanged() ||
-        '.konflux/overlay/***'.pathChanged() ||
-        '.tekton/topology-aware-lifecycle-manager-bundle-4-20-pull-request.yaml'.pathChanged() ||
-        '.konflux/Dockerfile.bundle'.pathChanged()
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/topology-aware-lifecycle-manager-bundle-4-20-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-bundle-4-20-push.yaml
@@ -12,15 +12,17 @@ metadata:
       event == "push" &&
       target_branch == "main" &&
       (
-        '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.konflux/container_build_args.conf'.pathChanged() ||
+        '.konflux/Dockerfile.bundle'.pathChanged() ||
+        '.konflux/overlay/***'.pathChanged() ||
+        '.tekton/build-pipeline.yaml'.pathChanged() ||
+        '.tekton/topology-aware-lifecycle-manager-bundle-4-20-push.yaml'.pathChanged() ||
         'bundle/***'.pathChanged() ||
         'config/***'.pathChanged() ||
         'hack/***'.pathChanged() ||
         'manifests/***'.pathChanged() ||
-        '.konflux/overlay/***'.pathChanged() ||
-        '.tekton/topology-aware-lifecycle-manager-bundle-4-20-push.yaml'.pathChanged() ||
-        '.konflux/Dockerfile.bundle'.pathChanged()
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/topology-aware-lifecycle-manager-fbc-4-20-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-fbc-4-20-pull-request.yaml
@@ -12,12 +12,14 @@ metadata:
       event == "pull_request" &&
       target_branch == "main" &&
       (
+        '.konflux/catalog/***'.pathChanged() ||
+        '.konflux/container_build_args.conf'.pathChanged() ||
+        '.konflux/Dockerfile.catalog'.pathChanged() ||
         '.tekton/fbc-pipeline.yaml'.pathChanged() ||
         '.tekton/images-mirror-set.yaml'.pathChanged() ||
         '.tekton/topology-aware-lifecycle-manager-fbc-4-20-pull-request.yaml'.pathChanged() ||
-        '.konflux/catalog/***'.pathChanged() ||
-        '.konflux/container_build_args.conf'.pathChanged() ||
-        '.konflux/Dockerfile.catalog'.pathChanged()
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/topology-aware-lifecycle-manager-fbc-4-20-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-fbc-4-20-push.yaml
@@ -11,12 +11,14 @@ metadata:
       event == "push" &&
       target_branch == "main" &&
       (
+        '.konflux/catalog/***'.pathChanged() ||
+        '.konflux/container_build_args.conf'.pathChanged() ||
+        '.konflux/Dockerfile.catalog'.pathChanged() ||
         '.tekton/fbc-pipeline.yaml'.pathChanged() ||
         '.tekton/images-mirror-set.yaml'.pathChanged() ||
         '.tekton/topology-aware-lifecycle-manager-fbc-4-20-push.yaml'.pathChanged() ||
-        '.konflux/catalog/***'.pathChanged() ||
-        '.konflux/container_build_args.conf'.pathChanged() ||
-        '.konflux/Dockerfile.catalog'.pathChanged()
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/topology-aware-lifecycle-manager-precache-4-20-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-precache-4-20-pull-request.yaml
@@ -12,17 +12,19 @@ metadata:
       event == "pull_request" &&
       target_branch == "main" &&
       (
-        '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.konflux/container_build_args.conf'.pathChanged() ||
+        '.tekton/build-pipeline.yaml'.pathChanged() ||
+        '.tekton/topology-aware-lifecycle-manager-precache-4-20-pull-request.yaml'.pathChanged() ||
         'config/***'.pathChanged() ||
+        'Dockerfile.precache'.pathChanged() ||
+        'go.mod'.pathChanged() ||
+        'go.sum'.pathChanged() ||
         'hack/***'.pathChanged() ||
         'pkg/***'.pathChanged() ||
         'pre-cache/***'.pathChanged() ||
-        'vendor/***'.pathChanged() ||
-        'go.mod'.pathChanged() ||
-        'go.sum'.pathChanged() ||
-        '.tekton/topology-aware-lifecycle-manager-precache-4-20-pull-request.yaml'.pathChanged() ||
-        'Dockerfile.precache'.pathChanged()
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged() ||
+        'vendor/***'.pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/topology-aware-lifecycle-manager-precache-4-20-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-precache-4-20-push.yaml
@@ -12,17 +12,19 @@ metadata:
       event == "push" &&
       target_branch == "main" &&
       (
-        '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.konflux/container_build_args.conf'.pathChanged() ||
+        '.tekton/build-pipeline.yaml'.pathChanged() ||
+        '.tekton/topology-aware-lifecycle-manager-precache-4-20-push.yaml'.pathChanged() ||
         'config/***'.pathChanged() ||
+        'Dockerfile.precache'.pathChanged() ||
+        'go.mod'.pathChanged() ||
+        'go.sum'.pathChanged() ||
         'hack/***'.pathChanged() ||
         'pkg/***'.pathChanged() ||
         'pre-cache/***'.pathChanged() ||
-        'vendor/***'.pathChanged() ||
-        'go.mod'.pathChanged() ||
-        'go.sum'.pathChanged() ||
-        '.tekton/topology-aware-lifecycle-manager-precache-4-20-push.yaml'.pathChanged() ||
-        'Dockerfile.precache'.pathChanged()
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged() ||
+        'vendor/***'.pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/topology-aware-lifecycle-manager-recovery-4-20-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-recovery-4-20-pull-request.yaml
@@ -12,17 +12,19 @@ metadata:
       event == "pull_request" &&
       target_branch == "main" &&
       (
-        '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.konflux/container_build_args.conf'.pathChanged() ||
+        '.tekton/build-pipeline.yaml'.pathChanged() ||
+        '.tekton/topology-aware-lifecycle-manager-recovery-4-20-pull-request.yaml'.pathChanged() ||
         'config/***'.pathChanged() ||
+        'Dockerfile.recovery'.pathChanged() ||
+        'go.mod'.pathChanged() ||
+        'go.sum'.pathChanged() ||
         'hack/***'.pathChanged() ||
         'pkg/***'.pathChanged() ||
         'recovery/***'.pathChanged() ||
-        'vendor/***'.pathChanged() ||
-        'go.mod'.pathChanged() ||
-        'go.sum'.pathChanged() ||
-        '.tekton/topology-aware-lifecycle-manager-recovery-4-20-pull-request.yaml'.pathChanged() ||
-        'Dockerfile.recovery'.pathChanged()
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged() ||
+        'vendor/***'.pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/topology-aware-lifecycle-manager-recovery-4-20-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-recovery-4-20-push.yaml
@@ -12,17 +12,19 @@ metadata:
       event == "push" &&
       target_branch == "main" &&
       (
-        '.tekton/build-pipeline.yaml'.pathChanged() ||
         '.konflux/container_build_args.conf'.pathChanged() ||
+        '.tekton/build-pipeline.yaml'.pathChanged() ||
+        '.tekton/topology-aware-lifecycle-manager-recovery-4-20-push.yaml'.pathChanged() ||
         'config/***'.pathChanged() ||
+        'Dockerfile.recovery'.pathChanged() ||
+        'go.mod'.pathChanged() ||
+        'go.sum'.pathChanged() ||
         'hack/***'.pathChanged() ||
         'pkg/***'.pathChanged() ||
         'recovery/***'.pathChanged() ||
-        'vendor/***'.pathChanged() ||
-        'go.mod'.pathChanged() ||
-        'go.sum'.pathChanged() ||
-        '.tekton/topology-aware-lifecycle-manager-recovery-4-20-push.yaml'.pathChanged() ||
-        'Dockerfile.recovery'.pathChanged()
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged() ||
+        'vendor/***'.pathChanged()
       )
   creationTimestamp: null
   labels:


### PR DESCRIPTION
- Sorting them will make it easier to keep the paths sane going forward
- Since the library scripts are used by the tekton builds, changes there should trigger the builds

AI-attribution: AIA,Entirely human-created,v1.0
For more information on AI attribution statements, see: https://aiattribution.github.io/