### PR TITLE
CNF-23549: Upstream catalog-template update — Topology Aware Lifecycle Manager 4.18.4

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-18@sha256:1767a41ce9655dd542817fb6418317ac8b0b5f9343e86c0bdee635763b3f8d11
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-18@sha256:cf57eaba19c7cad173c9c67e5d6a153693138cd9f17aa40f353d035cec587f59

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -28,6 +28,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.18.4
         replaces: 'topology-aware-lifecycle-manager.v4.18.3'
         skipRange: '>=4.16.0 <4.18.4'
+      # v4.18.5
+      - name: topology-aware-lifecycle-manager.v4.18.5
+        replaces: topology-aware-lifecycle-manager.v4.18.4
+        skipRange: '>=4.16.0 <4.18.5'
     name: stable
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -52,6 +56,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.18.4
         replaces: 'topology-aware-lifecycle-manager.v4.18.3'
         skipRange: '>=4.16.0 <4.18.4'
+      # v4.18.5
+      - name: topology-aware-lifecycle-manager.v4.18.5
+        replaces: topology-aware-lifecycle-manager.v4.18.4
+        skipRange: '>=4.16.0 <4.18.5'
     name: "4.18"
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -68,6 +76,9 @@ entries:
   - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:60fd48a5ff1bb29d5fdbd68501e9e4cd196081bd55826892b8ee03f70b5dc24c
     schema: olm.bundle
   # v4.18.4 bundle
+  - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:1767a41ce9655dd542817fb6418317ac8b0b5f9343e86c0bdee635763b3f8d11
+    schema: olm.bundle
+  # v4.18.5 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.18.4 → 4.18.5.

Generated by release-automator-konflux.