### PR TITLE
CNF-26586: Update registry namespace from openshift4 to openshift5

### DIFF
--- a/.konflux/catalog/catalog-idms.yaml
+++ b/.konflux/catalog/catalog-idms.yaml
@@ -9,3 +9,6 @@ spec:
   - mirrors:
     - quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-5-0
     source: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle
+  - mirrors:
+    - quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-5-0
+    source: registry.redhat.io/openshift5/topology-aware-lifecycle-manager-operator-bundle

--- a/.konflux/catalog/fbc-images-resolvable-integration-test-idms.yaml
+++ b/.konflux/catalog/fbc-images-resolvable-integration-test-idms.yaml
@@ -22,3 +22,18 @@ spec:
     - mirrors:
         - registry.stage.redhat.io/openshift4/topology-aware-lifecycle-manager-recovery-rhel9
       source: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-recovery-rhel9
+    - mirrors:
+        - registry.stage.redhat.io/openshift5/topology-aware-lifecycle-manager-rhel9-operator
+      source: registry.redhat.io/openshift5/topology-aware-lifecycle-manager-rhel9-operator
+    - mirrors:
+        - registry.stage.redhat.io/openshift5/topology-aware-lifecycle-manager-operator-bundle
+      source: registry.redhat.io/openshift5/topology-aware-lifecycle-manager-operator-bundle
+    - mirrors:
+        - registry.stage.redhat.io/openshift5/topology-aware-lifecycle-manager-aztp-rhel9
+      source: registry.redhat.io/openshift5/topology-aware-lifecycle-manager-aztp-rhel9
+    - mirrors:
+        - registry.stage.redhat.io/openshift5/topology-aware-lifecycle-manager-precache-rhel9
+      source: registry.redhat.io/openshift5/topology-aware-lifecycle-manager-precache-rhel9
+    - mirrors:
+        - registry.stage.redhat.io/openshift5/topology-aware-lifecycle-manager-recovery-rhel9
+      source: registry.redhat.io/openshift5/topology-aware-lifecycle-manager-recovery-rhel9

--- a/.konflux/overlay/map_images.in.yaml
+++ b/.konflux/overlay/map_images.in.yaml
@@ -1,21 +1,21 @@
 ---
 # Manager
 - key: manager
-  production: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-rhel9-operator
-  staging: registry.stage.redhat.io/openshift4/topology-aware-lifecycle-manager-rhel9-operator
+  production: registry.redhat.io/openshift5/topology-aware-lifecycle-manager-rhel9-operator
+  staging: registry.stage.redhat.io/openshift5/topology-aware-lifecycle-manager-rhel9-operator
 #
 # Aztp
 - key: aztp_img
-  production: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-aztp-rhel9
-  staging: registry.stage.redhat.io/openshift4/topology-aware-lifecycle-manager-aztp-rhel9
+  production: registry.redhat.io/openshift5/topology-aware-lifecycle-manager-aztp-rhel9
+  staging: registry.stage.redhat.io/openshift5/topology-aware-lifecycle-manager-aztp-rhel9
 #
 # Precache
 - key: precache_img
-  production: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-precache-rhel9
-  staging: registry.stage.redhat.io/openshift4/topology-aware-lifecycle-manager-precache-rhel9
+  production: registry.redhat.io/openshift5/topology-aware-lifecycle-manager-precache-rhel9
+  staging: registry.stage.redhat.io/openshift5/topology-aware-lifecycle-manager-precache-rhel9
 #
 # Recovery
 - key: recovery_img
-  production: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-recovery-rhel9
-  staging: registry.stage.redhat.io/openshift4/topology-aware-lifecycle-manager-recovery-rhel9
+  production: registry.redhat.io/openshift5/topology-aware-lifecycle-manager-recovery-rhel9
+  staging: registry.stage.redhat.io/openshift5/topology-aware-lifecycle-manager-recovery-rhel9
 #

--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -22,3 +22,18 @@ spec:
     - mirrors:
         - quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-recovery-5-0
       source: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-recovery-rhel9
+    - mirrors:
+        - quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-5-0
+      source: registry.redhat.io/openshift5/topology-aware-lifecycle-manager-rhel9-operator
+    - mirrors:
+        - quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-5-0
+      source: registry.redhat.io/openshift5/topology-aware-lifecycle-manager-operator-bundle
+    - mirrors:
+        - quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-aztp-5-0
+      source: registry.redhat.io/openshift5/topology-aware-lifecycle-manager-aztp-rhel9
+    - mirrors:
+        - quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-precache-5-0
+      source: registry.redhat.io/openshift5/topology-aware-lifecycle-manager-precache-rhel9
+    - mirrors:
+        - quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-recovery-5-0
+      source: registry.redhat.io/openshift5/topology-aware-lifecycle-manager-recovery-rhel9

--- a/.tekton/topology-aware-lifecycle-manager-5-0-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-5-0-pull-request.yaml
@@ -64,7 +64,7 @@ spec:
       value: []
     - name: additional-labels
       value:
-        - name=openshift4/topology-aware-lifecycle-manager-rhel9-operator
+        - name=openshift5/topology-aware-lifecycle-manager-rhel9-operator
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-5-0-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-5-0-push.yaml
@@ -62,7 +62,7 @@ spec:
       value: ["latest"]
     - name: additional-labels
       value:
-        - name=openshift4/topology-aware-lifecycle-manager-rhel9-operator
+        - name=openshift5/topology-aware-lifecycle-manager-rhel9-operator
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-aztp-5-0-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-aztp-5-0-pull-request.yaml
@@ -61,7 +61,7 @@ spec:
       value: []
     - name: additional-labels
       value:
-        - name=openshift4/topology-aware-lifecycle-manager-aztp-rhel9
+        - name=openshift5/topology-aware-lifecycle-manager-aztp-rhel9
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-aztp-5-0-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-aztp-5-0-push.yaml
@@ -59,7 +59,7 @@ spec:
       value: ["latest"]
     - name: additional-labels
       value:
-        - name=openshift4/topology-aware-lifecycle-manager-aztp-rhel9
+        - name=openshift5/topology-aware-lifecycle-manager-aztp-rhel9
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-bundle-5-0-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-bundle-5-0-pull-request.yaml
@@ -67,7 +67,7 @@ spec:
       value: []
     - name: additional-labels
       value:
-        - name=openshift4/topology-aware-lifecycle-manager-operator-bundle
+        - name=openshift5/topology-aware-lifecycle-manager-operator-bundle
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-bundle-5-0-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-bundle-5-0-push.yaml
@@ -65,7 +65,7 @@ spec:
       value: ["latest"]
     - name: additional-labels
       value:
-        - name=openshift4/topology-aware-lifecycle-manager-operator-bundle
+        - name=openshift5/topology-aware-lifecycle-manager-operator-bundle
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-precache-5-0-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-precache-5-0-pull-request.yaml
@@ -62,7 +62,7 @@ spec:
       value: []
     - name: additional-labels
       value:
-        - name=openshift4/topology-aware-lifecycle-manager-precache-rhel9
+        - name=openshift5/topology-aware-lifecycle-manager-precache-rhel9
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-precache-5-0-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-precache-5-0-push.yaml
@@ -60,7 +60,7 @@ spec:
       value: ["latest"]
     - name: additional-labels
       value:
-        - name=openshift4/topology-aware-lifecycle-manager-precache-rhel9
+        - name=openshift5/topology-aware-lifecycle-manager-precache-rhel9
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-recovery-5-0-pull-request.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-recovery-5-0-pull-request.yaml
@@ -62,7 +62,7 @@ spec:
       value: []
     - name: additional-labels
       value:
-        - name=openshift4/topology-aware-lifecycle-manager-recovery-rhel9
+        - name=openshift5/topology-aware-lifecycle-manager-recovery-rhel9
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/topology-aware-lifecycle-manager-recovery-5-0-push.yaml
+++ b/.tekton/topology-aware-lifecycle-manager-recovery-5-0-push.yaml
@@ -60,7 +60,7 @@ spec:
       value: ["latest"]
     - name: additional-labels
       value:
-        - name=openshift4/topology-aware-lifecycle-manager-recovery-rhel9
+        - name=openshift5/topology-aware-lifecycle-manager-recovery-rhel9
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:


### PR DESCRIPTION
## Summary
- Switch all remaining image registry references from `openshift4/` to `openshift5/` namespace for OCP 5.0 alignment.
- Updates Tekton pipeline definitions (push/pull-request for operator, aztp, bundle, precache, recovery), image mirror set, Konflux overlay/IDMS configs, and catalog IDMS.
- Excludes submodule (`telco5g-konflux/`) and `ose-kube-rbac-proxy` references in `renovate.json` which remain on `openshift4`.

Jira: https://redhat.atlassian.net/browse/CNF-26586

Made with [Cursor](https://cursor.com)