### PR TITLE
CNF-25366: Upstream release-config version bump — Topology Aware Lifecycle Manager 4.12.12

### DIFF
--- a/.konflux/overlay/release.in.yaml
+++ b/.konflux/overlay/release.in.yaml
@@ -6,6 +6,6 @@ variables:
       Topology Aware Lifecycle Manager is an operator that facilitates
       platform and operator upgrades of group of clusters
   display_name: "Topology Aware Lifecycle Manager"
-  manager_version: "topology-aware-lifecycle-manager.v4.12.12"
+  manager_version: "topology-aware-lifecycle-manager.v4.12.13"
   min_kube_version: "1.25.0"
-  version: "4.12.12"
+  version: "4.12.13"


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.12.12 → 4.12.13.

Generated by release-automator-konflux.