### PR TITLE
[release-4.14] Quote variable expansions in pre-cache shell scripts

### DIFF
--- a/pre-cache/check_space
+++ b/pre-cache/check_space
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cwd=$(dirname "$0")
-. $cwd/common
+. "$cwd/common"
 
 validate_disk_space() {
     local space_required=${1:-0}
@@ -13,9 +13,9 @@ validate_disk_space() {
     CACERT=${SERVICEACCOUNT}/ca.crt
 
     high=85 # default value for imageGCHighThresholdPercent
-    kubeletconfig=$(with_retries 3 20 curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/nodes/${NODE_NAME}/proxy/configz) 
+    kubeletconfig=$(with_retries 3 20 curl --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" -X GET "${APISERVER}/api/v1/nodes/${NODE_NAME}/proxy/configz")
     if [ $? -eq 0 ]; then
-        val=$(echo $kubeletconfig | chroot /host jq '.kubeletconfig.imageGCHighThresholdPercent')
+        val=$(echo "$kubeletconfig" | chroot /host jq '.kubeletconfig.imageGCHighThresholdPercent')
         if [[ $val -gt 0 && $val -lt 100 ]]; then
            high=$val
         fi
@@ -37,6 +37,6 @@ validate_disk_space() {
 }
 
 if [[ "${BASH_SOURCE[0]}" = "${0}" ]]; then
-    validate_disk_space ${1:-0}
+    validate_disk_space "${1:-0}"
     exit $?
 fi

--- a/pre-cache/common
+++ b/pre-cache/common
@@ -35,25 +35,25 @@ pull_index(){
     local index_pull_spec=$1
     local pull_secret_path=$2
     # Pull the image into the cache directory and attain the image ID
-    release_index_id=$($container_tool pull --quiet  $index_pull_spec --authfile=$pull_secret_path)
+    release_index_id=$("$container_tool" pull --quiet --authfile="$pull_secret_path" -- "$index_pull_spec")
     [[ $? -eq 0 ]] || return 1
-    echo $release_index_id
+    echo "$release_index_id"
     return 0
 }
 
 mount_index(){
     local image_id=$1
-    local image_mount=$($container_tool image mount $image_id)
+    local image_mount=$("$container_tool" image mount "$image_id")
     rv=$?
-    echo $image_mount
+    echo "$image_mount"
     return $rv
 }
 
 unmount_index(){
     local image_id=$1
-    local result=$($container_tool image unmount $image_id)
+    local result=$("$container_tool" image unmount "$image_id")
     rv=$?
-    echo $result
+    echo "$result"
     return $rv
 }
 

--- a/pre-cache/olm
+++ b/pre-cache/olm
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cwd=$(dirname "$0")
-. $cwd/common
+. "$cwd/common"
 
 extract_pull_spec(){
     rendered_index=$1
@@ -24,10 +24,10 @@ render_index(){
 
     if [[ -d "$image_mount/configs" ]]; then
       log_debug "Rendering file based catalog"
-      $opm_bin render "$image_mount/configs" > $rendered_index_path
+      "$opm_bin" render "$image_mount/configs" > "$rendered_index_path"
     else
       log_debug "Rendering SQLite catalog"
-      $opm_bin render "$image_mount/database/index.db" > $rendered_index_path
+      "$opm_bin" render "$image_mount/database/index.db" > "$rendered_index_path"
     fi
     if [[ $? -ne 0 ]]; then
         return 1
@@ -37,31 +37,31 @@ render_index(){
 
 extract_packages(){
     local packages
-    cat $config_volume_path/operators.packagesAndChannels |tr -d " " > /tmp/packagesAndChannels
+    tr -d " " < "$config_volume_path/operators.packagesAndChannels" > /tmp/packagesAndChannels
     for item in $(sort -u '/tmp/packagesAndChannels'); do
-        pkg=$(echo $item |cut -d ':' -f 1)
+        pkg=$(echo "$item" | cut -d ':' -f 1)
         packages="$packages$pkg,"
     done
-    echo ${packages%,}
+    echo "${packages%,}"
     return 0
 }
 
 olm_main(){
-    if ! [[ -n $(sort -u $config_volume_path/operators.indexes) ]]; then
+    if ! [[ -n $(sort -u "$config_volume_path/operators.indexes") ]]; then
       log_debug "Operators index is not specified. Operators won't be pre-cached"
       return 0
     fi
     # There could be several indexes, hence the loop
-    for index in $(sort -u $config_volume_path/operators.indexes) ; do
+    for index in $(sort -u "$config_volume_path/operators.indexes") ; do
 
-        image_id=$(pull_index $index $pull_secret_path)
+        image_id=$(pull_index "$index" "$pull_secret_path")
         if [[ $? -ne 0 ]]; then
           log_debug "pull_index failed for index $index"
           return 1
         fi
         log_debug "$index image ID is $image_id"
 
-        image_mount=$(mount_index $image_id)
+        image_mount=$(mount_index "$image_id")
         if [[ $? -ne 0 ]]; then
           log_debug "mount_index failed for index $index"
           return 1
@@ -74,18 +74,18 @@ olm_main(){
           return 1
         fi
 
-        render_index $index $packages $image_mount
+        render_index "$index" "$packages" "$image_mount"
         if [[ $? -ne 0 ]]; then
           log_debug "render_index failed: OLM index render failed for index $index, package(s) $packages"
           return 1
         fi
         operators_spec_file="$config_volume_path/operators.packagesAndChannels"
-        extract_pull_spec $rendered_index_path $operators_spec_file $pull_spec_file
+        extract_pull_spec "$rendered_index_path" "$operators_spec_file" "$pull_spec_file"
         if [[ $? -ne 0 ]]; then
           log_debug "extract_pull_spec failed"
           return 1
         fi
-        unmount_index $image_id
+        unmount_index "$image_id"
     done
     return 0
 }

--- a/pre-cache/pull
+++ b/pre-cache/pull
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 cwd="${cwd:-/tmp/precache}"
-. $cwd/common
+. "$cwd/common"
 
 wait_image(){
     local img=$1
     local pid=$2
 
     log_debug "Waiting to finish pulling image: ${img}"
-    wait $pid # The way wait monitor for each background task (PID). If any error then copy the image in the failed array so it can be retried later
+    wait "$pid" # The way wait monitor for each background task (PID). If any error then copy the image in the failed array so it can be retried later
     if [[ $? != 0 ]]; then
         log_error "Pull failed for image: ${img}! Will retry later... "
-        failed_pulls+=(${img}) # Failed, then add the image to be retrieved later
+        failed_pulls+=("${img}") # Failed, then add the image to be retrieved later
     fi
 }
 
@@ -19,7 +19,7 @@ mirror_images() {
     local pull_file=$1
     local pull_type=$2
 
-    if ! [[ -f $pull_file ]]; then
+    if ! [[ -f "$pull_file" ]]; then
         log_error "No pull spec provided for ${pull_type}"
         return 1
     fi
@@ -27,30 +27,30 @@ mirror_images() {
     # definition of vars once the config is provided
     local max_bg=$max_pull_threads
     declare -A pids # Hash that include the images pulled along with their pids to be monitored by wait command
-    local total_pulls=$(sort -u $pull_file | wc -l)  # Required to keep track of the pull task vs total
+    local total_pulls=$(sort -u "$pull_file" | wc -l)  # Required to keep track of the pull task vs total
     local current_pull=1
 
-    for line in $(sort -u $pull_file) ; do
+    for line in $(sort -u "$pull_file") ; do
         # Strip double quotes
         img="${line%\"}"
         img="${img#\"}"
         log_debug "Pulling ${img} [${current_pull}/${total_pulls}]"
         # If image is on disk, then skip. This improves the global performance
-        $container_tool image exists $img
+        "$container_tool" image exists -- "$img"
         if [[ $? == 0 ]]; then
             log_debug "Skipping existing image $img"
             current_pull=$((current_pull + 1))
             continue
         fi
-        $container_tool pull $img --authfile=$pull_secret_path -q > /dev/null &
+        "$container_tool" pull --authfile="$pull_secret_path" -q -- "$img" > /dev/null &
         #$container_tool copy docker://${img} --authfile=/var/lib/kubelet/config.json containers-storage:${img} -q & # SKOPEO 
         pids[${img}]=$! # Keeping track of the PID and container image in case the pull fails
         max_bg=$((max_bg - 1)) # Batch size adapted 
         current_pull=$((current_pull + 1)) 
         if [[ $max_bg == 0 ]] # If the batch is done, then monitor the status of all pulls before moving to the next batch
         then
-          for pid in ${!pids[@]}; do
-            wait_image $pid ${pids[$pid]}
+          for pid in "${!pids[@]}"; do
+            wait_image "$pid" "${pids[$pid]}"
           done
           # Once the batch is processed, reset the new batch size and clear the processes hash for the next one
           max_bg=$max_pull_threads
@@ -59,8 +59,8 @@ mirror_images() {
     done
 
     # Make sure that all pull-threads have been processed
-    for pid in ${!pids[@]}; do
-        wait_image $pid ${pids[$pid]}
+    for pid in "${!pids[@]}"; do
+        wait_image "$pid" "${pids[$pid]}"
     done
 }
 
@@ -76,7 +76,7 @@ retry_images() {
       until [[ $success -eq 1 ]] || [[ $iterations -eq 0 ]]
       do
         log_info "Retrying failed image pull: ${failed_pull}"
-        $container_tool pull $failed_pull --authfile=$pull_secret_path
+        "$container_tool" pull --authfile="$pull_secret_path" -- "$failed_pull"
         if [[ $? == 0 ]]; then
           success=1
         fi
@@ -97,10 +97,10 @@ pre_cache_images(){
     log_info "Image pre-caching starting for ${pull_type}"
 
     failed_pulls=() # Clear the failed_pull array
-    mirror_images $pull_file $pull_type
+    mirror_images "$pull_file" "$pull_type"
     [[ $? -eq 0 ]] || return 1
 
-    retry_images $pull_type # Return 1 if max.retries reached
+    retry_images "$pull_type" # Return 1 if max.retries reached
     if [[ $? -ne 0 ]]; then
         log_error "One or more images were not pre-cached successfully for ${pull_type}"
         return 1
@@ -120,8 +120,8 @@ if [[ "${BASH_SOURCE[0]}" = "${0}" ]]; then
     for pull_type in ${!pull_types[@]}; do
         pull_file=${pull_types[$pull_type]}
         # Check if the spec_file exists before executing pull statements
-        if [ -n "$(cat $pull_file)" ]; then
-                pre_cache_images $pull_file $pull_type
+        if [ -n "$(cat "$pull_file")" ]; then
+                pre_cache_images "$pull_file" "$pull_type"
                 [[ $? -eq 0 ]] || exit 1
         fi
     done

--- a/pre-cache/release
+++ b/pre-cache/release
@@ -1,37 +1,36 @@
 #!/bin/bash
 
 cwd=$(dirname "$0")
-. $cwd/common
+. "$cwd/common"
 
 extract_pull_spec(){
     local rel_img_mount=$1
 
     # remove empty lines
-    sed -i '/^[[:space:]]*$/d' $config_volume_path/excludePrecachePatterns
+    sed -i '/^[[:space:]]*$/d' "$config_volume_path/excludePrecachePatterns"
     # remove trailing and leading whitespace
-    sed -i 's/^[ \t]*//;s/[ \t]*$//' $config_volume_path/excludePrecachePatterns
-    
-    cat ${rel_img_mount}/release-manifests/image-references | \
-      jq  '.spec.tags[] | .name as $name |.from.name as $pull |[$name,$pull] |join("$")' | \
-       grep -vG -f $config_volume_path/excludePrecachePatterns | \
+    sed -i 's/^[ \t]*//;s/[ \t]*$//' "$config_volume_path/excludePrecachePatterns"
+
+    jq  '.spec.tags[] | .name as $name |.from.name as $pull |[$name,$pull] |join("$")' < "${rel_img_mount}/release-manifests/image-references" | \
+       grep -vG -f "$config_volume_path/excludePrecachePatterns" | \
        cut -d "$" -f2 | \
-       sed 's/^/"/' >> $pull_spec_file
+       sed 's/^/"/' >> "$pull_spec_file"
     log_debug "Release index image processing done"
 }
 
 release_main(){
-    rel_img=$(cat $config_volume_path/platform.image)
-    if ! [[ -n $rel_img ]]; then
+    rel_img=$(cat "$config_volume_path/platform.image")
+    if [[ -z $rel_img ]]; then
       log_debug "Release index is not specified. Release images will not be pre-cached"
       return 0
     fi
-    release_index_id=$(pull_index $rel_img $pull_secret_path)
+    release_index_id=$(pull_index "$rel_img" "$pull_secret_path")
     [[ $? -eq 0 ]] || return 1
-    rel_img_mount=$(mount_index $release_index_id)
+    rel_img_mount=$(mount_index "$release_index_id")
     [[ $? -eq 0 ]] || return 1
-    extract_pull_spec $rel_img_mount
+    extract_pull_spec "$rel_img_mount"
     [[ $? -eq 0 ]] || return 1
-    unmount_index $release_index_id
+    unmount_index "$release_index_id"
     [[ $? -eq 0 ]] || return 1
     return 0
 }

--- a/pre-cache/test.sh
+++ b/pre-cache/test.sh
@@ -10,7 +10,7 @@ fatal() {
 for f in common olm release pull; do
     echo "Testing import of $f"
     # shellcheck disable=1090,2154
-    . $cwd/$f
+    . "$cwd/$f"
     rc=$?
     [[ $rc -eq 0 ]] || fatal "Could not import $f"
     echo "Ok"
@@ -47,7 +47,7 @@ cat <<EOF > /tmp/release-manifests/image-references
 EOF
 
 # shellcheck disable=SC2154
-(rm $pull_spec_file || true) &> /dev/null
+(rm "$pull_spec_file" || true) &> /dev/null
 
 # shellcheck disable=SC2034
 container_tool=/usr/bin/echo
@@ -58,9 +58,9 @@ config_volume_path=/tmp
 echo "Testing common functions:"
 
 # shellcheck disable=SC2154
-result=$(pull_index "temp" $pull_secret_path)
+result=$(pull_index "temp" "$pull_secret_path")
 [[ $? -eq 0 ]] || fatal "pull_index unexpected exit code"
-[[ $result == "pull --quiet temp --authfile=$pull_secret_path" ]] || fatal "Index pull failure"
+[[ $result == "pull --quiet --authfile=$pull_secret_path -- temp" ]] || fatal "Index pull failure"
 echo " Index pull pass"
 
 result=$(mount_index test)
@@ -83,8 +83,8 @@ echo " extract_packages - pass"
 echo "Testing release unit:"
 result=$(extract_pull_spec "/tmp")
 [[ $? -eq 0 ]] || fatal "release_image extract unexpected exit code"
-[[ $(cat $pull_spec_file) == "\"quay.io/1\"" ]] || fatal "release pull spec extract failure"
+[[ $(cat "$pull_spec_file") == "\"quay.io/1\"" ]] || fatal "release pull spec extract failure"
 echo " release extract_pull_spec pass"
 
 # Clean
-rm -rf /tmp/operators.indexes /tmp/release-manifests $pull_spec_file /tmp/operators.packagesAndChannels
+rm -rf /tmp/operators.indexes /tmp/release-manifests "$pull_spec_file" /tmp/operators.packagesAndChannels


### PR DESCRIPTION
## Summary

* Backport of #10254 to `release-4.14`
* Add double quotes around all variable expansions and function arguments in pre-cache shell scripts (pull, common, olm, release, check_space, test.sh)
* Use `--` terminators before positional image references in podman invocations
* Note: `release-4.14` uses scripts without `.sh` extension (`check_space`, `common`, `olm`, `pull`, `release`), so changes were adapted manually

## Test plan

* Shell syntax verified (bash -n)
* CI integration tests pass


Made with [Cursor](https://cursor.com)