### PR TITLE
[release-4.20] Quote variable expansions in pre-cache shell scripts

### DIFF
--- a/pre-cache/check_space.sh
+++ b/pre-cache/check_space.sh
@@ -2,7 +2,7 @@
 
 cwd=$(dirname "$0")
 # shellcheck source=pre-cache/common.sh
-. $cwd/common.sh
+. "$cwd/common.sh"
 
 validate_disk_space() {
     local space_required=${1:-0}
@@ -14,9 +14,9 @@ validate_disk_space() {
     CACERT=${SERVICEACCOUNT}/ca.crt
 
     high=85 # default value for imageGCHighThresholdPercent
-    kubeletconfig=$(with_retries 3 20 curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/nodes/${NODE_NAME}/proxy/configz)
+    kubeletconfig=$(with_retries 3 20 curl --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -X GET "${APISERVER}/api/v1/nodes/${NODE_NAME}/proxy/configz")
     if [ $? -eq 0 ]; then
-        val=$(echo $kubeletconfig | chroot /host jq '.kubeletconfig.imageGCHighThresholdPercent')
+        val=$(echo "$kubeletconfig" | chroot /host jq '.kubeletconfig.imageGCHighThresholdPercent')
         if [[ $val -gt 0 && $val -lt 100 ]]; then
             high=$val
         fi
@@ -38,6 +38,6 @@ validate_disk_space() {
 }
 
 if [[ "${BASH_SOURCE[0]}" = "${0}" ]]; then
-    validate_disk_space ${1:-0}
+    validate_disk_space "${1:-0}"
     exit $?
 fi

--- a/pre-cache/common.sh
+++ b/pre-cache/common.sh
@@ -37,27 +37,27 @@ pull_index(){
     local index_pull_spec=$1
     local PULL_SECRET_PATH=$2
     # Pull the image into the cache directory and attain the image ID
-    release_index_id=$($CONTAINER_TOOL pull --quiet  $index_pull_spec --authfile=$PULL_SECRET_PATH)
+    release_index_id=$("$CONTAINER_TOOL" pull --quiet --authfile="$PULL_SECRET_PATH" -- "$index_pull_spec")
     [[ $? -eq 0 ]] || return 1
-    echo $release_index_id
+    echo "$release_index_id"
     return 0
 }
 
 mount_index(){
     local image_id=$1
     local image_mount
-    image_mount=$($CONTAINER_TOOL image mount $image_id)
+    image_mount=$("$CONTAINER_TOOL" image mount "$image_id")
     rv=$?
-    echo $image_mount
+    echo "$image_mount"
     return $rv
 }
 
 unmount_index(){
     local image_id=$1
     local result
-    result=$($CONTAINER_TOOL image unmount $image_id)
+    result=$("$CONTAINER_TOOL" image unmount "$image_id")
     rv=$?
-    echo $result
+    echo "$result"
     return $rv
 }
 

--- a/pre-cache/olm.sh
+++ b/pre-cache/olm.sh
@@ -2,7 +2,7 @@
 
 cwd=$(dirname "$0")
 # shellcheck source=pre-cache/common.sh
-. $cwd/common.sh
+. "$cwd/common.sh"
 
 rendered_index_path="${rendered_index_path:-/tmp/index.json}"
 
@@ -27,10 +27,10 @@ render_index(){
 
     if [[ -d "$image_mount/configs" ]]; then
         log_debug "Rendering file based catalog"
-        $opm_bin render "$image_mount/configs" > $rendered_index_path
+        "$opm_bin" render "$image_mount/configs" > "$rendered_index_path"
     else
         log_debug "Rendering SQLite catalog"
-        $opm_bin render "$image_mount/database/index.db" > $rendered_index_path
+        "$opm_bin" render "$image_mount/database/index.db" > "$rendered_index_path"
     fi
     if [[ $? -ne 0 ]]; then
         return 1
@@ -39,30 +39,30 @@ render_index(){
 
 extract_packages(){
     local packages
-    tr -d " " < $CONFIG_VOLUME_PATH/operators.packagesAndChannels > /tmp/packagesAndChannels
+    tr -d " " < "$CONFIG_VOLUME_PATH/operators.packagesAndChannels" > /tmp/packagesAndChannels
     while IFS= read -r item; do
-        pkg=$(echo $item |cut -d ':' -f 1)
+        pkg=$(echo "$item" | cut -d ':' -f 1)
         packages="$packages$pkg,"
     done < <(sort -u /tmp/packagesAndChannels)
-    echo ${packages%,}
+    echo "${packages%,}"
     return 0
 }
 
 olm_main(){
-    if [ -z $(sort -u $CONFIG_VOLUME_PATH/operators.indexes) ]; then
+    if [ -z "$(sort -u "$CONFIG_VOLUME_PATH/operators.indexes")" ]; then
         log_debug "Operators index is not specified. Operators won't be pre-cached"
         return 0
     fi
     # There could be several indexes, hence the loop
     while IFS= read -r index; do
-        image_id=$(pull_index $index $PULL_SECRET_PATH)
+        image_id=$(pull_index "$index" "$PULL_SECRET_PATH")
         if [[ $? -ne 0 ]]; then
             log_debug "pull_index failed for index $index"
             return 1
         fi
         log_debug "$index image ID is $image_id"
 
-        image_mount=$(mount_index $image_id)
+        image_mount=$(mount_index "$image_id")
         if [[ $? -ne 0 ]]; then
             log_debug "mount_index failed for index $index"
             return 1
@@ -75,19 +75,19 @@ olm_main(){
             return 1
         fi
 
-        render_index $index $packages $image_mount
+        render_index "$index" "$packages" "$image_mount"
         if [[ $? -ne 0 ]]; then
             log_debug "render_index failed: OLM index render failed for index $index, package(s) $packages"
             return 1
         fi
         operators_spec_file="$CONFIG_VOLUME_PATH/operators.packagesAndChannels"
-        extract_pull_spec $rendered_index_path $operators_spec_file $PULL_SPEC_FILE
+        extract_pull_spec "$rendered_index_path" "$operators_spec_file" "$PULL_SPEC_FILE"
         if [[ $? -ne 0 ]]; then
             log_debug "extract_pull_spec failed"
             return 1
         fi
-        unmount_index $image_id
-    done < <(sort -u $CONFIG_VOLUME_PATH/operators.indexes)
+        unmount_index "$image_id"
+    done < <(sort -u "$CONFIG_VOLUME_PATH/operators.indexes")
     return 0
 }
 

--- a/pre-cache/pull.sh
+++ b/pre-cache/pull.sh
@@ -2,14 +2,14 @@
 
 cwd="${cwd:-/tmp/precache}"
 # shellcheck source=pre-cache/common.sh
-. $cwd/common.sh
+. "$cwd/common.sh"
 
 wait_image(){
     local img=$1
     local pid=$2
 
     log_debug "Waiting to finish pulling image: ${img}"
-    wait $pid # The way wait monitor for each background task (PID). If any error then copy the image in the failed array so it can be retried later
+    wait "$pid" # The way wait monitor for each background task (PID). If any error then copy the image in the failed array so it can be retried later
     if [[ $? != 0 ]]; then
         log_error "Pull failed for image: ${img}! Will retry later... "
         failed_pulls+=("${img}") # Failed, then add the image to be retrieved later
@@ -20,7 +20,7 @@ mirror_images() {
     local pull_file=$1
     local pull_type=$2
 
-    if ! [[ -f $pull_file ]]; then
+    if ! [[ -f "$pull_file" ]]; then
         log_error "No pull spec provided for ${pull_type}"
         return 1
     fi
@@ -30,7 +30,7 @@ mirror_images() {
     local max_bg=$max_pull_threads
     declare -A pids # Hash that include the images pulled along with their pids to be monitored by wait command
     local total_pulls
-    total_pulls=$(sort -u $pull_file | wc -l)  # Required to keep track of the pull task vs total
+    total_pulls=$(sort -u "$pull_file" | wc -l)  # Required to keep track of the pull task vs total
     local current_pull=1
 
     # for line in $(sort -u $pull_file); do
@@ -40,30 +40,30 @@ mirror_images() {
         img="${img#\"}"
         log_debug "Pulling ${img} [${current_pull}/${total_pulls}]"
         # If image is on disk, then skip. This improves the global performance
-        $CONTAINER_TOOL image exists $img
+        "$CONTAINER_TOOL" image exists -- "$img"
         if [[ $? == 0 ]]; then
             log_debug "Skipping existing image $img"
             current_pull=$((current_pull + 1))
             continue
         fi
-        $CONTAINER_TOOL pull $img --authfile=$PULL_SECRET_PATH -q > /dev/null &
+        "$CONTAINER_TOOL" pull --authfile="$PULL_SECRET_PATH" -q -- "$img" > /dev/null &
         #$CONTAINER_TOOL copy docker://${img} --authfile=/var/lib/kubelet/config.json containers-storage:${img} -q & # SKOPEO 
         pids[${img}]=$! # Keeping track of the PID and container image in case the pull fails
         max_bg=$((max_bg - 1)) # Batch size adapted 
         current_pull=$((current_pull + 1))
         if [[ $max_bg == 0 ]]; then # If the batch is done, then monitor the status of all pulls before moving to the next batch
             for pid in "${!pids[@]}"; do
-                wait_image $pid ${pids[$pid]}
+                wait_image "$pid" "${pids[$pid]}"
             done
             # Once the batch is processed, reset the new batch size and clear the processes hash for the next one
             max_bg=$max_pull_threads
             pids=()
         fi
-    done < $pull_file
+    done < "$pull_file"
 
     # Make sure that all pull-threads have been processed
     for pid in "${!pids[@]}"; do
-        wait_image $pid ${pids[$pid]}
+        wait_image "$pid" "${pids[$pid]}"
     done
 }
 
@@ -78,7 +78,7 @@ retry_images() {
         iterations=10
         until [[ $success -eq 1 ]] || [[ $iterations -eq 0 ]]; do
             log_info "Retrying failed image pull: ${failed_pull}"
-            $CONTAINER_TOOL pull $failed_pull --authfile=$PULL_SECRET_PATH
+            "$CONTAINER_TOOL" pull --authfile="$PULL_SECRET_PATH" -- "$failed_pull"
             if [[ $? == 0 ]]; then
                 success=1
             fi
@@ -99,10 +99,10 @@ pre_cache_images(){
     log_info "Image pre-caching starting for ${pull_type}"
 
     failed_pulls=() # Clear the failed_pull array
-    mirror_images $pull_file $pull_type
+    mirror_images "$pull_file" "$pull_type"
     [[ $? -eq 0 ]] || return 1
 
-    retry_images $pull_type # Return 1 if max.retries reached
+    retry_images "$pull_type" # Return 1 if max.retries reached
     if [[ $? -ne 0 ]]; then
         log_error "One or more images were not pre-cached successfully for ${pull_type}"
         return 1
@@ -122,8 +122,8 @@ if [[ "${BASH_SOURCE[0]}" = "${0}" ]]; then
     for pull_type in "${!pull_types[@]}"; do
         pull_file=${pull_types[$pull_type]}
         # Check if the spec_file exists before executing pull statements
-        if [ -n "$(cat $pull_file)" ]; then
-                pre_cache_images $pull_file $pull_type
+        if [ -n "$(cat "$pull_file")" ]; then
+                pre_cache_images "$pull_file" "$pull_type"
                 [[ $? -eq 0 ]] || exit 1
         fi
     done

--- a/pre-cache/release.sh
+++ b/pre-cache/release.sh
@@ -2,36 +2,36 @@
 
 cwd=$(dirname "$0")
 # shellcheck source=pre-cache/common.sh
-. $cwd/common.sh
+. "$cwd/common.sh"
 
 extract_pull_spec(){
     local rel_img_mount=$1
 
     # remove empty lines
-    sed -i '/^[[:space:]]*$/d' $CONFIG_VOLUME_PATH/excludePrecachePatterns
+    sed -i '/^[[:space:]]*$/d' "$CONFIG_VOLUME_PATH/excludePrecachePatterns"
     # remove trailing and leading whitespace
-    sed -i 's/^[ \t]*//;s/[ \t]*$//' $CONFIG_VOLUME_PATH/excludePrecachePatterns
+    sed -i 's/^[ \t]*//;s/[ \t]*$//' "$CONFIG_VOLUME_PATH/excludePrecachePatterns"
 
-    jq  '.spec.tags[] | .name as $name |.from.name as $pull |[$name,$pull] |join("$")' < ${rel_img_mount}/release-manifests/image-references | \
-        grep -vG -f $CONFIG_VOLUME_PATH/excludePrecachePatterns | \
+    jq  '.spec.tags[] | .name as $name |.from.name as $pull |[$name,$pull] |join("$")' < "${rel_img_mount}/release-manifests/image-references" | \
+        grep -vG -f "$CONFIG_VOLUME_PATH/excludePrecachePatterns" | \
         cut -d "$" -f2 | \
-        sed 's/^/"/' >> $PULL_SPEC_FILE
+        sed 's/^/"/' >> "$PULL_SPEC_FILE"
     log_debug "Release index image processing done"
 }
 
 release_main(){
-    rel_img=$(cat $CONFIG_VOLUME_PATH/platform.image)
+    rel_img=$(cat "$CONFIG_VOLUME_PATH/platform.image")
     if [[ -z $rel_img ]]; then
         log_debug "Release index is not specified. Release images will not be pre-cached"
         return 0
     fi
-    release_index_id=$(pull_index $rel_img $PULL_SECRET_PATH)
+    release_index_id=$(pull_index "$rel_img" "$PULL_SECRET_PATH")
     [[ $? -eq 0 ]] || return 1
-    rel_img_mount=$(mount_index $release_index_id)
+    rel_img_mount=$(mount_index "$release_index_id")
     [[ $? -eq 0 ]] || return 1
-    extract_pull_spec $rel_img_mount
+    extract_pull_spec "$rel_img_mount"
     [[ $? -eq 0 ]] || return 1
-    unmount_index $release_index_id
+    unmount_index "$release_index_id"
     [[ $? -eq 0 ]] || return 1
     return 0
 }

--- a/pre-cache/test.sh
+++ b/pre-cache/test.sh
@@ -12,7 +12,7 @@ export TEST_ENV=true
 for f in common.sh olm.sh release.sh pull.sh; do
     echo "Testing import of $f"
     # shellcheck disable=1090,2154
-    . $cwd/$f
+    . "$cwd/$f"
     rc=$?
     [[ $rc -eq 0 ]] || fatal "Could not import $f"
     echo "Ok"
@@ -49,7 +49,7 @@ cat <<EOF > /tmp/release-manifests/image-references
 EOF
 
 # shellcheck disable=SC2154
-(rm $PULL_SPEC_FILE || true) &> /dev/null
+(rm "$PULL_SPEC_FILE" || true) &> /dev/null
 
 # shellcheck disable=SC2034
 CONTAINER_TOOL=/usr/bin/echo
@@ -60,9 +60,9 @@ CONFIG_VOLUME_PATH=/tmp
 echo "Testing common functions:"
 
 # shellcheck disable=SC2154
-result=$(pull_index "temp" $PULL_SECRET_PATH)
+result=$(pull_index "temp" "$PULL_SECRET_PATH")
 [[ $? -eq 0 ]] || fatal "pull_index unexpected exit code"
-[[ $result == "pull --quiet temp --authfile=$PULL_SECRET_PATH" ]] || fatal "Index pull failure"
+[[ $result == "pull --quiet --authfile=$PULL_SECRET_PATH -- temp" ]] || fatal "Index pull failure"
 echo " Index pull pass"
 
 result=$(mount_index test)
@@ -85,15 +85,15 @@ echo " extract_packages - pass"
 echo "Testing release unit:"
 result=$(extract_pull_spec "/tmp")
 [[ $? -eq 0 ]] || fatal "release_image extract unexpected exit code"
-[[ $(cat $PULL_SPEC_FILE) == "\"quay.io/1\"" ]] || fatal "release pull spec extract failure"
+[[ $(cat "$PULL_SPEC_FILE") == "\"quay.io/1\"" ]] || fatal "release pull spec extract failure"
 echo " release extract_pull_spec pass"
 
 # Test parse_index.py Python unit tests
 echo "Testing parse_index.py unit tests:"
 # shellcheck disable=SC2154
-python3 $cwd/test_parse_index.py
+python3 "$cwd/test_parse_index.py"
 [[ $? -eq 0 ]] || fatal "parse_index.py unit tests failed"
 echo " parse_index.py unit tests pass"
 
 # Clean
-rm -rf /tmp/operators.indexes /tmp/release-manifests $PULL_SPEC_FILE /tmp/operators.packagesAndChannels
+rm -rf /tmp/operators.indexes /tmp/release-manifests "$PULL_SPEC_FILE" /tmp/operators.packagesAndChannels


### PR DESCRIPTION
## Summary

* Backport of #10254 to `release-4.20`
* Add double quotes around all variable expansions and function arguments in pre-cache shell scripts (pull.sh, common.sh, olm.sh, release.sh, check_space.sh, test.sh)
* Use `--` terminators before positional image references in podman invocations

## Test plan

* Clean cherry-pick (no conflicts)
* CI integration tests pass


Made with [Cursor](https://cursor.com)