### PR TITLE
CNF-22867: Upstream catalog-template update — Topology Aware Lifecycle Manager 4.20.2

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-20@sha256:a4f8272fcb49b9e401ca52bfcc171b586fb91adc02dfffebd8379a892b6c206b
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-20@sha256:9668501ff9bed3ac5942251244a390b6448c4dbad1b67c9fef6e2fce68a7cfaa

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -20,6 +20,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.20.2
         replaces: topology-aware-lifecycle-manager.v4.20.1
         skipRange: '>=4.18.0 <4.20.2'
+      # v4.20.3
+      - name: topology-aware-lifecycle-manager.v4.20.3
+        replaces: topology-aware-lifecycle-manager.v4.20.2
+        skipRange: '>=4.18.0 <4.20.3'
     name: stable
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -36,6 +40,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.20.2
         replaces: topology-aware-lifecycle-manager.v4.20.1
         skipRange: '>=4.18.0 <4.20.2'
+      # v4.20.3
+      - name: topology-aware-lifecycle-manager.v4.20.3
+        replaces: topology-aware-lifecycle-manager.v4.20.2
+        skipRange: '>=4.18.0 <4.20.3'
     name: "4.20"
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -46,6 +54,9 @@ entries:
   - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:0de0944af187a414e933532d0b6b9030794ee293948ee13a7632f655e2390a99
     schema: olm.bundle
   # v4.20.2 bundle
+  - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:65d663e7c3a5622b55d70afebb89f28ad78d7e2dc016a473d362fd0d18ec76c7
+    schema: olm.bundle
+    # v4.20.3 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.20.2 → 4.20.3.

Generated by release-automator-konflux.