### PR TITLE
Replace text/template with structured object construction for precache CM

### DIFF
--- a/controllers/managedClusterResources.go
+++ b/controllers/managedClusterResources.go
@@ -72,7 +72,6 @@ type resourceTemplate struct {
 
 var precacheDependenciesCreateTemplates = []resourceTemplate{
 	{"precache-ns-create", templates.MngClusterActCreatePrecachingNS},
-	{"precache-spec-cm-create", templates.MngClusterActCreatePrecachingSpecCM},
 	{"precache-sa-create", templates.MngClusterActCreateServiceAcct},
 	{"precache-crb-create", templates.MngClusterActCreateClusterRoleBinding},
 }

--- a/controllers/managedClusterResources_test.go
+++ b/controllers/managedClusterResources_test.go
@@ -31,46 +31,6 @@ func TestMCR_renderYamlTemplates(t *testing.T) {
 		result       string
 	}{
 		{
-			name:         "create configmap",
-			resourceName: "precache-spec",
-			data: templateData{
-				Cluster:                 "test",
-				ResourceName:            "precache-spec",
-				ExcludePrecachePatterns: []string{"aws", "thanos"},
-				AdditionalImages:        []string{"image1:tag", "image2:tag"},
-				SpaceRequired:           "45",
-			},
-			template: templates.MngClusterActCreatePrecachingSpecCM,
-			result: `
-apiVersion: action.open-cluster-management.io/v1beta1
-kind: ManagedClusterAction
-metadata:
-  name: precache-spec
-  namespace: test
-spec:
-  actionType: Create
-  kube:
-    resource: configmap
-    template:
-      apiVersion: v1
-      data:
-        excludePrecachePatterns: |
-          aws  
-          thanos 
-        additionalImages: |
-          image1:tag 
-          image2:tag 
-        operators.indexes: ""
-        operators.packagesAndChannels: ""
-        platform.image:
-        spaceRequired: "45"
-      kind: ConfigMap
-      metadata:
-        name: pre-cache-spec
-        namespace: openshift-talo-pre-cache
-`,
-		},
-		{
 			name:         "create namespace",
 			resourceName: "test-ns",
 			data: templateData{

--- a/controllers/precache.go
+++ b/controllers/precache.go
@@ -332,9 +332,9 @@ func buildPrecacheSpecConfigMapAction(data templateData) *unstructured.Unstructu
 		"operators.indexes":             strings.Join(data.Operators.Indexes, "\n"),
 		"operators.packagesAndChannels": strings.Join(data.Operators.PackagesAndChannels, "\n"),
 		"excludePrecachePatterns":       strings.Join(data.ExcludePrecachePatterns, "\n"),
-		"additionalImages":             strings.Join(data.AdditionalImages, "\n"),
-		"platform.image":               data.PlatformImage,
-		"spaceRequired":                data.SpaceRequired,
+		"additionalImages":              strings.Join(data.AdditionalImages, "\n"),
+		"platform.image":                data.PlatformImage,
+		"spaceRequired":                 data.SpaceRequired,
 	}
 
 	return &unstructured.Unstructured{

--- a/controllers/precache.go
+++ b/controllers/precache.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift-kni/cluster-group-upgrades-operator/controllers/utils"
 	ranv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/clustergroupupgrades/v1alpha1"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -246,6 +247,16 @@ func (r *ClusterGroupUpgradeReconciler) deployDependencies(
 	if err != nil {
 		return false, err
 	}
+
+	spec.ResourceName = "precache-spec-cm-create"
+	cmAction := buildPrecacheSpecConfigMapAction(*spec)
+	if err := r.Create(ctx, cmAction); err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return false, err
+		}
+		r.Log.Info("[deployDependencies] ConfigMap MCA already exists", "cluster", cluster)
+	}
+
 	spec.ViewUpdateIntervalSec = utils.GetMCVUpdateInterval(len(clusterGroupUpgrade.Status.Precaching.Status))
 	err = r.createResourcesFromTemplates(ctx, spec, precacheDependenciesViewTemplates)
 	if err != nil {
@@ -311,6 +322,46 @@ func (r *ClusterGroupUpgradeReconciler) getPrecacheSpecTemplateData(
 	rv.AdditionalImages = spec.AdditionalImages
 	rv.SpaceRequired = spec.SpaceRequired
 	return rv
+}
+
+// buildPrecacheSpecConfigMapAction constructs the ManagedClusterAction for the
+// pre-cache-spec ConfigMap as a typed Go object instead of rendering a text template,
+// ensuring user-supplied strings are safely embedded as map values.
+func buildPrecacheSpecConfigMapAction(data templateData) *unstructured.Unstructured {
+	cmData := map[string]interface{}{
+		"operators.indexes":             strings.Join(data.Operators.Indexes, "\n"),
+		"operators.packagesAndChannels": strings.Join(data.Operators.PackagesAndChannels, "\n"),
+		"excludePrecachePatterns":       strings.Join(data.ExcludePrecachePatterns, "\n"),
+		"additionalImages":             strings.Join(data.AdditionalImages, "\n"),
+		"platform.image":               data.PlatformImage,
+		"spaceRequired":                data.SpaceRequired,
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "action.open-cluster-management.io/v1beta1",
+			"kind":       "ManagedClusterAction",
+			"metadata": map[string]interface{}{
+				"name":      data.ResourceName,
+				"namespace": data.Cluster,
+			},
+			"spec": map[string]interface{}{
+				"actionType": "Create",
+				"kube": map[string]interface{}{
+					"resource": "configmap",
+					"template": map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]interface{}{
+							"name":      "pre-cache-spec",
+							"namespace": "openshift-talo-pre-cache",
+						},
+						"data": cmData,
+					},
+				},
+			},
+		},
+	}
 }
 
 // includePreCachingConfigs retrieves the PreCachingConfigCR associated to the CGU

--- a/controllers/precache_test.go
+++ b/controllers/precache_test.go
@@ -1,9 +1,15 @@
 package controllers
 
 import (
+	"bytes"
+	"strings"
 	"testing"
+	"text/template"
 
+	"github.com/openshift-kni/cluster-group-upgrades-operator/controllers/templates"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 )
 
 func TestPrecache_parseSpaceRequired(t *testing.T) {
@@ -120,4 +126,232 @@ func TestPrecache_parseSpaceRequired(t *testing.T) {
 			assert.Equal(t, tc.expectedSpaceRequiredGiB, parsedSpaceRequired)
 		})
 	}
+}
+
+func TestPrecache_buildPrecacheSpecConfigMapAction(t *testing.T) {
+	testCases := []struct {
+		name     string
+		data     templateData
+		expected map[string]interface{}
+	}{
+		{
+			name: "basic fields",
+			data: templateData{
+				Cluster:      "spoke1",
+				ResourceName: "precache-spec-cm-create",
+				PlatformImage: "quay.io/openshift-release-dev/ocp-release@sha256:abc123",
+				Operators: operatorsData{
+					Indexes:             []string{"registry.example.com:5000/redhat-operators:v4.11"},
+					PackagesAndChannels: []string{"ptp-operator:4.9", "sriov-network-operator:4.9"},
+				},
+				ExcludePrecachePatterns: []string{"aws", "thanos"},
+				AdditionalImages:        []string{"image1:tag", "image2:tag"},
+				SpaceRequired:           "45",
+			},
+			expected: map[string]interface{}{
+				"operators.indexes":             "registry.example.com:5000/redhat-operators:v4.11",
+				"operators.packagesAndChannels": "ptp-operator:4.9\nsriov-network-operator:4.9",
+				"excludePrecachePatterns":       "aws\nthanos",
+				"additionalImages":             "image1:tag\nimage2:tag",
+				"platform.image":               "quay.io/openshift-release-dev/ocp-release@sha256:abc123",
+				"spaceRequired":                "45",
+			},
+		},
+		{
+			name: "empty arrays produce empty strings",
+			data: templateData{
+				Cluster:       "spoke1",
+				ResourceName:  "precache-spec-cm-create",
+				PlatformImage: "",
+				Operators: operatorsData{
+					Indexes:             []string{},
+					PackagesAndChannels: []string{},
+				},
+				ExcludePrecachePatterns: []string{},
+				AdditionalImages:        []string{},
+				SpaceRequired:           "10",
+			},
+			expected: map[string]interface{}{
+				"operators.indexes":             "",
+				"operators.packagesAndChannels": "",
+				"excludePrecachePatterns":       "",
+				"additionalImages":             "",
+				"platform.image":               "",
+				"spaceRequired":                "10",
+			},
+		},
+		{
+			name: "special characters in input are preserved as string values",
+			data: templateData{
+				Cluster:      "spoke1",
+				ResourceName: "precache-spec-cm-create",
+				Operators: operatorsData{
+					PackagesAndChannels: []string{"operator:4.9\n    extra-key: extra-value"},
+					Indexes:             []string{"# not-a-comment"},
+				},
+				ExcludePrecachePatterns: []string{"pattern\nother: true"},
+				AdditionalImages:        []string{`image:tag", "extra": "field`},
+				SpaceRequired:           "10",
+			},
+			expected: map[string]interface{}{
+				"operators.indexes":             "# not-a-comment",
+				"operators.packagesAndChannels": "operator:4.9\n    extra-key: extra-value",
+				"excludePrecachePatterns":       "pattern\nother: true",
+				"additionalImages":             `image:tag", "extra": "field`,
+				"platform.image":               "",
+				"spaceRequired":                "10",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := buildPrecacheSpecConfigMapAction(tc.data)
+
+			assert.Equal(t, "action.open-cluster-management.io/v1beta1", obj.GetAPIVersion())
+			assert.Equal(t, "ManagedClusterAction", obj.GetKind())
+			assert.Equal(t, tc.data.ResourceName, obj.GetName())
+			assert.Equal(t, tc.data.Cluster, obj.GetNamespace())
+
+			spec, found, err := unstructured.NestedMap(obj.Object, "spec")
+			assert.NoError(t, err)
+			assert.True(t, found)
+			assert.Equal(t, "Create", spec["actionType"])
+
+			kube := spec["kube"].(map[string]interface{})
+			assert.Equal(t, "configmap", kube["resource"])
+
+			tmpl := kube["template"].(map[string]interface{})
+			assert.Equal(t, "v1", tmpl["apiVersion"])
+			assert.Equal(t, "ConfigMap", tmpl["kind"])
+
+			meta := tmpl["metadata"].(map[string]interface{})
+			assert.Equal(t, "pre-cache-spec", meta["name"])
+			assert.Equal(t, "openshift-talo-pre-cache", meta["namespace"])
+
+			cmData := tmpl["data"].(map[string]interface{})
+			for key, expectedValue := range tc.expected {
+				assert.Equal(t, expectedValue, cmData[key], "mismatch for ConfigMap data key %q", key)
+			}
+		})
+	}
+}
+
+func TestPrecache_buildPrecacheSpecConfigMapAction_equivalence(t *testing.T) {
+	// This is the old template that was removed from precache-templates.go.
+	// We keep it here to verify that the new builder produces functionally
+	// equivalent ConfigMap data values for the same inputs.
+	const oldTemplate = `
+{{ template "actionGVK"}}
+{{ template "metadata" . }}
+spec:
+  actionType: Create
+  kube:
+    resource: configmap
+    template:
+      apiVersion: v1
+      data:
+        operators.indexes: |{{ range .Operators.Indexes }}
+          {{ . }} {{ end }}
+        operators.packagesAndChannels: |{{ range .Operators.PackagesAndChannels }} 
+          {{ . }} {{ end }}
+        excludePrecachePatterns: |{{ range .ExcludePrecachePatterns }} 
+          {{ . }} {{ end }}
+        additionalImages: |{{ range .AdditionalImages }}
+          {{ . }} {{ end }}
+        platform.image: {{ .PlatformImage }}
+        spaceRequired: "{{ .SpaceRequired }}"
+      kind: ConfigMap
+      metadata:
+        name: pre-cache-spec
+        namespace: openshift-talo-pre-cache
+`
+
+	data := templateData{
+		Cluster:       "spoke1",
+		ResourceName:  "precache-spec-cm-create",
+		PlatformImage: "quay.io/openshift-release-dev/ocp-release@sha256:abc123",
+		Operators: operatorsData{
+			Indexes: []string{
+				"registry.example.com:5000/redhat-operators:v4.11",
+				"registry.example.com:5000/certified-operators:v4.11",
+				"registry.example.com:5000/community-operators:v4.11",
+			},
+			PackagesAndChannels: []string{
+				"ptp-operator:4.9",
+				"sriov-network-operator:4.9",
+				"performance-addon-operator:4.9",
+				"local-storage-operator:stable",
+				"cluster-logging:stable",
+			},
+		},
+		ExcludePrecachePatterns: []string{"aws", "thanos", "azure", "gcp"},
+		AdditionalImages: []string{
+			"quay.io/example/app1:v1.0",
+			"quay.io/example/app2:v2.0",
+			"quay.io/example/app3@sha256:def456",
+		},
+		SpaceRequired: "45",
+	}
+
+	// Render using the old template
+	w := new(bytes.Buffer)
+	tmpl, err := template.New("old").Parse(templates.CommonTemplates + oldTemplate)
+	assert.NoError(t, err)
+	err = tmpl.Execute(w, data)
+	assert.NoError(t, err)
+
+	oldObj := &unstructured.Unstructured{}
+	dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	_, _, err = dec.Decode(w.Bytes(), nil, oldObj)
+	assert.NoError(t, err)
+
+	// Build using the new builder
+	newObj := buildPrecacheSpecConfigMapAction(data)
+
+	// Extract ConfigMap data from both
+	oldKube := oldObj.Object["spec"].(map[string]interface{})["kube"].(map[string]interface{})
+	oldCMData := oldKube["template"].(map[string]interface{})["data"].(map[string]interface{})
+
+	newKube := newObj.Object["spec"].(map[string]interface{})["kube"].(map[string]interface{})
+	newCMData := newKube["template"].(map[string]interface{})["data"].(map[string]interface{})
+
+	// The old template produces values with trailing whitespace/newlines from the
+	// {{ range }} iteration. Trim both sides before comparing to verify functional
+	// equivalence (the pre-cache workload trims values when reading them).
+	for _, key := range []string{"platform.image", "spaceRequired"} {
+		assert.Equal(t, oldCMData[key], newCMData[key], "scalar field %q differs", key)
+	}
+
+	// For array fields, the old template produces block scalars with leading/trailing
+	// whitespace per element. Compare the trimmed, split lines.
+	arrayKeys := []string{"operators.indexes", "operators.packagesAndChannels", "excludePrecachePatterns", "additionalImages"}
+	for _, key := range arrayKeys {
+		oldVal := strings.TrimSpace(oldCMData[key].(string))
+		newVal := strings.TrimSpace(newCMData[key].(string))
+
+		oldLines := splitAndTrim(oldVal)
+		newLines := splitAndTrim(newVal)
+
+		assert.Equal(t, oldLines, newLines, "array field %q has different elements", key)
+	}
+
+	// Verify structural equivalence of the MCA envelope
+	assert.Equal(t, oldObj.GetAPIVersion(), newObj.GetAPIVersion())
+	assert.Equal(t, oldObj.GetKind(), newObj.GetKind())
+	assert.Equal(t, oldObj.GetName(), newObj.GetName())
+	assert.Equal(t, oldObj.GetNamespace(), newObj.GetNamespace())
+	assert.Equal(t, oldKube["resource"], newKube["resource"])
+}
+
+func splitAndTrim(s string) []string {
+	parts := strings.Split(s, "\n")
+	var result []string
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }

--- a/controllers/precache_test.go
+++ b/controllers/precache_test.go
@@ -137,8 +137,8 @@ func TestPrecache_buildPrecacheSpecConfigMapAction(t *testing.T) {
 		{
 			name: "basic fields",
 			data: templateData{
-				Cluster:      "spoke1",
-				ResourceName: "precache-spec-cm-create",
+				Cluster:       "spoke1",
+				ResourceName:  "precache-spec-cm-create",
 				PlatformImage: "quay.io/openshift-release-dev/ocp-release@sha256:abc123",
 				Operators: operatorsData{
 					Indexes:             []string{"registry.example.com:5000/redhat-operators:v4.11"},
@@ -152,9 +152,9 @@ func TestPrecache_buildPrecacheSpecConfigMapAction(t *testing.T) {
 				"operators.indexes":             "registry.example.com:5000/redhat-operators:v4.11",
 				"operators.packagesAndChannels": "ptp-operator:4.9\nsriov-network-operator:4.9",
 				"excludePrecachePatterns":       "aws\nthanos",
-				"additionalImages":             "image1:tag\nimage2:tag",
-				"platform.image":               "quay.io/openshift-release-dev/ocp-release@sha256:abc123",
-				"spaceRequired":                "45",
+				"additionalImages":              "image1:tag\nimage2:tag",
+				"platform.image":                "quay.io/openshift-release-dev/ocp-release@sha256:abc123",
+				"spaceRequired":                 "45",
 			},
 		},
 		{
@@ -175,9 +175,9 @@ func TestPrecache_buildPrecacheSpecConfigMapAction(t *testing.T) {
 				"operators.indexes":             "",
 				"operators.packagesAndChannels": "",
 				"excludePrecachePatterns":       "",
-				"additionalImages":             "",
-				"platform.image":               "",
-				"spaceRequired":                "10",
+				"additionalImages":              "",
+				"platform.image":                "",
+				"spaceRequired":                 "10",
 			},
 		},
 		{
@@ -197,9 +197,9 @@ func TestPrecache_buildPrecacheSpecConfigMapAction(t *testing.T) {
 				"operators.indexes":             "# not-a-comment",
 				"operators.packagesAndChannels": "operator:4.9\n    extra-key: extra-value",
 				"excludePrecachePatterns":       "pattern\nother: true",
-				"additionalImages":             `image:tag", "extra": "field`,
-				"platform.image":               "",
-				"spaceRequired":                "10",
+				"additionalImages":              `image:tag", "extra": "field`,
+				"platform.image":                "",
+				"spaceRequired":                 "10",
 			},
 		},
 	}

--- a/controllers/templates/precache-templates.go
+++ b/controllers/templates/precache-templates.go
@@ -40,33 +40,6 @@ spec:
           workload.openshift.io/allowed: management
 `
 
-// MngClusterActCreatePrecachingSpecCM creates precachingSpec configmap
-const MngClusterActCreatePrecachingSpecCM string = `
-{{ template "actionGVK"}}
-{{ template "metadata" . }}
-spec:
-  actionType: Create
-  kube:
-    resource: configmap
-    template:
-      apiVersion: v1
-      data:
-        operators.indexes: |{{ range .Operators.Indexes }}
-          {{ . }} {{ end }}
-        operators.packagesAndChannels: |{{ range .Operators.PackagesAndChannels }} 
-          {{ . }} {{ end }}
-        excludePrecachePatterns: |{{ range .ExcludePrecachePatterns }} 
-          {{ . }} {{ end }}
-        additionalImages: |{{ range .AdditionalImages }}
-          {{ . }} {{ end }}
-        platform.image: {{ .PlatformImage }}
-        spaceRequired: "{{ .SpaceRequired }}"
-      kind: ConfigMap
-      metadata:
-        name: pre-cache-spec
-        namespace: openshift-talo-pre-cache
-`
-
 // MngClusterActCreateServiceAcct creates serviceaccount
 const MngClusterActCreateServiceAcct string = `
 {{ template "actionGVK"}}

--- a/tests/kuttl/cgu/pre-caching-complete/01-assert.yaml
+++ b/tests/kuttl/cgu/pre-caching-complete/01-assert.yaml
@@ -153,12 +153,15 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
-          \  \nperformance-addon-operator:4.9 \n"
-        platform.image: null
-        spaceRequired: '35'
+        additionalImages: ""
+        excludePrecachePatterns: ""
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          ptp-operator:4.9
+          sriov-network-operator:4.9
+          performance-addon-operator:4.9
+        platform.image: ""
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -234,12 +237,15 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
-          \  \nperformance-addon-operator:4.9 \n"
-        platform.image: null
-        spaceRequired: '35'
+        additionalImages: ""
+        excludePrecachePatterns: ""
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          ptp-operator:4.9
+          sriov-network-operator:4.9
+          performance-addon-operator:4.9
+        platform.image: ""
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -315,12 +321,15 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
-          \  \nperformance-addon-operator:4.9 \n"
-        platform.image: null
-        spaceRequired: '35'
+        additionalImages: ""
+        excludePrecachePatterns: ""
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          ptp-operator:4.9
+          sriov-network-operator:4.9
+          performance-addon-operator:4.9
+        platform.image: ""
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -396,12 +405,15 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
-          \  \nperformance-addon-operator:4.9 \n"
-        platform.image: null
-        spaceRequired: '35'
+        additionalImages: ""
+        excludePrecachePatterns: ""
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          ptp-operator:4.9
+          sriov-network-operator:4.9
+          performance-addon-operator:4.9
+        platform.image: ""
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec

--- a/tests/kuttl/cgu/pre-caching-partial-complete/01-assert.yaml
+++ b/tests/kuttl/cgu/pre-caching-partial-complete/01-assert.yaml
@@ -152,11 +152,15 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
-          \  \nperformance-addon-operator:4.9 \n"
-        platform.image: null
+        additionalImages: ""
+        excludePrecachePatterns: ""
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          ptp-operator:4.9
+          sriov-network-operator:4.9
+          performance-addon-operator:4.9
+        platform.image: ""
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -232,11 +236,15 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
-          \  \nperformance-addon-operator:4.9 \n"
-        platform.image: null
+        additionalImages: ""
+        excludePrecachePatterns: ""
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          ptp-operator:4.9
+          sriov-network-operator:4.9
+          performance-addon-operator:4.9
+        platform.image: ""
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -312,11 +320,15 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
-          \  \nperformance-addon-operator:4.9 \n"
-        platform.image: null
+        additionalImages: ""
+        excludePrecachePatterns: ""
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          ptp-operator:4.9
+          sriov-network-operator:4.9
+          performance-addon-operator:4.9
+        platform.image: ""
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -392,11 +404,15 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
-          \  \nperformance-addon-operator:4.9 \n"
-        platform.image: null
+        additionalImages: ""
+        excludePrecachePatterns: ""
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          ptp-operator:4.9
+          sriov-network-operator:4.9
+          performance-addon-operator:4.9
+        platform.image: ""
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec

--- a/tests/kuttl/cgu/pre-caching-with-configs/02-assert.yaml
+++ b/tests/kuttl/cgu/pre-caching-with-configs/02-assert.yaml
@@ -165,13 +165,18 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable\
-          \  \nsriov-network-operator:stable \n"
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          performance-addon-operator:stable
+          ptp-operator:stable
+          sriov-network-operator:stable
         platform.image: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
-        excludePrecachePatterns: "aws  \nazure \n"
-        additionalImages: "image1:latest \nimage2:latest \n"
+        excludePrecachePatterns: |-
+          aws
+          azure
+        additionalImages: |-
+          image1:latest
+          image2:latest
         spaceRequired: '40'
       kind: ConfigMap
       metadata:
@@ -248,13 +253,18 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable\
-          \  \nsriov-network-operator:stable \n"
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          performance-addon-operator:stable
+          ptp-operator:stable
+          sriov-network-operator:stable
         platform.image: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
-        excludePrecachePatterns: "aws  \nazure \n"
-        additionalImages: "image1:latest \nimage2:latest \n"
+        excludePrecachePatterns: |-
+          aws
+          azure
+        additionalImages: |-
+          image1:latest
+          image2:latest
         spaceRequired: '40'
       kind: ConfigMap
       metadata:
@@ -331,13 +341,18 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable\
-          \  \nsriov-network-operator:stable \n"
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          performance-addon-operator:stable
+          ptp-operator:stable
+          sriov-network-operator:stable
         platform.image: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
-        excludePrecachePatterns: "aws  \nazure \n"
-        additionalImages: "image1:latest \nimage2:latest \n"
+        excludePrecachePatterns: |-
+          aws
+          azure
+        additionalImages: |-
+          image1:latest
+          image2:latest
         spaceRequired: '40'
       kind: ConfigMap
       metadata:
@@ -414,13 +429,18 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable\
-          \  \nsriov-network-operator:stable \n"
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          performance-addon-operator:stable
+          ptp-operator:stable
+          sriov-network-operator:stable
         platform.image: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
-        excludePrecachePatterns: "aws  \nazure \n"
-        additionalImages: "image1:latest \nimage2:latest \n"
+        excludePrecachePatterns: |-
+          aws
+          azure
+        additionalImages: |-
+          image1:latest
+          image2:latest
         spaceRequired: '40'
       kind: ConfigMap
       metadata:


### PR DESCRIPTION
Replace the MngClusterActCreatePrecachingSpecCM text template with a buildPrecacheSpecConfigMapAction() function that constructs the ManagedClusterAction as a structured Go object. User-supplied values are assigned as map entries rather than interpolated into raw YAML, making the construction more robust when inputs contain special characters.