### PR TITLE
CNF-26799: Seed catalog-template with released 4.22.0 bundle

### DIFF
--- a/.konflux/catalog/catalog-template.in.yaml
+++ b/.konflux/catalog/catalog-template.in.yaml
@@ -9,22 +9,21 @@ entries:
     schema: olm.package
   # Channel entries for 'stable' channel
   - entries:
-      # v5.0.0
-      - name: topology-aware-lifecycle-manager.v5.0.0
-        skipRange: '>=4.22.0 <5.0.0'
+      # v4.22.0
+      - name: topology-aware-lifecycle-manager.v4.22.0
+        skipRange: '>=4.20.0 <4.22.0'
     name: stable
     package: topology-aware-lifecycle-manager
     schema: olm.channel
-  # Channel entries for '5.0' channel
+  # Channel entries for '4.22' channel
   - entries:
-      # v5.0.0
-      - name: topology-aware-lifecycle-manager.v5.0.0
-        skipRange: '>=4.22.0 <5.0.0'
-    name: "5.0"
+      # v4.22.0
+      - name: topology-aware-lifecycle-manager.v4.22.0
+        skipRange: '>=4.20.0 <4.22.0'
+    name: "4.22"
     package: topology-aware-lifecycle-manager
     schema: olm.channel
-  # v5.0.0 bundle
-  # The url for this last entry is updated by telco5g-konflux/scripts/catalog/update-catalog-template.sh automatically
-  - image: placeholder.will.be.updated.by.telco5g-konflux.scripts.catalog.update-catalog-template.sh
+  # v4.22.0 bundle
+  - image: registry.redhat.io/openshift4/topology-aware-lifecycle-manager-operator-bundle@sha256:0c7970b4e55113c342a5c13cc74913acf5c26714831fa6511077a81c2cf82b13
     schema: olm.bundle
 schema: olm.template.basic

--- a/.tekton/fbc-pipeline.yaml
+++ b/.tekton/fbc-pipeline.yaml
@@ -142,9 +142,9 @@ spec:
       value: $(params.image-expires-after)
     - name: SCRIPT_RUNNER_IMAGE
       value: quay.io/konflux-ci/yq:latest
-        # update catalog template
+        # skip catalog template update; render catalog-template.in.yaml as-is
     - name: SCRIPT
-      value: ./telco5g-konflux/scripts/catalog/konflux-update-catalog-template.sh --set-catalog-template-input-file .konflux/catalog/catalog-template.in.yaml --set-bundle-builds-file .konflux/catalog/bundle.builds.in.yaml
+      value: "true"
     - name: HERMETIC
       value: $(params.hermetic)
     - name: SOURCE_ARTIFACT


### PR DESCRIPTION
## Summary
- Replace the 5.0 placeholder catalog template with the published 4.22.0 entry from `registry.redhat.io/redhat/redhat-operator-index:v4.22`
- Include the released `registry.redhat.io/openshift4/` bundle digest; omit the in-progress placeholder and all 5.0 channel/bundle entries
- Skip the FBC pipeline catalog-template update so the published 4.22.0 entry is rendered as-is (same approach as https://github.com/openshift-kni/lifecycle-agent/pull/8624)

## Test plan
- Confirm `catalog-template.in.yaml` lists only `v4.22.0` in `stable` and `4.22` channels
- Confirm there is no placeholder image entry and no `5.0` channel
- Confirm `run-opm-pre-actions` SCRIPT is `"true"` so `bundle.builds.in.yaml` cannot overwrite the last bundle

## Jira
https://redhat.atlassian.net/browse/CNF-26799

Blocker: https://redhat.atlassian.net/browse/CLOUDDST-32983 (fbc-inject-lifecycle skips COPY --from=builder in Dockerfile.catalog)