### PR TITLE
[release-4.12] Deprecate unused ConfigMap override fields

### DIFF
--- a/controllers/managedClusterResources.go
+++ b/controllers/managedClusterResources.go
@@ -620,7 +620,6 @@ func (r *ClusterGroupUpgradeReconciler) checkDependencies(
 //
 //	error
 func (r *ClusterGroupUpgradeReconciler) getPrecacheJobTemplateData(
-	ctx context.Context,
 	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade, clusterName string) (
 	*templateData, error) {
 
@@ -629,7 +628,7 @@ func (r *ClusterGroupUpgradeReconciler) getPrecacheJobTemplateData(
 	rv.Cluster = clusterName
 	rv.JobTimeout = uint64(
 		clusterGroupUpgrade.Spec.RemediationStrategy.Timeout) * 60
-	image, err := r.getPrecacheimagePullSpec(ctx, clusterGroupUpgrade)
+	image, err := r.getPrecacheimagePullSpec()
 	if err != nil {
 		return rv, err
 	}
@@ -671,7 +670,7 @@ func (r *ClusterGroupUpgradeReconciler) deployWorkload(
 	var err error
 	switch workloadType {
 	case precache:
-		spec, err = r.getPrecacheJobTemplateData(ctx, clusterGroupUpgrade, cluster)
+		spec, err = r.getPrecacheJobTemplateData(clusterGroupUpgrade, cluster)
 		if err != nil {
 			return err
 		}

--- a/controllers/precache.go
+++ b/controllers/precache.go
@@ -228,24 +228,13 @@ func (r *ClusterGroupUpgradeReconciler) deployDependencies(
 // returns: image - pull spec string
 //
 //	error
-func (r *ClusterGroupUpgradeReconciler) getPrecacheimagePullSpec(
-	ctx context.Context,
-	clusterGroupUpgrade *ranv1alpha1.ClusterGroupUpgrade) (
-	string, error) {
+func (r *ClusterGroupUpgradeReconciler) getPrecacheimagePullSpec() (string, error) {
 
-	overrides, err := r.getOverrides(ctx, clusterGroupUpgrade)
-	if err != nil {
-		r.Log.Error(err, "getOverrides failed ")
-		return "", err
-	}
-	image := overrides["precache.image"]
+	image := os.Getenv("PRECACHE_IMG")
+	r.Log.Info("[getPrecacheimagePullSpec]", "workload image", image)
 	if image == "" {
-		image = os.Getenv("PRECACHE_IMG")
-		r.Log.Info("[getPrecacheimagePullSpec]", "workload image", image)
-		if image == "" {
-			return "", fmt.Errorf(
-				"can't find pre-caching image pull spec in environment or overrides")
-		}
+		return "", fmt.Errorf(
+			"PRECACHE_IMG environment variable is not set")
 	}
 	return image, nil
 }
@@ -292,29 +281,20 @@ func (r *ClusterGroupUpgradeReconciler) includeSoftwareSpecOverrides(
 		return *rv, err
 	}
 
-	platformImage := overrides["platform.image"]
-	operatorsIndexes := strings.Split(overrides["operators.indexes"], "\n")
+	// Platform image: always use TALM-derived value (ConfigMap overrides are deprecated)
+	rv.PlatformImage = spec.PlatformImage
+
+	// Operator indexes: always use TALM-derived value (ConfigMap overrides are deprecated)
+	rv.OperatorsIndexes = spec.OperatorsIndexes
+
+	// Operator packages and channels: ConfigMap override > TALM-derived
 	operatorsPackagesAndChannels := strings.Split(overrides["operators.packagesAndChannels"], "\n")
-	if platformImage == "" {
-		platformImage = spec.PlatformImage
-	}
-	rv.PlatformImage = platformImage
-
-	if overrides["operators.indexes"] == "" {
-		operatorsIndexes = spec.OperatorsIndexes
-	}
-
-	rv.OperatorsIndexes = operatorsIndexes
-
 	if overrides["operators.packagesAndChannels"] == "" {
 		operatorsPackagesAndChannels = spec.OperatorsPackagesAndChannels
 	}
 	rv.OperatorsPackagesAndChannels = operatorsPackagesAndChannels
 
-	if err != nil {
-		return *rv, err
-	}
-	return *rv, err
+	return *rv, nil
 }
 
 // checkPreCacheSpecConsistency checks software spec can be precached


### PR DESCRIPTION
## Summary
- Backport of #10171 to `release-4.12`
- Remove ConfigMap override logic for `platformImage`, `operatorsIndexes`, and `preCacheImage`
- TALM now always derives these values: `platformImage` from ClusterVersion policies, `operatorsIndexes` from CatalogSource objects, `preCacheImage` from `PRECACHE_IMG` env var
- The `operatorsPackagesAndChannels` ConfigMap override is preserved for backward compatibility
- Note: `release-4.12` does not have the `PreCachingConfig` CRD, so only the ConfigMap override logic is affected

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go vet ./...` passes
- [x] `gofmt` formatting verified
- [x] No unit tests affected (no unit tests for these functions on 4.12)
- [ ] CI integration tests (kuttl) pass


Made with [Cursor](https://cursor.com)