### PR TITLE
CNF-22981: update renovate labels and git-submodules config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,23 +42,16 @@
         "packageRules": [
             {
                 "addLabels": [
-                    "approved",
-                    "lgtm"
+                    "allow-automatic-merge"
                 ],
                 "additionalBranchPrefix": "telco5g-konflux-",
                 "autoApprove": true,
                 "automerge": true,
-                "matchFileNames": [
-                    "telco5g-konflux/**"
+                "matchPackageNames": [
+                    "https://github.com/openshift-kni/telco5g-konflux.git"
                 ],
                 "schedule": [
                     "at any time"
-                ]
-            },
-            {
-                "additionalBranchPrefix": "telco5g-konflux-",
-                "matchFileNames": [
-                    "telco5g-konflux/**"
                 ]
             }
         ]
@@ -69,8 +62,7 @@
     "packageRules": [
         {
             "addLabels": [
-                "approved",
-                "lgtm"
+                "allow-automatic-merge"
             ],
             "autoApprove": true,
             "automerge": true,
@@ -100,6 +92,11 @@
     "prConcurrentLimit": 0,
     "pruneBranchAfterAutomerge": true,
     "tekton": {
+        "addLabels": [
+            "allow-automatic-merge"
+        ],
+        "autoApprove": true,
+        "automerge": true,
         "enabled": true,
         "ignoreTests": false,
         "includePaths": [


### PR DESCRIPTION
Replace approved/lgtm labels with allow-automatic-merge across all renovate rules. Switch git-submodules from matchFileNames to matchPackageNames with the upstream URL. Add automerge labels to tekton section.

Made-with: Cursor