### PR TITLE
Remove default name label from build-pipeline

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -263,7 +263,6 @@ spec:
             - description=topology-aware-lifecycle-manager
             - distribution-scope=public
             - io.k8s.description=topology-aware-lifecycle-manager
-            - name=openshift4/topology-aware-lifecycle-manager-rhel9-operator
             - release=4.20
             - cpe="cpe:/a:redhat:openshift:4.20::el9"
             - url=https://github.com/openshift-kni/cluster-group-upgrades-operator


### PR DESCRIPTION
- this is passed in via the additional-labels field instead

AI-attribution: AIA,Entirely human-created,v1.0
For more information on AI attribution statements, see: https://aiattribution.github.io/