### PR TITLE
CNF-22867: Upstream release-config version bump — Topology Aware Lifecycle Manager 4.20.2

### DIFF
--- a/.konflux/overlay/release.in.yaml
+++ b/.konflux/overlay/release.in.yaml
@@ -6,6 +6,6 @@ variables:
       Topology Aware Lifecycle Manager is an operator that facilitates
       platform and operator upgrades of group of clusters
   display_name: "Topology Aware Lifecycle Manager"
-  manager_version: "topology-aware-lifecycle-manager.v4.20.2"
+  manager_version: "topology-aware-lifecycle-manager.v4.20.3"
   min_kube_version: "1.33.0"
-  version: "4.20.2"
+  version: "4.20.3"


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.20.2 → 4.20.3.

Generated by release-automator-konflux.