### PR TITLE
CNF-26436: Switch runtime base image to ubi9-minimal-pqc

### DIFF
--- a/.konflux/container_build_args.conf
+++ b/.konflux/container_build_args.conf
@@ -8,7 +8,7 @@ BUILDER_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_go
 #
 
 # The runtime image is used to run the binaries
-RUNTIME_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:7c372902c8d211db2d25c8277ba534a73b92742a334874dced829a63b0f21221
+RUNTIME_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest@sha256:e7f7720259142a68a8087fb4df9d21a91189863aa083e9b27c2c2801878ef5c4
 #
 
 # The yq image is used at build time to manipulate yaml


### PR DESCRIPTION
## Summary

- Switch the TALM runtime base image from `ubi9/ubi-minimal` to `ubi9/ubi-minimal-pqc` to enable the `DEFAULT:PQ` crypto-policy in the container
- Required by [OCPSTRAT-3113](https://redhat.atlassian.net/browse/OCPSTRAT-3113) for platform-wide PQC (Post-Quantum Cryptography) consistency

## Changes

Updated `.konflux/container_build_args.conf` to use `registry.redhat.io/ubi9/ubi-minimal-pqc:latest` (pinned by digest) as the runtime image. This affects all Konflux-built images (operator, aztp, recovery, precache) since they all consume the `RUNTIME_IMAGE` build arg from this file.

The PQC base image uses the `DEFAULT:PQ` crypto-policy instead of `DEFAULT`, enabling post-quantum algorithms (ML-KEM, ML-DSA) in OpenSSL. For Go-based operators, ML-KEM key exchange is handled natively by Go's `crypto/tls`, but the base image switch is required for platform consistency.

## Test plan

- [ ] Verify no regressions in standard mode (non-FIPS)
- [ ] Verify no regressions in FIPS mode (PQC modules auto-disabled by FIPS provider)
- [ ] Confirm ML-KEM (`X25519MLKEM768`) is still negotiated successfully via `tls-scanner`

## References

- Jira: [CNF-26436](https://redhat.atlassian.net/browse/CNF-26436)
- Parent initiative: [OCPSTRAT-3113](https://redhat.atlassian.net/browse/OCPSTRAT-3113)
- Similar ticket for NROP: [CNF-26427](https://redhat.atlassian.net/browse/CNF-26427)


Made with [Cursor](https://cursor.com)