### PR TITLE
Update opm image tag to 5.0

### DIFF
--- a/.konflux/Dockerfile.catalog
+++ b/.konflux/Dockerfile.catalog
@@ -1,5 +1,6 @@
 # The opm image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-ARG OPM_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22
+ARG OPM_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v5.0
+
 # CNF-18555: When there is a Konflux build available for this then we need to update from the brew image
 ARG BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26
 

--- a/.konflux/container_build_args.conf
+++ b/.konflux/container_build_args.conf
@@ -7,11 +7,6 @@ KONFLUX=true
 BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26@sha256:6d42a4dd2c245c6f6417f3d3f95692128b2183377c392d7bd12b1f0d55bd5495
 #
 
-# The opm image is used to serve the FBC
-# There is a metadata processing bug preventing us from pinning this particular image for now
-# OPM_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22@sha256:ae8e121e6cd4da6af2ed85307771470cd65f5fcecb0fd5f04aae9fe931506c6b#
-#
-
 # The runtime image is used to run the binaries
 RUNTIME_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:463cae32c6f6f5594b11a5c22de275016bd8545ce58a6373388e8b24f13fc15c
 #


### PR DESCRIPTION
- Should be 5.0 now as 4.22 is causing fbc pruning errors