### PR TITLE
CNF-25366: Upstream catalog-template update — Topology Aware Lifecycle Manager 4.12.12

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-12@sha256:277bb098b62d5fa4640ca965fcde26f0912a21ac47bd0f6912c1917beb312017
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-4-12@sha256:eafa42ba05e725f93bb5dab94fa5ca28bf5b399ecb973bebce2d80f0a64e47df

--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -59,6 +59,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.12.12
         replaces: topology-aware-lifecycle-manager.v4.12.11
         skipRange: '>=4.12.0 <4.12.12'
+      # v4.12.13
+      - name: topology-aware-lifecycle-manager.v4.12.13
+        replaces: topology-aware-lifecycle-manager.v4.12.12
+        skipRange: '>=4.12.0 <4.12.13'
     name: stable
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -114,6 +118,10 @@ entries:
       - name: topology-aware-lifecycle-manager.v4.12.12
         replaces: topology-aware-lifecycle-manager.v4.12.11
         skipRange: '>=4.12.0 <4.12.12'
+      # v4.12.13
+      - name: topology-aware-lifecycle-manager.v4.12.13
+        replaces: topology-aware-lifecycle-manager.v4.12.12
+        skipRange: '>=4.12.0 <4.12.13'
     name: "4.12"
     package: topology-aware-lifecycle-manager
     schema: olm.channel
@@ -154,6 +162,9 @@ entries:
   - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:e363f2bc216c44c348761857008192dc005978b331cfd145fae3af699d6a2fcd
     schema: olm.bundle
     # v4.12.12 bundle
+  - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:5a377390951aa027e1460b82a4bb45403778ca1e4abbb88cb42dc660bf40198c
+    schema: olm.bundle
+    # v4.12.13 bundle
   # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
   - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
     schema: olm.bundle


### PR DESCRIPTION
Automated post-release update for Topology Aware Lifecycle Manager 4.12.12 → 4.12.13.

Generated by release-automator-konflux.