### PR TITLE
[release-4.20] Deprecate unused PreCachingConfig override fields

### DIFF
--- a/bundle/manifests/ran.openshift.io_precachingconfigs.yaml
+++ b/bundle/manifests/ran.openshift.io_precachingconfigs.yaml
@@ -55,8 +55,9 @@ spec:
                   values derived by TALM.
                 properties:
                   operatorsIndexes:
-                    description: Override the pre-cached OLM index images derived
-                      by TALM (list of image pull specs)
+                    description: |-
+                      Deprecated: OperatorsIndexes is no longer used by the controller and will be removed in a future release.
+                      OLM index images are now derived automatically from policy-referenced CatalogSource objects.
                     items:
                       type: string
                     type: array
@@ -67,13 +68,15 @@ spec:
                       type: string
                     type: array
                   platformImage:
-                    description: Override the pre-cached OpenShift platform image
-                      derived by TALM
+                    description: |-
+                      Deprecated: PlatformImage is no longer used by the controller and will be removed in a future release.
+                      The platform image is now always derived from the ClusterVersion object in the managed policies.
                     type: string
                   preCacheImage:
                     description: |-
-                      Override the pre-caching workload image pull spec - typically derived by TALM from the operator
-                      ClusterServiceVersion (csv) object.
+                      Deprecated: PreCacheImage is no longer used by the controller and will be removed in a future release.
+                      The pre-caching workload image is now always derived from the PRECACHE_IMG environment variable
+                      set via the operator CSV relatedImages.
                     type: string
                 type: object
               spaceRequired:

--- a/config/crd/bases/ran.openshift.io_precachingconfigs.yaml
+++ b/config/crd/bases/ran.openshift.io_precachingconfigs.yaml
@@ -55,8 +55,9 @@ spec:
                   values derived by TALM.
                 properties:
                   operatorsIndexes:
-                    description: Override the pre-cached OLM index images derived
-                      by TALM (list of image pull specs)
+                    description: |-
+                      Deprecated: OperatorsIndexes is no longer used by the controller and will be removed in a future release.
+                      OLM index images are now derived automatically from policy-referenced CatalogSource objects.
                     items:
                       type: string
                     type: array
@@ -67,13 +68,15 @@ spec:
                       type: string
                     type: array
                   platformImage:
-                    description: Override the pre-cached OpenShift platform image
-                      derived by TALM
+                    description: |-
+                      Deprecated: PlatformImage is no longer used by the controller and will be removed in a future release.
+                      The platform image is now always derived from the ClusterVersion object in the managed policies.
                     type: string
                   preCacheImage:
                     description: |-
-                      Override the pre-caching workload image pull spec - typically derived by TALM from the operator
-                      ClusterServiceVersion (csv) object.
+                      Deprecated: PreCacheImage is no longer used by the controller and will be removed in a future release.
+                      The pre-caching workload image is now always derived from the PRECACHE_IMG environment variable
+                      set via the operator CSV relatedImages.
                     type: string
                 type: object
               spaceRequired:

--- a/controllers/managedClusterResources.go
+++ b/controllers/managedClusterResources.go
@@ -622,7 +622,6 @@ func (r *ClusterGroupUpgradeReconciler) checkDependencies(
 //
 //	error
 func (r *ClusterGroupUpgradeReconciler) getPrecacheJobTemplateData(
-	ctx context.Context,
 	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, clusterName string) (
 	*templateData, error) {
 
@@ -631,7 +630,7 @@ func (r *ClusterGroupUpgradeReconciler) getPrecacheJobTemplateData(
 	rv.Cluster = clusterName
 	rv.JobTimeout = uint64(
 		clusterGroupUpgrade.Spec.RemediationStrategy.Timeout) * 60
-	image, err := r.getPrecacheImagePullSpec(ctx, clusterGroupUpgrade)
+	image, err := r.getPrecacheImagePullSpec()
 	if err != nil {
 		return rv, err
 	}
@@ -673,7 +672,7 @@ func (r *ClusterGroupUpgradeReconciler) deployWorkload(
 	var err error
 	switch workloadType {
 	case precache:
-		spec, err = r.getPrecacheJobTemplateData(ctx, clusterGroupUpgrade, cluster)
+		spec, err = r.getPrecacheJobTemplateData(clusterGroupUpgrade, cluster)
 		if err != nil {
 			return err
 		}

--- a/controllers/preCachingConfig.go
+++ b/controllers/preCachingConfig.go
@@ -62,8 +62,6 @@ func (r *ClusterGroupUpgradeReconciler) mapPreCachingConfigSpecToPrecachingSpec(
 
 	// Extract overrides if defined
 	if !reflect.DeepEqual(preCachingConfigSpec.Overrides, ranv1alpha1.PlatformPreCachingSpec{}) {
-		precachingSpec.PlatformImage = preCachingConfigSpec.Overrides.PlatformImage
-		precachingSpec.OperatorsIndexes = preCachingConfigSpec.Overrides.OperatorsIndexes
 		precachingSpec.OperatorsPackagesAndChannels = preCachingConfigSpec.Overrides.OperatorsPackagesAndChannels
 	}
 

--- a/controllers/preCachingConfig_test.go
+++ b/controllers/preCachingConfig_test.go
@@ -13,9 +13,6 @@ import (
 )
 
 func TestPreCachingConfig_getPreCachingConfigSpec(t *testing.T) {
-	preCacheImage := "precache-workload-override:v:0.0"
-	platformImage := "test-platform-image:test-tag"
-	operatorsIndexes := []string{"registry.example.com:5000/test-index:v0.0"}
 	operatorsPackagesAndChannels := []string{
 		"local-storage-operator: stable",
 		"performance-addon-operator: 4.9",
@@ -37,10 +34,7 @@ func TestPreCachingConfig_getPreCachingConfigSpec(t *testing.T) {
 			cguConfigNamespace: "test",
 			inputPreCachingConfigSpec: ranv1alpha1.PreCachingConfigSpec{
 				Overrides: ranv1alpha1.PlatformPreCachingSpec{
-					PlatformImage:                platformImage,
-					OperatorsIndexes:             operatorsIndexes,
 					OperatorsPackagesAndChannels: operatorsPackagesAndChannels,
-					PreCacheImage:                preCacheImage,
 				},
 				SpaceRequired:           "15 GiB",
 				AdditionalImages:        []string{"image1:tag", "image2:tag"},
@@ -48,10 +42,7 @@ func TestPreCachingConfig_getPreCachingConfigSpec(t *testing.T) {
 			},
 			expectedPreCachingConfigSpec: ranv1alpha1.PreCachingConfigSpec{
 				Overrides: ranv1alpha1.PlatformPreCachingSpec{
-					PlatformImage:                platformImage,
-					OperatorsIndexes:             operatorsIndexes,
 					OperatorsPackagesAndChannels: operatorsPackagesAndChannels,
-					PreCacheImage:                preCacheImage,
 				},
 				SpaceRequired:           "15 GiB",
 				AdditionalImages:        []string{"image1:tag", "image2:tag"},
@@ -66,8 +57,6 @@ func TestPreCachingConfig_getPreCachingConfigSpec(t *testing.T) {
 			cguConfigNamespace: "test",
 			inputPreCachingConfigSpec: ranv1alpha1.PreCachingConfigSpec{
 				Overrides: ranv1alpha1.PlatformPreCachingSpec{
-					PlatformImage:                platformImage,
-					OperatorsIndexes:             operatorsIndexes,
 					OperatorsPackagesAndChannels: operatorsPackagesAndChannels,
 				},
 				SpaceRequired:           "15 GiB",
@@ -145,8 +134,8 @@ func TestPreCachingConfig_mapPreCachingConfigSpecToPrecachingSpec(t *testing.T) 
 				ExcludePrecachePatterns: []string{"aws", "azure"},
 			},
 			expectedPrecachingSpec: &ranv1alpha1.PrecachingSpec{
-				PlatformImage:    "test-platform-image:test-tag",
-				OperatorsIndexes: []string{"registry.example.com:5000/test-index:v0.0"},
+				PlatformImage:    "",
+				OperatorsIndexes: []string(nil),
 				OperatorsPackagesAndChannels: []string{
 					"local-storage-operator: stable",
 					"performance-addon-operator: 4.9",
@@ -171,8 +160,8 @@ func TestPreCachingConfig_mapPreCachingConfigSpecToPrecachingSpec(t *testing.T) 
 				},
 			},
 			expectedPrecachingSpec: &ranv1alpha1.PrecachingSpec{
-				PlatformImage:    "test-platform-image:test-tag",
-				OperatorsIndexes: []string{"registry.example.com:5000/test-index:v0.0"},
+				PlatformImage:    "",
+				OperatorsIndexes: []string(nil),
 				OperatorsPackagesAndChannels: []string{
 					"local-storage-operator: stable",
 					"performance-addon-operator: 4.9",

--- a/controllers/precache.go
+++ b/controllers/precache.go
@@ -256,35 +256,13 @@ func (r *ClusterGroupUpgradeReconciler) deployDependencies(
 // returns: image - pull spec string
 //
 //	error
-func (r *ClusterGroupUpgradeReconciler) getPrecacheImagePullSpec(
-	ctx context.Context,
-	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) (
-	string, error) {
+func (r *ClusterGroupUpgradeReconciler) getPrecacheImagePullSpec() (string, error) {
 
-	preCachingConfigSpec, err := r.getPreCachingConfigSpec(ctx, clusterGroupUpgrade)
-	if err != nil {
-		r.Log.Error(err, "getPreCachingConfigSpec failed ")
-		return "", err
-	}
-
-	preCacheImage := preCachingConfigSpec.Overrides.PreCacheImage
+	preCacheImage := os.Getenv("PRECACHE_IMG")
+	r.Log.Info("[getPrecacheImagePullSpec]", "workload image", preCacheImage)
 	if preCacheImage == "" {
-		overrides, err := r.getOverrides(ctx, clusterGroupUpgrade)
-		if err != nil {
-			r.Log.Error(err, "getOverrides failed ")
-			return "", err
-		}
-		preCacheImage = overrides["precache.image"]
-		if preCacheImage == "" {
-			preCacheImage = os.Getenv("PRECACHE_IMG")
-			r.Log.Info("[getPrecacheImagePullSpec]", "workload image", preCacheImage)
-			if preCacheImage == "" {
-				return "", fmt.Errorf(
-					"can't find pre-caching image pull spec in environment or overrides")
-			}
-		} else {
-			r.Log.Info(getDeprecationMessage("precache.image"))
-		}
+		return "", fmt.Errorf(
+			"PRECACHE_IMG environment variable is not set")
 	}
 	return preCacheImage, nil
 }
@@ -347,29 +325,14 @@ func (r *ClusterGroupUpgradeReconciler) includePreCachingConfigs(
 		return *rv, err
 	}
 
-	// Support specifying overrides via ConfigMap (if PreCachingConfig fields are not specified)
 	overrides, err := r.getOverrides(ctx, clusterGroupUpgrade)
 	if err != nil {
 		return *rv, err
 	}
 
-	// Check the OpenShift platform image
-	platformImage := preCachingConfigSpec.Overrides.PlatformImage
-	if platformImage == "" {
-		overrideField := "platform.image"
-		platformImage = overrides[overrideField]
-		if platformImage == "" {
-			platformImage = spec.PlatformImage
-		} else {
-			r.Log.Info(getDeprecationMessage(overrideField))
-		}
-	}
-	rv.PlatformImage = platformImage
+	// Platform image: always use TALM-derived value (CR and ConfigMap overrides are deprecated)
+	rv.PlatformImage = spec.PlatformImage
 
-	// Define re-usable function to extract pre-caching config from the following sources (in order of precedence):
-	// 1) PreCachingConfig CR,
-	// 2) cluster-group-upgrade-overrides ConfigMap (log deprecation message if this source is used),
-	// 3) spec.<field> (value derived by TALM)
 	extractConfig := func(preCachingConfigCRValue []string, overrideField string, talmDerivedValue []string) []string {
 		if len(preCachingConfigCRValue) == 0 {
 			extractedOverrides := strings.Split(overrides[overrideField], "\n")
@@ -377,7 +340,6 @@ func (r *ClusterGroupUpgradeReconciler) includePreCachingConfigs(
 				return talmDerivedValue
 			}
 			r.Log.Info(getDeprecationMessage(overrideField))
-			// Remove empty strings as a consequence of strings.Split
 			var filteredResult []string
 			for _, value := range extractedOverrides {
 				if value != "" {
@@ -389,22 +351,21 @@ func (r *ClusterGroupUpgradeReconciler) includePreCachingConfigs(
 		return preCachingConfigCRValue
 	}
 
-	// Extract the operator indexes
-	rv.OperatorsIndexes = extractConfig(preCachingConfigSpec.Overrides.OperatorsIndexes,
-		"operators.indexes", spec.OperatorsIndexes)
+	// Operator indexes: always use TALM-derived value (CR and ConfigMap overrides are deprecated)
+	rv.OperatorsIndexes = spec.OperatorsIndexes
 
-	// Extract the operator packages and channels
+	// Operator packages and channels: CR override > ConfigMap override > TALM-derived
 	rv.OperatorsPackagesAndChannels = extractConfig(preCachingConfigSpec.Overrides.OperatorsPackagesAndChannels,
 		"operators.packagesAndChannels", spec.OperatorsPackagesAndChannels)
 
-	// Extract the pre-cache exclusion patterns
+	// Exclude patterns: CR value > ConfigMap override > empty
 	rv.ExcludePrecachePatterns = extractConfig(preCachingConfigSpec.ExcludePrecachePatterns,
 		"excludePrecachePatterns", []string{})
 
-	// Retrieve additional user images
+	// Additional user images from the PreCachingConfig CR
 	rv.AdditionalImages = preCachingConfigSpec.AdditionalImages
 
-	// Extract the space required for pre-caching
+	// Space required: CR value > ConfigMap override > default
 	spaceRequired := preCachingConfigSpec.SpaceRequired
 	if spaceRequired == "" {
 		overrideField := "precache.spaceRequired"

--- a/deploy/upgrades/pre-caching/pre-caching-config-cr.yaml
+++ b/deploy/upgrades/pre-caching/pre-caching-config-cr.yaml
@@ -6,9 +6,7 @@ metadata:
   annotations:
     cluster-group-upgrades-operator/name-suffix: kuttl      
 spec:
-  overrides:
-    preCacheImage: quay.io/test_images/pre-cache:latest
-    platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
+  overrides: {}
   additionalImages:
     - image1:latest
     - image2:latest

--- a/deploy/upgrades/pre-caching/pre-caching-with-configs.yaml
+++ b/deploy/upgrades/pre-caching/pre-caching-with-configs.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   managedPolicies:
     - policy0-common-config-policy
+    - policy1-common-cluster-version-policy
     - policy2-common-pao-sub-policy
     - policy3-common-ptp-sub-policy
     - policy4-common-sriov-sub-policy

--- a/pkg/api/clustergroupupgrades/v1alpha1/types.go
+++ b/pkg/api/clustergroupupgrades/v1alpha1/types.go
@@ -359,14 +359,17 @@ type ClusterGroupUpgradeList struct {
 
 // PlatformPreCachingSpec modify the default pre-caching behavior and values derived by TALM.
 type PlatformPreCachingSpec struct {
-	// Override the pre-cached OpenShift platform image derived by TALM
+	// Deprecated: PlatformImage is no longer used by the controller and will be removed in a future release.
+	// The platform image is now always derived from the ClusterVersion object in the managed policies.
 	PlatformImage string `json:"platformImage,omitempty"`
-	// Override the pre-cached OLM index images derived by TALM (list of image pull specs)
+	// Deprecated: OperatorsIndexes is no longer used by the controller and will be removed in a future release.
+	// OLM index images are now derived automatically from policy-referenced CatalogSource objects.
 	OperatorsIndexes []string `json:"operatorsIndexes,omitempty"`
 	// Override the pre-cached operator packages and channels derived by TALM (list of <package:channel> string entries)
 	OperatorsPackagesAndChannels []string `json:"operatorsPackagesAndChannels,omitempty"`
-	// Override the pre-caching workload image pull spec - typically derived by TALM from the operator
-	// ClusterServiceVersion (csv) object.
+	// Deprecated: PreCacheImage is no longer used by the controller and will be removed in a future release.
+	// The pre-caching workload image is now always derived from the PRECACHE_IMG environment variable
+	// set via the operator CSV relatedImages.
 	PreCacheImage string `json:"preCacheImage,omitempty"`
 }
 

--- a/tests/kuttl/cgu/pre-caching-with-configs/00-assert.yaml
+++ b/tests/kuttl/cgu/pre-caching-with-configs/00-assert.yaml
@@ -16,6 +16,7 @@ spec:
     namespace: default
   managedPolicies:
   - policy0-common-config-policy
+  - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   - policy3-common-ptp-sub-policy
   - policy4-common-sriov-sub-policy
@@ -40,6 +41,7 @@ status:
     type: PrecacheSpecValid
   managedPoliciesCompliantBeforeUpgrade:
   - policy0-common-config-policy
+  - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   managedPoliciesContent:
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'

--- a/tests/kuttl/cgu/pre-caching-with-configs/00-setup-with-pre-caching-config-missing.yaml
+++ b/tests/kuttl/cgu/pre-caching-with-configs/00-setup-with-pre-caching-config-missing.yaml
@@ -5,6 +5,8 @@ commands:
   # Create all the managed inform policies
   - command: oc apply -f ../../../../deploy/acm/policies/all_policies/policy0-common-config-policy.yaml
     namespaced: true
+  - command: oc apply -f ../../../../deploy/acm/policies/all_policies/policy1-common-cluster-version-policy.yaml
+    namespaced: true
   - command: oc apply -f ../../../../deploy/acm/policies/all_policies/policy2-common-pao-sub-policy.yaml
     namespaced: true
   - command: oc apply -f ../../../../deploy/acm/policies/all_policies/policy3-common-ptp-sub-policy.yaml
@@ -16,12 +18,29 @@ commands:
   - command: ../../../../deploy/upgrades/pre-caching/patch-policies-status.sh default default default default
     ignoreFailure: false
 
+  # Patch policy1 (ClusterVersion) as Compliant for all spokes
+  - command: >
+      curl -k -s -X PATCH -H "Accept: application/json, */*"
+      -H "Content-Type: application/merge-patch+json"
+      http://localhost:8001/apis/policy.open-cluster-management.io/v1/namespaces/default/policies/policy1-common-cluster-version-policy/status
+      --data '{"status":{"compliant":"Compliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"Compliant"},{"clustername":"spoke2","clusternamespace":"spoke2","compliant":"Compliant"},{"clustername":"spoke5","clusternamespace":"spoke5","compliant":"Compliant"},{"clustername":"spoke6","clusternamespace":"spoke6","compliant":"Compliant"}]}}'
+    ignoreFailure: false
+
   # Create all the child policies to map the inform policies above.
   - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy0-common-config-policy.yaml
     namespaced: true
   - command: oc apply --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy0-common-config-policy.yaml
     namespaced: true
   - command: oc apply --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy0-common-config-policy.yaml
+    namespaced: true
+
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke5 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
     namespaced: true
 
   - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml

--- a/tests/kuttl/cgu/pre-caching-with-configs/01-assert.yaml
+++ b/tests/kuttl/cgu/pre-caching-with-configs/01-assert.yaml
@@ -16,6 +16,7 @@ spec:
     namespace: default
   managedPolicies:
   - policy0-common-config-policy
+  - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   - policy3-common-ptp-sub-policy
   - policy4-common-sriov-sub-policy
@@ -43,6 +44,7 @@ status:
     type: PrecachingSuceeded
   managedPoliciesCompliantBeforeUpgrade:
   - policy0-common-config-policy
+  - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   managedPoliciesContent:
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'
@@ -63,7 +65,7 @@ status:
   - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   precaching:
     spec:
-      platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
+      platformImage: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
       operatorsIndexes:
       - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
       operatorsPackagesAndChannels:
@@ -97,9 +99,7 @@ metadata:
   name: pre-caching-config
   namespace: default
 spec:
-  overrides:
-    platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
-    preCacheImage: quay.io/test_images/pre-cache:latest
+  overrides: {}
   additionalImages:
   - image1:latest
   - image2:latest

--- a/tests/kuttl/cgu/pre-caching-with-configs/02-assert.yaml
+++ b/tests/kuttl/cgu/pre-caching-with-configs/02-assert.yaml
@@ -13,6 +13,7 @@ spec:
   enable: false
   managedPolicies:
   - policy0-common-config-policy
+  - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   - policy3-common-ptp-sub-policy
   - policy4-common-sriov-sub-policy
@@ -44,6 +45,7 @@ status:
     type: PrecachingSuceeded
   managedPoliciesCompliantBeforeUpgrade:
   - policy0-common-config-policy
+  - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   managedPoliciesContent:
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'
@@ -64,7 +66,7 @@ status:
   - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   precaching:
     spec:
-      platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
+      platformImage: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
       operatorsIndexes:
       - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
       operatorsPackagesAndChannels:
@@ -167,7 +169,7 @@ spec:
           \ \n"
         operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable\
           \  \nsriov-network-operator:stable \n"
-        platform.image: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
+        platform.image: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
         excludePrecachePatterns: "aws  \nazure \n"
         additionalImages: "image1:latest \nimage2:latest \n"
         spaceRequired: '40'
@@ -250,7 +252,7 @@ spec:
           \ \n"
         operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable\
           \  \nsriov-network-operator:stable \n"
-        platform.image: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
+        platform.image: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
         excludePrecachePatterns: "aws  \nazure \n"
         additionalImages: "image1:latest \nimage2:latest \n"
         spaceRequired: '40'
@@ -333,7 +335,7 @@ spec:
           \ \n"
         operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable\
           \  \nsriov-network-operator:stable \n"
-        platform.image: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
+        platform.image: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
         excludePrecachePatterns: "aws  \nazure \n"
         additionalImages: "image1:latest \nimage2:latest \n"
         spaceRequired: '40'
@@ -416,7 +418,7 @@ spec:
           \ \n"
         operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable\
           \  \nsriov-network-operator:stable \n"
-        platform.image: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
+        platform.image: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
         excludePrecachePatterns: "aws  \nazure \n"
         additionalImages: "image1:latest \nimage2:latest \n"
         spaceRequired: '40'

--- a/tests/kuttl/cgu/pre-caching-with-configs/03-assert.yaml
+++ b/tests/kuttl/cgu/pre-caching-with-configs/03-assert.yaml
@@ -13,6 +13,7 @@ spec:
   enable: false
   managedPolicies:
   - policy0-common-config-policy
+  - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   - policy3-common-ptp-sub-policy
   - policy4-common-sriov-sub-policy
@@ -44,6 +45,7 @@ status:
     type: PrecachingSuceeded
   managedPoliciesCompliantBeforeUpgrade:
   - policy0-common-config-policy
+  - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   managedPoliciesContent:
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'
@@ -64,7 +66,7 @@ status:
   - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   precaching:
     spec:
-      platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
+      platformImage: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
       operatorsIndexes:
       - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
       operatorsPackagesAndChannels:

--- a/tests/kuttl/cgu/pre-caching-with-configs/04-assert.yaml
+++ b/tests/kuttl/cgu/pre-caching-with-configs/04-assert.yaml
@@ -13,6 +13,7 @@ spec:
   enable: false
   managedPolicies:
   - policy0-common-config-policy
+  - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   - policy3-common-ptp-sub-policy
   - policy4-common-sriov-sub-policy
@@ -44,6 +45,7 @@ status:
     type: PrecachingSuceeded
   managedPoliciesCompliantBeforeUpgrade:
   - policy0-common-config-policy
+  - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   managedPoliciesContent:
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'
@@ -64,7 +66,7 @@ status:
   - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   precaching:
     spec:
-      platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
+      platformImage: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
       operatorsIndexes:
       - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
       operatorsPackagesAndChannels:
@@ -132,7 +134,7 @@ spec:
                 valueFrom:
                   fieldRef:
                     fieldPath: spec.nodeName
-              image: quay.io/test_images/pre-cache:latest
+              image: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.20.0
               name: pre-cache-container
               resources: {}
               securityContext:
@@ -315,7 +317,7 @@ spec:
                 valueFrom:
                   fieldRef:
                     fieldPath: spec.nodeName
-              image: quay.io/test_images/pre-cache:latest
+              image: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.20.0
               name: pre-cache-container
               resources: {}
               securityContext:
@@ -498,7 +500,7 @@ spec:
                 valueFrom:
                   fieldRef:
                     fieldPath: spec.nodeName
-              image: quay.io/test_images/pre-cache:latest
+              image: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.20.0
               name: pre-cache-container
               resources: {}
               securityContext:
@@ -681,7 +683,7 @@ spec:
                 valueFrom:
                   fieldRef:
                     fieldPath: spec.nodeName
-              image: quay.io/test_images/pre-cache:latest
+              image: quay.io/openshift-kni/cluster-group-upgrades-operator-precache:4.20.0
               name: pre-cache-container
               resources: {}
               securityContext:

--- a/tests/kuttl/cgu/pre-caching-with-configs/05-assert.yaml
+++ b/tests/kuttl/cgu/pre-caching-with-configs/05-assert.yaml
@@ -13,6 +13,7 @@ spec:
   enable: false
   managedPolicies:
   - policy0-common-config-policy
+  - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   - policy3-common-ptp-sub-policy
   - policy4-common-sriov-sub-policy
@@ -44,6 +45,7 @@ status:
     type: PrecachingSuceeded
   managedPoliciesCompliantBeforeUpgrade:
   - policy0-common-config-policy
+  - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   managedPoliciesContent:
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'
@@ -64,7 +66,7 @@ status:
   - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   precaching:
     spec:
-      platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
+      platformImage: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
       operatorsIndexes:
       - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
       operatorsPackagesAndChannels:

--- a/tests/kuttl/cgu/pre-caching-with-configs/06-assert.yaml
+++ b/tests/kuttl/cgu/pre-caching-with-configs/06-assert.yaml
@@ -13,6 +13,7 @@ spec:
   enable: false
   managedPolicies:
   - policy0-common-config-policy
+  - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   - policy3-common-ptp-sub-policy
   - policy4-common-sriov-sub-policy
@@ -48,6 +49,7 @@ status:
     type: Progressing
   managedPoliciesCompliantBeforeUpgrade:
   - policy0-common-config-policy
+  - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   managedPoliciesContent:
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'
@@ -68,7 +70,7 @@ status:
   - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   precaching:
     spec:
-      platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
+      platformImage: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
       operatorsIndexes:
       - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
       operatorsPackagesAndChannels:


### PR DESCRIPTION
## Summary
Backport of #10171 to the release branch.

- Deprecate `platformImage`, `operatorsIndexes`, and `preCacheImage` override fields in `PreCachingConfig`
- Remove override logic from the controller — TALM-derived values are always used
- Regenerate CRD manifests with updated deprecation descriptions
- Update kuttl test fixtures to reflect the new behavior (add ClusterVersion policy for platformImage derivation)

Cherry-pick of d9ba19eb53 (squash merge of #10171 into main).

Made with [Cursor](https://cursor.com)