### PR TITLE
CNF-24522: Upstream catalog-template update — Topology Aware Lifecycle Manager 4.18.5

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-18@sha256:35e2e2f29710971172eed716c3653778a64ed45a3bd52e4bd2bb61b2433be678
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-18@sha256:c89f87827e6ea2555cda153a4c92b99841a3101994392598e68627e35c5649bb

--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-18@sha256:c89f87827e6ea2555cda153a4c92b99841a3101994392598e68627e35c5649bb
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-18@sha256:bcd6bca3b978dd1ad767ac9496e802de02f57d3f9f12aaa6589f642e06a363ab

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -32,6 +32,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.18.5
         replaces: topology-aware-lifecycle-manager.v4.18.4
         skipRange: '>=4.16.0 <4.18.5'
+      # v4.18.6
+      - name: topology-aware-lifecycle-manager.v4.18.6
+        replaces: topology-aware-lifecycle-manager.v4.18.5
+        skipRange: '>=4.16.0 <4.18.6'
     name: stable
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -60,6 +64,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.18.5
         replaces: topology-aware-lifecycle-manager.v4.18.4
         skipRange: '>=4.16.0 <4.18.5'
+      # v4.18.6
+      - name: topology-aware-lifecycle-manager.v4.18.6
+        replaces: topology-aware-lifecycle-manager.v4.18.5
+        skipRange: '>=4.16.0 <4.18.6'
     name: "4.18"
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -79,6 +87,9 @@ entries:
   - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:1767a41ce9655dd542817fb6418317ac8b0b5f9343e86c0bdee635763b3f8d11
     schema: olm.bundle
   # v4.18.5 bundle
+  - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:cb7a6f254805352684807efa1bcfc3cc48c6d17fd1f55fb4cf08604fed78e85b
+    schema: olm.bundle
+    # v4.18.6 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.18.5 → 4.18.6.

Generated by release-automator-konflux.