### PR TITLE
CNF-26586: Remove openshift4 entry from catalog-idms

### DIFF
--- a/.konflux/catalog/bundle.builds.in.yaml
+++ b/.konflux/catalog/bundle.builds.in.yaml
@@ -1,2 +1,2 @@
 ---
-quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-5-0@sha256:cd59a492928dc66c93dbc616c8111ee09f41a1de92c147858b866a899eca93d5
+quay: quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-5-0@sha256:c9b8ae490361431629bce7894906954f12855450cef3f1fd08311bebba9a8ab9

--- a/.konflux/catalog/catalog-idms.yaml
+++ b/.konflux/catalog/catalog-idms.yaml
@@ -8,7 +8,4 @@ spec:
   imageDigestMirrors:
   - mirrors:
     - quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-5-0
-    source: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle
-  - mirrors:
-    - quay.io/redhat-user-workloads/telco-5g-tenant/topology-aware-lifecycle-manager-bundle-5-0
     source: registry.redhat.io/openshift5/topology-aware-lifecycle-manager-operator-bundle


### PR DESCRIPTION
## Summary
- Remove the now-unnecessary `openshift4` entry from `catalog-idms.yaml`, keeping only the `openshift5` entry.
- Follow-up to #11165 which added both entries during the migration.

Jira: https://redhat.atlassian.net/browse/CNF-26586

Made with [Cursor](https://cursor.com)