### PR TITLE
Fix skipRange to >=4.22.0 <5.0.0 in catalog template

### DIFF
--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -11,7 +11,7 @@ entries:
   - entries:
       # v5.0.0
       - name: topology-aware-lifecycle-manager.v5.0.0
-        skipRange: '>=4.20.0 <5.0.0'
+        skipRange: '>=4.22.0 <5.0.0'
     name: stable
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -19,7 +19,7 @@ entries:
   - entries:
       # v5.0.0
       - name: topology-aware-lifecycle-manager.v5.0.0
-        skipRange: '>=4.20.0 <5.0.0'
+        skipRange: '>=4.22.0 <5.0.0'
     name: "5.0"
     package: topology-aware-lifecycle-manager
     schema: olm.channel


### PR DESCRIPTION
## Summary
- Fix the `skipRange` in `.konflux/catalog/catalog-template.in.yaml` from `>=4.20.0 <5.0.0` to `>=4.22.0 <5.0.0` for both the `stable` and `5.0` channels.
- 4.22 is the minimum version for upgrading to 5.0.0.


Made with [Cursor](https://cursor.com)