### PR TITLE
CNF-24733: Upstream catalog-template update — Topology Aware Lifecycle Manager 4.20.3

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-20@sha256:c36d0c704b2d9c2ae4468d5084d42a3949610934541ae7ed4fce43ab5df495df
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-20@sha256:8de2779d22abad5ea1cf1f2525c840311ca627d501794c7c668f30472505d1f5

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -24,6 +24,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.20.3
         replaces: topology-aware-lifecycle-manager.v4.20.2
         skipRange: '>=4.18.0 <4.20.3'
+      # v4.20.4
+      - name: topology-aware-lifecycle-manager.v4.20.4
+        replaces: topology-aware-lifecycle-manager.v4.20.3
+        skipRange: '>=4.18.0 <4.20.4'
     name: stable
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -44,6 +48,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.20.3
         replaces: topology-aware-lifecycle-manager.v4.20.2
         skipRange: '>=4.18.0 <4.20.3'
+      # v4.20.4
+      - name: topology-aware-lifecycle-manager.v4.20.4
+        replaces: topology-aware-lifecycle-manager.v4.20.3
+        skipRange: '>=4.18.0 <4.20.4'
     name: "4.20"
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -57,6 +65,9 @@ entries:
   - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:65d663e7c3a5622b55d70afebb89f28ad78d7e2dc016a473d362fd0d18ec76c7
     schema: olm.bundle
     # v4.20.3 bundle
+  - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:ee74e07922888fe52655c24b51644e5def85d0d4189f70b1f50e7090e05d34e7
+    schema: olm.bundle
+    # v4.20.4 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.20.3 → 4.20.4.

Generated by release-automator-konflux.