### PR TITLE
CNF-23549: Upstream release-config version bump — Topology Aware Lifecycle Manager 4.18.4

### DIFF
--- a/.konflux/overlay/release.in.yaml
+++ b/.konflux/overlay/release.in.yaml
@@ -6,6 +6,6 @@ variables:
       Topology Aware Lifecycle Manager is an operator that facilitates
       platform and operator upgrades of group of clusters
   display_name: "Topology Aware Lifecycle Manager"
-  manager_version: "topology-aware-lifecycle-manager.v4.18.4"
+  manager_version: "topology-aware-lifecycle-manager.v4.18.5"
   min_kube_version: "1.31.0"
-  version: "4.18.4"
+  version: "4.18.5"


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.18.4 → 4.18.5.

Generated by release-automator-konflux.