### PR TITLE
CNF-24236: Upstream catalog-template update — Topology Aware Lifecycle Manager 4.22.0

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-22@sha256:92fadbc640fba0b1a263dd1e61d11808be6e99f7b2560e426aa1d348f17b64d7
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-22@sha256:96ce8d5312b9216fb7cd48f0d71d834d90db5def69b4b0443eea69b50e737776

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -12,6 +12,10 @@ entries:
       # v4.22.0
       - name: topology-aware-lifecycle-manager.v4.22.0
         skipRange: '>=4.20.0 <4.22.0'
+      # v4.22.1
+      - name: topology-aware-lifecycle-manager.v4.22.1
+        replaces: topology-aware-lifecycle-manager.v4.22.0
+        skipRange: '>=4.20.0 <4.22.1'
     name: stable
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -20,10 +24,17 @@ entries:
       # v4.22.0
       - name: topology-aware-lifecycle-manager.v4.22.0
         skipRange: '>=4.20.0 <4.22.0'
+      # v4.22.1
+      - name: topology-aware-lifecycle-manager.v4.22.1
+        replaces: topology-aware-lifecycle-manager.v4.22.0
+        skipRange: '>=4.20.0 <4.22.1'
     name: "4.22"
     package: topology-aware-lifecycle-manager
     schema: olm.channel
   # v4.22.0 bundle
+  - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:0c7970b4e55113c342a5c13cc74913acf5c26714831fa6511077a81c2cf82b13
+    schema: olm.bundle
+    # v4.22.1 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.22.0 → 4.22.1.

Generated by release-automator-konflux.