### PR TITLE
CNF-23199: Upstream catalog-template update — Topology Aware Lifecycle Manager 4.21.2

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-21@sha256:32fe595294e12e2b3aa8c9d71cba4786227277351c058377bda3155959ea6d04
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-21@sha256:73acdcb83465ffe23a3dc9c4ef29971f303847b5e0dc674602a6427562511ea7

--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-21@sha256:30c92b4256230881a175e4bbcfd1ed8ce6844bcc88490d8d9f88c1e998564605
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-21@sha256:32fe595294e12e2b3aa8c9d71cba4786227277351c058377bda3155959ea6d04

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -20,6 +20,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.21.2
         replaces: topology-aware-lifecycle-manager.v4.21.1
         skipRange: '>=4.20.0 <4.21.2'
+      # v4.21.3
+      - name: topology-aware-lifecycle-manager.v4.21.3
+        replaces: topology-aware-lifecycle-manager.v4.21.2
+        skipRange: '>=4.20.0 <4.21.3'
     name: stable
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -36,6 +40,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.21.2
         replaces: topology-aware-lifecycle-manager.v4.21.1
         skipRange: '>=4.20.0 <4.21.2'
+      # v4.21.3
+      - name: topology-aware-lifecycle-manager.v4.21.3
+        replaces: topology-aware-lifecycle-manager.v4.21.2
+        skipRange: '>=4.20.0 <4.21.3'
     name: "4.21"
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -46,6 +54,9 @@ entries:
   - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:daf1d3642722431ecd9ab38184aa7e3591f7c2e0b1d792d0be2c9032bd18b10c
     schema: olm.bundle
   # v4.21.2 bundle
+  - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:95f1091944f8891df77ece1694c4e9a4e4d3c0b75d6e499e652b131027ca51ba
+    schema: olm.bundle
+  # v4.21.3 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.21.2 → 4.21.3.

Generated by release-automator-konflux.