### PR TITLE
CNFCERT-1258: Add kustomize validation check

### DIFF
--- a/.github/workflows/kustomize-validation.yml
+++ b/.github/workflows/kustomize-validation.yml
@@ -1,0 +1,47 @@
+name: Kustomize Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  kustomize-validation:
+    name: Validate Kustomization Files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Kustomize
+        run: |
+          # Download with retries to prevent flaky CI failures
+          MAX_ATTEMPTS=3
+          ATTEMPT=1
+          
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            echo "Attempt $ATTEMPT of $MAX_ATTEMPTS: Downloading kustomize install script..."
+            if curl -fsSL --retry 3 --retry-delay 2 "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash; then
+              echo "Successfully downloaded and installed kustomize"
+              break
+            else
+              echo "Failed to install kustomize"
+              if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
+                echo "All attempts failed"
+                exit 1
+              fi
+              echo "Waiting 5 seconds before retry..."
+              sleep 5
+              ATTEMPT=$((ATTEMPT + 1))
+            fi
+          done
+          
+          sudo mv kustomize /usr/local/bin/
+          kustomize version
+
+      - name: Validate Kustomization Files
+        run: make test-kustomize
+

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ common-deps-update:	controller-gen kustomize
 
 
 .PHONY: ci-job
-ci-job: common-deps-update generate fmt vet golangci-lint unittests verify-bindata shellcheck bashate yamllint bundle-check
+ci-job: common-deps-update generate fmt vet golangci-lint unittests verify-bindata shellcheck bashate yamllint test-kustomize bundle-check
 
 # Set the paths to the binaries in the local bin directory
 BASHATE = $(LOCALBIN)/bashate
@@ -436,6 +436,10 @@ complete-kuttl-test: complete-deployment kuttl-test stop-test-proxy
 
 pre-cache-unit-test: ## Run pre-cache scripts unit tests
 	cwd=pre-cache ./pre-cache/test.sh
+
+test-kustomize: ## Validate all kustomization.yaml files can build successfully
+	@echo "Running kustomize validation"
+	$(PROJECT_DIR)/hack/test-kustomize.sh
 
 ##@ Tools and linting
 

--- a/hack/test-kustomize.sh
+++ b/hack/test-kustomize.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Directories that require external kustomize plugins or have special requirements
+# that prevent standard kustomize build from working.
+#
+# These directories are excluded because they depend on generated files that are
+# created during the build process (make bundle, make deploy):
+# - config/manager requires generated related-images/patch.yaml
+# - config/default depends on config/manager
+# - config/manifests depends on config/default
+#
+# These files are generated using envsubst from related-images/in.yaml with
+# environment-specific image references.
+EXCLUDED_DIRS=(
+    "./config/manager"
+    "./config/default"
+    "./config/manifests"
+)
+
+# Check if kustomize is installed
+if ! command -v kustomize &> /dev/null; then
+    echo -e "${RED}ERROR: kustomize is not installed${NC}"
+    echo ""
+    echo "Please install kustomize to run this check:"
+    echo "  - macOS: brew install kustomize"
+    echo "  - Linux: curl -s \"https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh\" | bash"
+    echo "  - Manual: https://kubectl.docs.kubernetes.io/installation/kustomize/"
+    echo ""
+    exit 1
+fi
+
+echo "Checking all kustomization.yaml files can build successfully..."
+echo ""
+
+ERRORS=0
+CHECKED=0
+SKIPPED=0
+
+# Helper function to check if directory should be excluded
+is_excluded() {
+    local dir="$1"
+    for excluded in "${EXCLUDED_DIRS[@]}"; do
+        if [ "$dir" = "$excluded" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Find all kustomization.yaml files
+kustomize_files=()
+while IFS= read -r file; do
+    kustomize_files+=("$file")
+done < <(find . -name 'kustomization.yaml' -not -path '*/vendor/*' -not -path '*/.git/*' -not -path '*/bin/*' -not -path '*/testbin/*' | sort)
+
+if [ ${#kustomize_files[@]} -eq 0 ]; then
+    echo -e "${YELLOW}WARNING: No kustomization.yaml files found${NC}"
+    exit 0
+fi
+
+for kustomize_file in "${kustomize_files[@]}"; do
+    dir=$(dirname "$kustomize_file")
+    echo -n "  $dir: "
+    
+    # Check if this directory requires external plugins
+    if is_excluded "$dir"; then
+        echo -e "${BLUE}SKIPPED${NC} (requires external plugins)"
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+    
+    # Try to build the kustomization
+    if kustomize build "$dir" > /dev/null 2>&1; then
+        echo -e "${GREEN}OK${NC}"
+        CHECKED=$((CHECKED + 1))
+    else
+        echo -e "${RED}FAILED${NC}"
+        echo -e "${YELLOW}    Error details:${NC}"
+        kustomize build "$dir" 2>&1 | sed 's/^/    /'
+        echo ""
+        ERRORS=$((ERRORS + 1))
+        CHECKED=$((CHECKED + 1))
+    fi
+done
+
+echo ""
+if [ $SKIPPED -eq 0 ]; then
+    echo "Summary: Checked $CHECKED kustomization.yaml files"
+else
+    echo "Summary: Checked $CHECKED kustomization.yaml files, skipped $SKIPPED (require external plugins)"
+fi
+
+if [[ $ERRORS -eq 0 ]]; then
+    echo -e "${GREEN}All kustomization files validated successfully!${NC}"
+    exit 0
+else
+    echo -e "${RED}$ERRORS kustomization file(s) failed validation${NC}"
+    exit 1
+fi
+


### PR DESCRIPTION
Similar to: https://github.com/openshift-kni/telco-reference/pull/433

Changes:
- Adds a quick PR check that attempts to `kustomize build` appropriate files.  Only runs against `main`.
- Adds a make path for `make test-kustomize` which runs the script.  Users can run this locally as well as there are safeguards to ensure `kustomize` exists first.
- Skips YAMLs that might require external plugins.  See `EXCLUDED_DIRS`.

Example run:

```
$ make test-kustomize 
Running kustomize validation
/Users/bpalm/Repositories/go/src/github.com/openshift-kni/cluster-group-upgrades-operator/hack/test-kustomize.sh
Checking all kustomization.yaml files can build successfully...

  ./config/crd: OK
  ./config/default: SKIPPED (requires external plugins)
  ./config/manager: SKIPPED (requires external plugins)
  ./config/manifests: SKIPPED (requires external plugins)
  ./config/networkpolicies: OK
  ./config/prometheus: OK
  ./config/rbac: OK
  ./config/samples: OK
  ./config/scorecard: OK
  ./samples/precache: OK

Summary: Checked 7 kustomization.yaml files, skipped 3 (require external plugins)
All kustomization files validated successfully!
```