### PR TITLE
CNF-24489: Upstream catalog-template update — Topology Aware Lifecycle Manager 4.21.3

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-21@sha256:9698159364350db7753c317c098ec008d73ab26796a7c400153b1a97607bc8c1
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-21@sha256:46698e42dc096b4b0353419dcfdf9e2655e3eaaa679b4f2b5ba6739363f3adea

--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-21@sha256:46698e42dc096b4b0353419dcfdf9e2655e3eaaa679b4f2b5ba6739363f3adea
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-21@sha256:001e9c17b5fd778ba2e192e39bb223559115a68337d7bd0c0ae2d0ad0534b459

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -24,6 +24,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.21.3
         replaces: topology-aware-lifecycle-manager.v4.21.2
         skipRange: '>=4.20.0 <4.21.3'
+      # v4.21.4
+      - name: topology-aware-lifecycle-manager.v4.21.4
+        replaces: topology-aware-lifecycle-manager.v4.21.3
+        skipRange: '>=4.20.0 <4.21.4'
     name: stable
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -44,6 +48,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.21.3
         replaces: topology-aware-lifecycle-manager.v4.21.2
         skipRange: '>=4.20.0 <4.21.3'
+      # v4.21.4
+      - name: topology-aware-lifecycle-manager.v4.21.4
+        replaces: topology-aware-lifecycle-manager.v4.21.3
+        skipRange: '>=4.20.0 <4.21.4'
     name: "4.21"
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -57,6 +65,9 @@ entries:
   - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:95f1091944f8891df77ece1694c4e9a4e4d3c0b75d6e499e652b131027ca51ba
     schema: olm.bundle
   # v4.21.3 bundle
+  - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:9698159364350db7753c317c098ec008d73ab26796a7c400153b1a97607bc8c1
+    schema: olm.bundle
+    # v4.21.4 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.21.3 → 4.21.4.

Generated by release-automator-konflux.