### PR TITLE
CNF-24733: Upstream release-config version bump — Topology Aware Lifecycle Manager 4.20.3

### DIFF
--- a/.konflux/overlay/release.in.yaml
+++ b/.konflux/overlay/release.in.yaml
@@ -6,6 +6,6 @@ variables:
       Topology Aware Lifecycle Manager is an operator that facilitates
       platform and operator upgrades of group of clusters
   display_name: "Topology Aware Lifecycle Manager"
-  manager_version: "topology-aware-lifecycle-manager.v4.20.3"
+  manager_version: "topology-aware-lifecycle-manager.v4.20.4"
   min_kube_version: "1.33.0"
-  version: "4.20.3"
+  version: "4.20.4"


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.20.3 → 4.20.4.

Generated by release-automator-konflux.