### PR TITLE
CNF-24465: Upstream catalog-template update — Topology Aware Lifecycle Manager 4.19.4

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-19@sha256:40496a2c00b164c66f4b79789eb256377ef483e6957f540c8c4bd17c1c6cf8ad
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-19@sha256:d2efbdf39ec84cd23e894cfeb49af1a05e6e9ba7b20ec0dff5e3ca1b9f563292

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -28,6 +28,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.19.4
         replaces: topology-aware-lifecycle-manager.v4.19.3
         skipRange: '>=4.18.0 <4.19.4'
+      # v4.19.5
+      - name: topology-aware-lifecycle-manager.v4.19.5
+        replaces: topology-aware-lifecycle-manager.v4.19.4
+        skipRange: '>=4.18.0 <4.19.5'
     name: stable
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -52,6 +56,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.19.4
         replaces: topology-aware-lifecycle-manager.v4.19.3
         skipRange: '>=4.18.0 <4.19.4'
+      # v4.19.5
+      - name: topology-aware-lifecycle-manager.v4.19.5
+        replaces: topology-aware-lifecycle-manager.v4.19.4
+        skipRange: '>=4.18.0 <4.19.5'
     name: "4.19"
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -68,6 +76,9 @@ entries:
   - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:2d4ca9fecc4597f6f8bf8895e331dee16350635f22f94c9712773550aca4a0fd
     schema: olm.bundle
   # v4.19.4 bundle
+  - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:6799dd5053c44415a0f4444f2fbf0c741a1affa8691765b4f592d82c669ca3f4
+    schema: olm.bundle
+    # v4.19.5 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.19.4 → 4.19.5.

Generated by release-automator-konflux.