### PR TITLE
CNF-24894: Upstream catalog-template update — Topology Aware Lifecycle Manager 4.14.11

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-14@sha256:a9fc55fda9c4455e95ae39d72eadec5c6b82993bb8602a54a9c184c07c89a065
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-14@sha256:e2ae738647ede59030193ec277ed3376d89d7367c35d91ea38d9ac225fca68f0

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -56,6 +56,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.14.11
         replaces: topology-aware-lifecycle-manager.v4.14.10
         skipRange: '>=4.12.0 <4.14.11'
+      # v4.14.12
+      - name: topology-aware-lifecycle-manager.v4.14.12
+        replaces: topology-aware-lifecycle-manager.v4.14.11
+        skipRange: '>=4.12.0 <4.14.12'
     name: stable
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -108,6 +112,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.14.11
         replaces: topology-aware-lifecycle-manager.v4.14.10
         skipRange: '>=4.12.0 <4.14.11'
+      # v4.14.12
+      - name: topology-aware-lifecycle-manager.v4.14.12
+        replaces: topology-aware-lifecycle-manager.v4.14.11
+        skipRange: '>=4.12.0 <4.14.12'
     name: "4.14"
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -145,6 +153,9 @@ entries:
   - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:66523e1417bc11f1c70c981734d6549a24d53534e6f665cae8c6e2d53c356ca9
     schema: olm.bundle
   # v4.14.11 bundle
+  - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:94d0d777f34363e3ddae59e4a2646a2c1f3b404d40be3aab57e0f3960b3995c4
+    schema: olm.bundle
+    # v4.14.12 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.14.11 → 4.14.12.

Generated by release-automator-konflux.