### PR TITLE
CNF-24236: Upstream release-config version bump — Topology Aware Lifecycle Manager 4.22.0

### DIFF
--- a/.konflux/overlay/release.in.yaml
+++ b/.konflux/overlay/release.in.yaml
@@ -6,6 +6,6 @@ variables:
       Topology Aware Lifecycle Manager is an operator that facilitates
       platform and operator upgrades of group of clusters
   display_name: "Topology Aware Lifecycle Manager"
-  manager_version: "topology-aware-lifecycle-manager.v4.22.0"
+  manager_version: "topology-aware-lifecycle-manager.v4.22.1"
   min_kube_version: "1.35.0"
-  version: "4.22.0"
+  version: "4.22.1"


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.22.0 → 4.22.1.

Generated by release-automator-konflux.