### PR TITLE
CNF-22810: Upstream catalog-template update — Topology Aware Lifecycle Manager 4.16.8

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-16@sha256:53523c995fe92580c998220940d4017716d0076dfbf1f30a13d74ef177b548bf
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-16@sha256:9d9fb6b15ba1055ce948b8ab21ed4c1466bb73e62642d8a07cc6ae842fc533e9

--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-16@sha256:5d1785a92918ad412e427e7bb6f0159ed1975f015baf60d2ce999d2d1c3d1fbc
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-16@sha256:53523c995fe92580c998220940d4017716d0076dfbf1f30a13d74ef177b548bf

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -44,6 +44,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.16.8
         replaces: topology-aware-lifecycle-manager.v4.16.7
         skipRange: '>=4.14.0 <4.16.8'
+      # v4.16.9
+      - name: topology-aware-lifecycle-manager.v4.16.9
+        replaces: topology-aware-lifecycle-manager.v4.16.8
+        skipRange: '>=4.14.0 <4.16.9'
     name: stable
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -84,6 +88,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.16.8
         replaces: topology-aware-lifecycle-manager.v4.16.7
         skipRange: '>=4.14.0 <4.16.8'
+      # v4.16.9
+      - name: topology-aware-lifecycle-manager.v4.16.9
+        replaces: topology-aware-lifecycle-manager.v4.16.8
+        skipRange: '>=4.14.0 <4.16.9'
     name: "4.16"
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -112,6 +120,9 @@ entries:
   - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:e25e47451071f1950981885175589e57fd1f93596935ca62a576dfe0790abad5
     schema: olm.bundle
   # v4.16.8 bundle
+  - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:3f35194368f8efbe2b8bf9e009510be77ffb31bef2bf8d007195740e1f064777
+    schema: olm.bundle
+  # v4.16.9 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.16.8 → 4.16.9.

Generated by release-automator-konflux.