### PR TITLE
CNF-22798: Upstream catalog-template update — Topology Aware Lifecycle Manager 4.19.3

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-19@sha256:96b5eb2fb50aa2c8ccdd6610d249f62e3fa8127629d6446f71aac49d29e110f1
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-19@sha256:cb92a7c5f7896885623166fbe2423f99a7f8d7ff2ed66eeb5cb30235659165c9

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -24,6 +24,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.19.3
         replaces: 'topology-aware-lifecycle-manager.v4.19.2'
         skipRange: '>=4.18.0 <4.19.3'
+      # v4.19.4
+      - name: topology-aware-lifecycle-manager.v4.19.4
+        replaces: topology-aware-lifecycle-manager.v4.19.3
+        skipRange: '>=4.18.0 <4.19.4'
     name: stable
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -44,6 +48,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.19.3
         replaces: 'topology-aware-lifecycle-manager.v4.19.2'
         skipRange: '>=4.18.0 <4.19.3'
+      # v4.19.4
+      - name: topology-aware-lifecycle-manager.v4.19.4
+        replaces: topology-aware-lifecycle-manager.v4.19.3
+        skipRange: '>=4.18.0 <4.19.4'
     name: "4.19"
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -57,6 +65,9 @@ entries:
   - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:0a1920f3ead9344d50476b5451b381a4f64dd4a38cc8d2ec475665cc3cf86daa
     schema: olm.bundle
   # v4.19.3 bundle
+  - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:2d4ca9fecc4597f6f8bf8895e331dee16350635f22f94c9712773550aca4a0fd
+    schema: olm.bundle
+  # v4.19.4 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.19.3 → 4.19.4.

Generated by release-automator-konflux.