### PR TITLE
CNF-24477: Upstream catalog-template update — Topology Aware Lifecycle Manager 4.16.9

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-16@sha256:81486a8b42c0ca3c04da434b7eaebc0867bb3042c53cf1ddd509c40bd1bf0b4e
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-16@sha256:1c43b6f6702fae5b4757ad68bb137c4899e8baa40c247b5bbf7b14a2101d4bee

--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-16@sha256:02cce7604a6fddf84f49c368616496484ce2ca65e82bdd702f56f2a047a55f1c
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-16@sha256:81486a8b42c0ca3c04da434b7eaebc0867bb3042c53cf1ddd509c40bd1bf0b4e

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -48,6 +48,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.16.9
         replaces: topology-aware-lifecycle-manager.v4.16.8
         skipRange: '>=4.14.0 <4.16.9'
+      # v4.16.10
+      - name: topology-aware-lifecycle-manager.v4.16.10
+        replaces: topology-aware-lifecycle-manager.v4.16.9
+        skipRange: '>=4.14.0 <4.16.10'
     name: stable
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -92,6 +96,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.16.9
         replaces: topology-aware-lifecycle-manager.v4.16.8
         skipRange: '>=4.14.0 <4.16.9'
+      # v4.16.10
+      - name: topology-aware-lifecycle-manager.v4.16.10
+        replaces: topology-aware-lifecycle-manager.v4.16.9
+        skipRange: '>=4.14.0 <4.16.10'
     name: "4.16"
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -123,6 +131,9 @@ entries:
   - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:3f35194368f8efbe2b8bf9e009510be77ffb31bef2bf8d007195740e1f064777
     schema: olm.bundle
   # v4.16.9 bundle
+  - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:02cce7604a6fddf84f49c368616496484ce2ca65e82bdd702f56f2a047a55f1c
+    schema: olm.bundle
+    # v4.16.10 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.16.9 → 4.16.10.

Generated by release-automator-konflux.