### PR TITLE
[release-4.12] Quote variable expansions in pre-cache shell scripts

### DIFF
--- a/pre-cache/common
+++ b/pre-cache/common
@@ -16,24 +16,24 @@ pull_index(){
     local index_pull_spec=$1
     local pull_secret_path=$2
     # Pull the image into the cache directory and attain the image ID
-    release_index_id=$($container_tool pull --quiet  $index_pull_spec --authfile=$pull_secret_path)
+    release_index_id=$("$container_tool" pull --quiet --authfile="$pull_secret_path" -- "$index_pull_spec")
     [[ $? -eq 0 ]] || return 1
-    echo $release_index_id
+    echo "$release_index_id"
     return 0
 }
 
 mount_index(){
     local image_id=$1
-    local image_mount=$($container_tool image mount $image_id)
+    local image_mount=$("$container_tool" image mount "$image_id")
     rv=$?
-    echo $image_mount
+    echo "$image_mount"
     return $rv
 }
 
 unmount_index(){
     local image_id=$1
-    local result=$($container_tool image unmount $image_id)
+    local result=$("$container_tool" image unmount "$image_id")
     rv=$?
-    echo $result
+    echo "$result"
     return $rv
 }

--- a/pre-cache/olm
+++ b/pre-cache/olm
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cwd=$(dirname "$0")
-. $cwd/common
+. "$cwd/common"
 
 extract_pull_spec(){
     rendered_index=$1
@@ -19,7 +19,7 @@ render_index(){
     capath="/host/etc/docker/certs.d/${index%/*}/ca.crt"
     # opm doesn't accept cacert as an arg
     if [[ -f "$capath" ]]; then
-        cp $capath /etc/pki/ca-trust/source/anchors/ 
+        cp "$capath" /etc/pki/ca-trust/source/anchors/
         update-ca-trust
     fi
     if [[ -h "$image_mount/bin/opm" ]]; then
@@ -30,10 +30,10 @@ render_index(){
 
     if [[ -d "$image_mount/configs" ]]; then
       log_debug "Rendering file based catalog"
-      $opm_bin render "$image_mount/configs" > $rendered_index_path
+      "$opm_bin" render "$image_mount/configs" > "$rendered_index_path"
     else
       log_debug "Rendering SQLite catalog"
-      $opm_bin render "$image_mount/database/index.db" > $rendered_index_path
+      "$opm_bin" render "$image_mount/database/index.db" > "$rendered_index_path"
     fi
     if [[ $? -ne 0 ]]; then
         return 1
@@ -43,30 +43,30 @@ render_index(){
 
 extract_packages(){
     local packages
-    cat $config_volume_path/operators.packagesAndChannels |tr -d " " > /tmp/packagesAndChannels
+    tr -d " " < "$config_volume_path/operators.packagesAndChannels" > /tmp/packagesAndChannels
     for item in $(sort -u '/tmp/packagesAndChannels'); do
-        pkg=$(echo $item |cut -d ':' -f 1)
+        pkg=$(echo "$item" | cut -d ':' -f 1)
         packages="$packages$pkg,"
     done
-    echo ${packages%,}
+    echo "${packages%,}"
     return 0
 }
 
 olm_main(){
-    if ! [[ -n $(sort -u $config_volume_path/operators.indexes) ]]; then
+    if ! [[ -n $(sort -u "$config_volume_path/operators.indexes") ]]; then
       log_debug "Operators index is not specified. Operators won't be pre-cached"
       return 0
     fi
     # There could be several indexes, hence the loop
-    for index in $(sort -u $config_volume_path/operators.indexes) ; do
+    for index in $(sort -u "$config_volume_path/operators.indexes") ; do
 
-        image_id=$(pull_index $index $pull_secret_path)
+        image_id=$(pull_index "$index" "$pull_secret_path")
         if [[ $? -ne 0 ]]; then
           log_debug "pull_index failed for index $index"
           return 1
         fi
         log_debug "$index image ID is $image_id"
-        image_mount=$(mount_index $image_id)
+        image_mount=$(mount_index "$image_id")
         if [[ $? -ne 0 ]]; then
           log_debug "mount_index failed for index $index"
           return 1
@@ -77,18 +77,18 @@ olm_main(){
           log_debug "operators index is set, but no packages provided - inconsistent configuration"
           return 1
         fi
-        render_index $index $packages $image_mount
+        render_index "$index" "$packages" "$image_mount"
         if [[ $? -ne 0 ]]; then
           log_debug "render_index failed: OLM index render failed for index $index, package(s) $packages"
           return 1
         fi
         operators_spec_file="$config_volume_path/operators.packagesAndChannels"
-        extract_pull_spec $rendered_index_path $operators_spec_file $pull_spec_file
+        extract_pull_spec "$rendered_index_path" "$operators_spec_file" "$pull_spec_file"
         if [[ $? -ne 0 ]]; then
           log_debug "extract_pull_spec failed"
           return 1
         fi
-        unmount_index $image_id
+        unmount_index "$image_id"
     done
     return 0
 }

--- a/pre-cache/pull
+++ b/pre-cache/pull
@@ -1,44 +1,44 @@
 #!/bin/bash
 
 cwd="${cwd:-/tmp/precache}"
-. $cwd/common
+. "$cwd/common"
 
 mirror_images() {
 
-    if ! [[ -f $pull_spec_file ]]; then
+    if ! [[ -f "$pull_spec_file" ]]; then
         log_debug "no pull spec provided - misconfiguration error"
         return 1
     fi
     # definition of vars once the config is provided
     local max_bg=$max_pull_threads
     declare -A pids # Hash that include the images pulled along with their pids to be monitored by wait command
-    local total_pulls=$(sort -u $pull_spec_file | wc -l)  # Required to keep track of the pull task vs total
+    local total_pulls=$(sort -u "$pull_spec_file" | wc -l)  # Required to keep track of the pull task vs total
     local current_pull=1
 
-    for line in $(sort -u $pull_spec_file) ; do
+    for line in $(sort -u "$pull_spec_file") ; do
         # Strip double quotes
         img="${line%\"}"
         img="${img#\"}"
         log_debug "Pulling ${img} [${current_pull}/${total_pulls}]"
         # If image is on disk, then skip. This improves the global performance
-        $container_tool image exists $img
+        "$container_tool" image exists -- "$img"
         if [[ $? == 0 ]]; then
             log_debug "Skipping existing image $img"
             current_pull=$((current_pull + 1))
             continue
         fi
-        $container_tool pull $img --authfile=/var/lib/kubelet/config.json -q > /dev/null &
+        "$container_tool" pull --authfile=/var/lib/kubelet/config.json -q -- "$img" > /dev/null &
         #$container_tool copy docker://${img} --authfile=/var/lib/kubelet/config.json containers-storage:${img} -q & # SKOPEO 
         pids[${img}]=$! # Keeping track of the PID and container image in case the pull fails
         max_bg=$((max_bg - 1)) # Batch size adapted 
         current_pull=$((current_pull + 1)) 
         if [[ $max_bg == 0 ]] # If the batch is done, then monitor the status of all pulls before moving to the next batch
         then
-          for pid in ${!pids[@]}; do
-            wait ${pids[$pid]} # The way wait monitor for each background task (PID). If any error then copy the image in the failed array so it can be retried later
+          for pid in "${!pids[@]}"; do
+            wait "${pids[$pid]}" # The way wait monitor for each background task (PID). If any error then copy the image in the failed array so it can be retried later
             if [[ $? != 0 ]]; then
               log_debug "Pull failed for container image: ${pid} . Retrying later... "
-              failed_pulls+=(${pid}) # Failed, then add the image to be retrieved later
+              failed_pulls+=("${pid}") # Failed, then add the image to be retrieved later
             fi
           done
           # Once the batch is processed, reset the new batch size and clear the processes hash for the next one
@@ -52,13 +52,13 @@ retry_images() {
     local success
     local iterations
     local rv=0
-    for failed_pull in ${failed_pulls[@]}; do
+    for failed_pull in "${failed_pulls[@]}"; do
       success=0
       iterations=10
       until [[ $success -eq 1 ]] || [[ $iterations -eq 0 ]]
       do
         log_debug "Retrying failed image pull: ${failed_pull}"
-        $container_tool pull $failed_pull --authfile=/var/lib/kubelet/config.json
+        "$container_tool" pull --authfile=/var/lib/kubelet/config.json -- "$failed_pull"
         if [[ $? == 0 ]]; then
           success=1
         fi

--- a/pre-cache/release
+++ b/pre-cache/release
@@ -1,27 +1,27 @@
 #!/bin/bash
 
 cwd=$(dirname "$0")
-. $cwd/common
+. "$cwd/common"
 
 extract_pull_spec(){
     local rel_img_mount=$1
-    cat ${rel_img_mount}/release-manifests/image-references |jq '.spec.tags[].from.name' >> $pull_spec_file
+    jq '.spec.tags[].from.name' < "${rel_img_mount}/release-manifests/image-references" >> "$pull_spec_file"
     log_debug "Release index image processing done"
 }
 
 release_main(){
-    rel_img=$(cat $config_volume_path/platform.image)
-    if ! [[ -n $rel_img ]]; then
+    rel_img=$(cat "$config_volume_path/platform.image")
+    if [[ -z $rel_img ]]; then
       log_debug "Release index is not specified. Release images will not be pre-cached"
       return 0
     fi
-    release_index_id=$(pull_index $rel_img $pull_secret_path)
+    release_index_id=$(pull_index "$rel_img" "$pull_secret_path")
     [[ $? -eq 0 ]] || return 1
-    rel_img_mount=$(mount_index $release_index_id)
+    rel_img_mount=$(mount_index "$release_index_id")
     [[ $? -eq 0 ]] || return 1
-    extract_pull_spec $rel_img_mount
+    extract_pull_spec "$rel_img_mount"
     [[ $? -eq 0 ]] || return 1
-    unmount_index $release_index_id
+    unmount_index "$release_index_id"
     [[ $? -eq 0 ]] || return 1
     return 0
 }

--- a/pre-cache/test.sh
+++ b/pre-cache/test.sh
@@ -10,7 +10,7 @@ fatal() {
 for f in common olm release pull; do
     echo "Testing import of $f"
     # shellcheck disable=1090,2154
-    . $cwd/$f
+    . "$cwd/$f"
     rc=$?
     [[ $rc -eq 0 ]] || fatal "Could not import $f"
     echo "Ok"
@@ -36,7 +36,7 @@ cat <<EOF > /tmp/release-manifests/image-references
 EOF
 
 # shellcheck disable=SC2154
-(rm $pull_spec_file || true) &> /dev/null
+(rm "$pull_spec_file" || true) &> /dev/null
 
 # shellcheck disable=SC2034
 container_tool=/usr/bin/echo
@@ -47,9 +47,9 @@ config_volume_path=/tmp
 echo "Testing common functions:"
 
 # shellcheck disable=SC2154
-result=$(pull_index "temp" $pull_secret_path)
+result=$(pull_index "temp" "$pull_secret_path")
 [[ $? -eq 0 ]] || fatal "pull_index unexpected exit code"
-[[ $result == "pull --quiet temp --authfile=$pull_secret_path" ]] || fatal "Index pull failure"
+[[ $result == "pull --quiet --authfile=$pull_secret_path -- temp" ]] || fatal "Index pull failure"
 echo " Index pull pass"
 
 result=$(mount_index test)
@@ -72,8 +72,8 @@ echo " extract_packages - pass"
 echo "Testing release unit:"
 result=$(extract_pull_spec "/tmp")
 [[ $? -eq 0 ]] || fatal "release_image extract unexpected exit code"
-[[ $(cat $pull_spec_file) == "\"test\"" ]] || fatal "release pull spec extract failure"
+[[ $(cat "$pull_spec_file") == "\"test\"" ]] || fatal "release pull spec extract failure"
 echo " release extract_pull_spec pass"
 
 # Clean
-rm -rf /tmp/operators.indexes /tmp/release-manifests $pull_spec_file /tmp/operators.packagesAndChannels
+rm -rf /tmp/operators.indexes /tmp/release-manifests "$pull_spec_file" /tmp/operators.packagesAndChannels


### PR DESCRIPTION
## Summary

* Backport of #10254 to `release-4.12`
* Add double quotes around all variable expansions and function arguments in pre-cache shell scripts (pull, common, olm, release, test.sh)
* Use `--` terminators before positional image references in podman invocations
* Note: `release-4.12` uses scripts without `.sh` extension and has no `check_space` script, so changes were adapted manually

## Test plan

* Shell syntax verified (bash -n)
* CI integration tests pass


Made with [Cursor](https://cursor.com)