### PR TITLE
[release-4.14] Replace text/template with structured object construction for precache CM

### DIFF
--- a/controllers/managedClusterResources.go
+++ b/controllers/managedClusterResources.go
@@ -72,7 +72,6 @@ type resourceTemplate struct {
 
 var precacheDependenciesCreateTemplates = []resourceTemplate{
 	{"precache-ns-create", templates.MngClusterActCreatePrecachingNS},
-	{"precache-spec-cm-create", templates.MngClusterActCreatePrecachingSpecCM},
 	{"precache-sa-create", templates.MngClusterActCreateServiceAcct},
 	{"precache-crb-create", templates.MngClusterActCreateClusterRoleBinding},
 }

--- a/controllers/managedClusterResources_test.go
+++ b/controllers/managedClusterResources_test.go
@@ -31,46 +31,6 @@ func TestMCR_renderYamlTemplates(t *testing.T) {
 		result       string
 	}{
 		{
-			name:         "create configmap",
-			resourceName: "precache-spec",
-			data: templateData{
-				Cluster:                 "test",
-				ResourceName:            "precache-spec",
-				ExcludePrecachePatterns: []string{"aws", "thanos"},
-				AdditionalImages:        []string{"image1:tag", "image2:tag"},
-				SpaceRequired:           "45",
-			},
-			template: templates.MngClusterActCreatePrecachingSpecCM,
-			result: `
-apiVersion: action.open-cluster-management.io/v1beta1
-kind: ManagedClusterAction
-metadata:
-  name: precache-spec
-  namespace: test
-spec:
-  actionType: Create
-  kube:
-    resource: configmap
-    template:
-      apiVersion: v1
-      data:
-        excludePrecachePatterns: |
-          aws  
-          thanos 
-        additionalImages: |
-          image1:tag 
-          image2:tag 
-        operators.indexes: ""
-        operators.packagesAndChannels: ""
-        platform.image:
-        spaceRequired: "45"
-      kind: ConfigMap
-      metadata:
-        name: pre-cache-spec
-        namespace: openshift-talo-pre-cache
-`,
-		},
-		{
 			name:         "create namespace",
 			resourceName: "test-ns",
 			data: templateData{

--- a/controllers/precache.go
+++ b/controllers/precache.go
@@ -18,6 +18,7 @@ import (
 	ranv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/api/v1alpha1"
 	"github.com/openshift-kni/cluster-group-upgrades-operator/controllers/utils"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -245,6 +246,16 @@ func (r *ClusterGroupUpgradeReconciler) deployDependencies(
 	if err != nil {
 		return false, err
 	}
+
+	spec.ResourceName = "precache-spec-cm-create"
+	cmAction := buildPrecacheSpecConfigMapAction(*spec)
+	if err := r.Create(ctx, cmAction); err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return false, err
+		}
+		r.Log.Info("[deployDependencies] ConfigMap MCA already exists", "cluster", cluster)
+	}
+
 	spec.ViewUpdateIntervalSec = utils.GetMCVUpdateInterval(len(clusterGroupUpgrade.Status.Precaching.Status))
 	err = r.createResourcesFromTemplates(ctx, spec, precacheDependenciesViewTemplates)
 	if err != nil {
@@ -332,6 +343,46 @@ func (r *ClusterGroupUpgradeReconciler) getPrecacheSpecTemplateData(
 	rv.AdditionalImages = spec.AdditionalImages
 	rv.SpaceRequired = spec.SpaceRequired
 	return rv
+}
+
+// buildPrecacheSpecConfigMapAction constructs the ManagedClusterAction for the
+// pre-cache-spec ConfigMap as a typed Go object instead of rendering a text template,
+// ensuring user-supplied strings are safely embedded as map values.
+func buildPrecacheSpecConfigMapAction(data templateData) *unstructured.Unstructured {
+	cmData := map[string]interface{}{
+		"operators.indexes":             strings.Join(data.Operators.Indexes, "\n"),
+		"operators.packagesAndChannels": strings.Join(data.Operators.PackagesAndChannels, "\n"),
+		"excludePrecachePatterns":       strings.Join(data.ExcludePrecachePatterns, "\n"),
+		"additionalImages":              strings.Join(data.AdditionalImages, "\n"),
+		"platform.image":                data.PlatformImage,
+		"spaceRequired":                 data.SpaceRequired,
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "action.open-cluster-management.io/v1beta1",
+			"kind":       "ManagedClusterAction",
+			"metadata": map[string]interface{}{
+				"name":      data.ResourceName,
+				"namespace": data.Cluster,
+			},
+			"spec": map[string]interface{}{
+				"actionType": "Create",
+				"kube": map[string]interface{}{
+					"resource": "configmap",
+					"template": map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]interface{}{
+							"name":      "pre-cache-spec",
+							"namespace": "openshift-talo-pre-cache",
+						},
+						"data": cmData,
+					},
+				},
+			},
+		},
+	}
 }
 
 // includePreCachingConfigs retrieves the PreCachingConfigCR associated to the CGU

--- a/controllers/precache_test.go
+++ b/controllers/precache_test.go
@@ -1,8 +1,15 @@
 package controllers
 
 import (
-	"github.com/stretchr/testify/assert"
+	"bytes"
+	"strings"
 	"testing"
+	"text/template"
+
+	"github.com/openshift-kni/cluster-group-upgrades-operator/controllers/templates"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 )
 
 func TestPrecache_parseSpaceRequired(t *testing.T) {
@@ -119,4 +126,232 @@ func TestPrecache_parseSpaceRequired(t *testing.T) {
 			assert.Equal(t, tc.expectedSpaceRequiredGiB, parsedSpaceRequired)
 		})
 	}
+}
+
+func TestPrecache_buildPrecacheSpecConfigMapAction(t *testing.T) {
+	testCases := []struct {
+		name     string
+		data     templateData
+		expected map[string]interface{}
+	}{
+		{
+			name: "basic fields",
+			data: templateData{
+				Cluster:       "spoke1",
+				ResourceName:  "precache-spec-cm-create",
+				PlatformImage: "quay.io/openshift-release-dev/ocp-release@sha256:abc123",
+				Operators: operatorsData{
+					Indexes:             []string{"registry.example.com:5000/redhat-operators:v4.11"},
+					PackagesAndChannels: []string{"ptp-operator:4.9", "sriov-network-operator:4.9"},
+				},
+				ExcludePrecachePatterns: []string{"aws", "thanos"},
+				AdditionalImages:        []string{"image1:tag", "image2:tag"},
+				SpaceRequired:           "45",
+			},
+			expected: map[string]interface{}{
+				"operators.indexes":             "registry.example.com:5000/redhat-operators:v4.11",
+				"operators.packagesAndChannels": "ptp-operator:4.9\nsriov-network-operator:4.9",
+				"excludePrecachePatterns":       "aws\nthanos",
+				"additionalImages":              "image1:tag\nimage2:tag",
+				"platform.image":                "quay.io/openshift-release-dev/ocp-release@sha256:abc123",
+				"spaceRequired":                 "45",
+			},
+		},
+		{
+			name: "empty arrays produce empty strings",
+			data: templateData{
+				Cluster:       "spoke1",
+				ResourceName:  "precache-spec-cm-create",
+				PlatformImage: "",
+				Operators: operatorsData{
+					Indexes:             []string{},
+					PackagesAndChannels: []string{},
+				},
+				ExcludePrecachePatterns: []string{},
+				AdditionalImages:        []string{},
+				SpaceRequired:           "10",
+			},
+			expected: map[string]interface{}{
+				"operators.indexes":             "",
+				"operators.packagesAndChannels": "",
+				"excludePrecachePatterns":       "",
+				"additionalImages":              "",
+				"platform.image":                "",
+				"spaceRequired":                 "10",
+			},
+		},
+		{
+			name: "special characters in input are preserved as string values",
+			data: templateData{
+				Cluster:      "spoke1",
+				ResourceName: "precache-spec-cm-create",
+				Operators: operatorsData{
+					PackagesAndChannels: []string{"operator:4.9\n    extra-key: extra-value"},
+					Indexes:             []string{"# not-a-comment"},
+				},
+				ExcludePrecachePatterns: []string{"pattern\nother: true"},
+				AdditionalImages:        []string{`image:tag", "extra": "field`},
+				SpaceRequired:           "10",
+			},
+			expected: map[string]interface{}{
+				"operators.indexes":             "# not-a-comment",
+				"operators.packagesAndChannels": "operator:4.9\n    extra-key: extra-value",
+				"excludePrecachePatterns":       "pattern\nother: true",
+				"additionalImages":              `image:tag", "extra": "field`,
+				"platform.image":                "",
+				"spaceRequired":                 "10",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := buildPrecacheSpecConfigMapAction(tc.data)
+
+			assert.Equal(t, "action.open-cluster-management.io/v1beta1", obj.GetAPIVersion())
+			assert.Equal(t, "ManagedClusterAction", obj.GetKind())
+			assert.Equal(t, tc.data.ResourceName, obj.GetName())
+			assert.Equal(t, tc.data.Cluster, obj.GetNamespace())
+
+			spec, found, err := unstructured.NestedMap(obj.Object, "spec")
+			assert.NoError(t, err)
+			assert.True(t, found)
+			assert.Equal(t, "Create", spec["actionType"])
+
+			kube := spec["kube"].(map[string]interface{})
+			assert.Equal(t, "configmap", kube["resource"])
+
+			tmpl := kube["template"].(map[string]interface{})
+			assert.Equal(t, "v1", tmpl["apiVersion"])
+			assert.Equal(t, "ConfigMap", tmpl["kind"])
+
+			meta := tmpl["metadata"].(map[string]interface{})
+			assert.Equal(t, "pre-cache-spec", meta["name"])
+			assert.Equal(t, "openshift-talo-pre-cache", meta["namespace"])
+
+			cmData := tmpl["data"].(map[string]interface{})
+			for key, expectedValue := range tc.expected {
+				assert.Equal(t, expectedValue, cmData[key], "mismatch for ConfigMap data key %q", key)
+			}
+		})
+	}
+}
+
+func TestPrecache_buildPrecacheSpecConfigMapAction_equivalence(t *testing.T) {
+	// This is the old template that was removed from precache-templates.go.
+	// We keep it here to verify that the new builder produces functionally
+	// equivalent ConfigMap data values for the same inputs.
+	const oldTemplate = `
+{{ template "actionGVK"}}
+{{ template "metadata" . }}
+spec:
+  actionType: Create
+  kube:
+    resource: configmap
+    template:
+      apiVersion: v1
+      data:
+        operators.indexes: |{{ range .Operators.Indexes }}
+          {{ . }} {{ end }}
+        operators.packagesAndChannels: |{{ range .Operators.PackagesAndChannels }} 
+          {{ . }} {{ end }}
+        excludePrecachePatterns: |{{ range .ExcludePrecachePatterns }} 
+          {{ . }} {{ end }}
+        additionalImages: |{{ range .AdditionalImages }}
+          {{ . }} {{ end }}
+        platform.image: {{ .PlatformImage }}
+        spaceRequired: "{{ .SpaceRequired }}"
+      kind: ConfigMap
+      metadata:
+        name: pre-cache-spec
+        namespace: openshift-talo-pre-cache
+`
+
+	data := templateData{
+		Cluster:       "spoke1",
+		ResourceName:  "precache-spec-cm-create",
+		PlatformImage: "quay.io/openshift-release-dev/ocp-release@sha256:abc123",
+		Operators: operatorsData{
+			Indexes: []string{
+				"registry.example.com:5000/redhat-operators:v4.11",
+				"registry.example.com:5000/certified-operators:v4.11",
+				"registry.example.com:5000/community-operators:v4.11",
+			},
+			PackagesAndChannels: []string{
+				"ptp-operator:4.9",
+				"sriov-network-operator:4.9",
+				"performance-addon-operator:4.9",
+				"local-storage-operator:stable",
+				"cluster-logging:stable",
+			},
+		},
+		ExcludePrecachePatterns: []string{"aws", "thanos", "azure", "gcp"},
+		AdditionalImages: []string{
+			"quay.io/example/app1:v1.0",
+			"quay.io/example/app2:v2.0",
+			"quay.io/example/app3@sha256:def456",
+		},
+		SpaceRequired: "45",
+	}
+
+	// Render using the old template
+	w := new(bytes.Buffer)
+	tmpl, err := template.New("old").Parse(templates.CommonTemplates + oldTemplate)
+	assert.NoError(t, err)
+	err = tmpl.Execute(w, data)
+	assert.NoError(t, err)
+
+	oldObj := &unstructured.Unstructured{}
+	dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	_, _, err = dec.Decode(w.Bytes(), nil, oldObj)
+	assert.NoError(t, err)
+
+	// Build using the new builder
+	newObj := buildPrecacheSpecConfigMapAction(data)
+
+	// Extract ConfigMap data from both
+	oldKube := oldObj.Object["spec"].(map[string]interface{})["kube"].(map[string]interface{})
+	oldCMData := oldKube["template"].(map[string]interface{})["data"].(map[string]interface{})
+
+	newKube := newObj.Object["spec"].(map[string]interface{})["kube"].(map[string]interface{})
+	newCMData := newKube["template"].(map[string]interface{})["data"].(map[string]interface{})
+
+	// The old template produces values with trailing whitespace/newlines from the
+	// {{ range }} iteration. Trim both sides before comparing to verify functional
+	// equivalence (the pre-cache workload trims values when reading them).
+	for _, key := range []string{"platform.image", "spaceRequired"} {
+		assert.Equal(t, oldCMData[key], newCMData[key], "scalar field %q differs", key)
+	}
+
+	// For array fields, the old template produces block scalars with leading/trailing
+	// whitespace per element. Compare the trimmed, split lines.
+	arrayKeys := []string{"operators.indexes", "operators.packagesAndChannels", "excludePrecachePatterns", "additionalImages"}
+	for _, key := range arrayKeys {
+		oldVal := strings.TrimSpace(oldCMData[key].(string))
+		newVal := strings.TrimSpace(newCMData[key].(string))
+
+		oldLines := splitAndTrim(oldVal)
+		newLines := splitAndTrim(newVal)
+
+		assert.Equal(t, oldLines, newLines, "array field %q has different elements", key)
+	}
+
+	// Verify structural equivalence of the MCA envelope
+	assert.Equal(t, oldObj.GetAPIVersion(), newObj.GetAPIVersion())
+	assert.Equal(t, oldObj.GetKind(), newObj.GetKind())
+	assert.Equal(t, oldObj.GetName(), newObj.GetName())
+	assert.Equal(t, oldObj.GetNamespace(), newObj.GetNamespace())
+	assert.Equal(t, oldKube["resource"], newKube["resource"])
+}
+
+func splitAndTrim(s string) []string {
+	parts := strings.Split(s, "\n")
+	var result []string
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }

--- a/controllers/templates/precache-templates.go
+++ b/controllers/templates/precache-templates.go
@@ -40,33 +40,6 @@ spec:
           workload.openshift.io/allowed: management
 `
 
-// MngClusterActCreatePrecachingSpecCM creates precachingSpec configmap
-const MngClusterActCreatePrecachingSpecCM string = `
-{{ template "actionGVK"}}
-{{ template "metadata" . }}
-spec:
-  actionType: Create
-  kube:
-    resource: configmap
-    template:
-      apiVersion: v1
-      data:
-        operators.indexes: |{{ range .Operators.Indexes }}
-          {{ . }} {{ end }}
-        operators.packagesAndChannels: |{{ range .Operators.PackagesAndChannels }} 
-          {{ . }} {{ end }}
-        excludePrecachePatterns: |{{ range .ExcludePrecachePatterns }} 
-          {{ . }} {{ end }}
-        additionalImages: |{{ range .AdditionalImages }}
-          {{ . }} {{ end }}
-        platform.image: {{ .PlatformImage }}
-        spaceRequired: "{{ .SpaceRequired }}"
-      kind: ConfigMap
-      metadata:
-        name: pre-cache-spec
-        namespace: openshift-talo-pre-cache
-`
-
 // MngClusterActCreateServiceAcct creates serviceaccount
 const MngClusterActCreateServiceAcct string = `
 {{ template "actionGVK"}}

--- a/tests/kuttl/tests/pre-caching-complete/01-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-complete/01-assert.yaml
@@ -159,12 +159,15 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
-          \  \nperformance-addon-operator:4.9 \n"
-        platform.image: null
-        spaceRequired: '35'
+        additionalImages: ""
+        excludePrecachePatterns: ""
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          ptp-operator:4.9
+          sriov-network-operator:4.9
+          performance-addon-operator:4.9
+        platform.image: ""
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -240,12 +243,15 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
-          \  \nperformance-addon-operator:4.9 \n"
-        platform.image: null
-        spaceRequired: '35'
+        additionalImages: ""
+        excludePrecachePatterns: ""
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          ptp-operator:4.9
+          sriov-network-operator:4.9
+          performance-addon-operator:4.9
+        platform.image: ""
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -321,12 +327,15 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
-          \  \nperformance-addon-operator:4.9 \n"
-        platform.image: null
-        spaceRequired: '35'
+        additionalImages: ""
+        excludePrecachePatterns: ""
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          ptp-operator:4.9
+          sriov-network-operator:4.9
+          performance-addon-operator:4.9
+        platform.image: ""
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -402,12 +411,15 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
-          \  \nperformance-addon-operator:4.9 \n"
-        platform.image: null
-        spaceRequired: '35'
+        additionalImages: ""
+        excludePrecachePatterns: ""
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          ptp-operator:4.9
+          sriov-network-operator:4.9
+          performance-addon-operator:4.9
+        platform.image: ""
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec

--- a/tests/kuttl/tests/pre-caching-partial-complete/01-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-partial-complete/01-assert.yaml
@@ -158,11 +158,15 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
-          \  \nperformance-addon-operator:4.9 \n"
-        platform.image: null
+        additionalImages: ""
+        excludePrecachePatterns: ""
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          ptp-operator:4.9
+          sriov-network-operator:4.9
+          performance-addon-operator:4.9
+        platform.image: ""
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -238,11 +242,15 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
-          \  \nperformance-addon-operator:4.9 \n"
-        platform.image: null
+        additionalImages: ""
+        excludePrecachePatterns: ""
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          ptp-operator:4.9
+          sriov-network-operator:4.9
+          performance-addon-operator:4.9
+        platform.image: ""
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -318,11 +326,15 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
-          \  \nperformance-addon-operator:4.9 \n"
-        platform.image: null
+        additionalImages: ""
+        excludePrecachePatterns: ""
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          ptp-operator:4.9
+          sriov-network-operator:4.9
+          performance-addon-operator:4.9
+        platform.image: ""
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec
@@ -398,11 +410,15 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "ptp-operator:4.9  \nsriov-network-operator:4.9\
-          \  \nperformance-addon-operator:4.9 \n"
-        platform.image: null
+        additionalImages: ""
+        excludePrecachePatterns: ""
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          ptp-operator:4.9
+          sriov-network-operator:4.9
+          performance-addon-operator:4.9
+        platform.image: ""
+        spaceRequired: "35"
       kind: ConfigMap
       metadata:
         name: pre-cache-spec

--- a/tests/kuttl/tests/pre-caching-with-configs/02-assert.yaml
+++ b/tests/kuttl/tests/pre-caching-with-configs/02-assert.yaml
@@ -13,6 +13,7 @@ spec:
   enable: false
   managedPolicies:
   - policy0-common-config-policy
+  - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   - policy3-common-ptp-sub-policy
   - policy4-common-sriov-sub-policy
@@ -42,11 +43,9 @@ status:
     reason: InProgress
     status: 'False'
     type: PrecachingSuceeded
-  copiedPolicies:
-  - cgu-policy3-common-ptp-sub-policy-kuttl
-  - cgu-policy4-common-sriov-sub-policy-kuttl
   managedPoliciesCompliantBeforeUpgrade:
   - policy0-common-config-policy
+  - policy1-common-cluster-version-policy
   - policy2-common-pao-sub-policy
   managedPoliciesContent:
     policy3-common-ptp-sub-policy: '[{"kind":"Subscription","name":"ptp-operator-subscription","apiVersion":"operators.coreos.com/v1alpha1","namespace":"openshift-ptp"}]'
@@ -62,12 +61,12 @@ status:
   placementBindings:
   - cgu-policy3-common-ptp-sub-policy-placement-kuttl
   - cgu-policy4-common-sriov-sub-policy-placement-kuttl
-  placementRules:
+  placements:
   - cgu-policy3-common-ptp-sub-policy-placement-kuttl
   - cgu-policy4-common-sriov-sub-policy-placement-kuttl
   precaching:
     spec:
-      platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
+      platformImage: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
       operatorsIndexes:
       - e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
       operatorsPackagesAndChannels:
@@ -92,13 +91,10 @@ status:
     - spoke1
     - spoke5
   safeResourceNames:
-    /cgu-common-ptp-sub-policy-config: cgu-common-ptp-sub-policy-config-kuttl
-    /cgu-common-sriov-sub-policy-config: cgu-common-sriov-sub-policy-config-kuttl
-    default/cgu-policy3-common-ptp-sub-policy: cgu-policy3-common-ptp-sub-policy-kuttl
     default/cgu-policy3-common-ptp-sub-policy-placement: cgu-policy3-common-ptp-sub-policy-placement-kuttl
-    default/cgu-policy4-common-sriov-sub-policy: cgu-policy4-common-sriov-sub-policy-kuttl
     default/cgu-policy4-common-sriov-sub-policy-placement: cgu-policy4-common-sriov-sub-policy-placement-kuttl
 ---
+# MCAs
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -169,13 +165,18 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable\
-          \  \nsriov-network-operator:stable \n"
-        platform.image: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
-        excludePrecachePatterns: "aws  \nazure \n"
-        additionalImages: "image1:latest \nimage2:latest \n"
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          performance-addon-operator:stable
+          ptp-operator:stable
+          sriov-network-operator:stable
+        platform.image: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
+        excludePrecachePatterns: |-
+          aws
+          azure
+        additionalImages: |-
+          image1:latest
+          image2:latest
         spaceRequired: '40'
       kind: ConfigMap
       metadata:
@@ -252,13 +253,18 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable\
-          \  \nsriov-network-operator:stable \n"
-        platform.image: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
-        excludePrecachePatterns: "aws  \nazure \n"
-        additionalImages: "image1:latest \nimage2:latest \n"
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          performance-addon-operator:stable
+          ptp-operator:stable
+          sriov-network-operator:stable
+        platform.image: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
+        excludePrecachePatterns: |-
+          aws
+          azure
+        additionalImages: |-
+          image1:latest
+          image2:latest
         spaceRequired: '40'
       kind: ConfigMap
       metadata:
@@ -335,13 +341,18 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable\
-          \  \nsriov-network-operator:stable \n"
-        platform.image: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
-        excludePrecachePatterns: "aws  \nazure \n"
-        additionalImages: "image1:latest \nimage2:latest \n"
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          performance-addon-operator:stable
+          ptp-operator:stable
+          sriov-network-operator:stable
+        platform.image: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
+        excludePrecachePatterns: |-
+          aws
+          azure
+        additionalImages: |-
+          image1:latest
+          image2:latest
         spaceRequired: '40'
       kind: ConfigMap
       metadata:
@@ -418,13 +429,18 @@ spec:
     template:
       apiVersion: v1
       data:
-        operators.indexes: "e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11\
-          \ \n"
-        operators.packagesAndChannels: "performance-addon-operator:stable  \nptp-operator:stable\
-          \  \nsriov-network-operator:stable \n"
-        platform.image: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
-        excludePrecachePatterns: "aws  \nazure \n"
-        additionalImages: "image1:latest \nimage2:latest \n"
+        operators.indexes: e27-h01-000-r650.rdu2.scalelab.redhat.com:5000/olm-mirror/redhat-operator-index:v4.11
+        operators.packagesAndChannels: |-
+          performance-addon-operator:stable
+          ptp-operator:stable
+          sriov-network-operator:stable
+        platform.image: quay.io/openshift-release-dev/ocp-release@sha256:c91c0faf7ae3c480724a935b3dab7e5f49aae19d195b12f3a4ae38f8440ea96b
+        excludePrecachePatterns: |-
+          aws
+          azure
+        additionalImages: |-
+          image1:latest
+          image2:latest
         spaceRequired: '40'
       kind: ConfigMap
       metadata:


### PR DESCRIPTION
## Summary

* Backport of #10175 to `release-4.14`
* Replace `text/template` with structured Go object construction for precache ConfigMap MCA
* User-supplied values are assigned as map entries rather than interpolated into raw YAML

## Test plan

* `go build ./...` compiles successfully
* CI integration tests (kuttl) pass

Made with [Cursor](https://cursor.com)