### PR TITLE
CNF-23857: Upstream catalog-template update — Topology Aware Lifecycle Manager 4.12.11

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-12@sha256:8ac11cf058c57bb274b9b04f3e9bfb666be36dc1463efd43330e85682c6d241f
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-12@sha256:03e4e096e6b7620a229f29074939e3d4ca71fbb4de1bb93f3e2f8a63b8d257eb

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -55,6 +55,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.12.11
         replaces: topology-aware-lifecycle-manager.v4.12.10
         skipRange: '>=4.12.0 <4.12.11'
+      # v4.12.12
+      - name: topology-aware-lifecycle-manager.v4.12.12
+        replaces: topology-aware-lifecycle-manager.v4.12.11
+        skipRange: '>=4.12.0 <4.12.12'
     name: stable
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -106,6 +110,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.12.11
         replaces: topology-aware-lifecycle-manager.v4.12.10
         skipRange: '>=4.12.0 <4.12.11'
+      # v4.12.12
+      - name: topology-aware-lifecycle-manager.v4.12.12
+        replaces: topology-aware-lifecycle-manager.v4.12.11
+        skipRange: '>=4.12.0 <4.12.12'
     name: "4.12"
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -143,6 +151,9 @@ entries:
   - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:e75d4418ee7f040083a35cba0e4b8526127c978ae8eb83da533ae15452f5f3f9
     schema: olm.bundle
   # v4.12.11 bundle
+  - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:e363f2bc216c44c348761857008192dc005978b331cfd145fae3af699d6a2fcd
+    schema: olm.bundle
+    # v4.12.12 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.12.11 → 4.12.12.

Generated by release-automator-konflux.