### PR TITLE
CNF-24477: Upstream release-config version bump — Topology Aware Lifecycle Manager 4.16.9

### DIFF
--- a/.konflux/overlay/release.in.yaml
+++ b/.konflux/overlay/release.in.yaml
@@ -6,6 +6,6 @@ variables:
       Topology Aware Lifecycle Manager is an operator that facilitates
       platform and operator upgrades of group of clusters
   display_name: "Topology Aware Lifecycle Manager"
-  manager_version: "topology-aware-lifecycle-manager.v4.16.9"
+  manager_version: "topology-aware-lifecycle-manager.v4.16.10"
   min_kube_version: "1.29.0"
-  version: "4.16.9"
+  version: "4.16.10"


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.16.9 → 4.16.10.

Generated by release-automator-konflux.