### PR TITLE
OCPBUGS-122218: ztp-deploy-wave annotation: read from root policy instead of child policy

### DIFF
--- a/controllers/managedclusterForCGU_controller.go
+++ b/controllers/managedclusterForCGU_controller.go
@@ -178,7 +178,11 @@ func (r *ManagedClusterForCguReconciler) newClusterGroupUpgrade(
 
 	// Generate a list of ordered managed policies based on the deploy wave.
 	// Deploywave is a way to order deployment of policies, it's defined
-	// as a annotation in policy.
+	// as an annotation on the root (parent) policy - i.e. the Policy CR
+	// created by the user in its own namespace - not on the child policy
+	// copied by ACM into the managed cluster's namespace, becausei f the
+	// root policy has .spec.copyPolicyMetadata=false, the annotation
+	// won't be copied to the child policy.
 	// For example,
 	//   metadata:
 	//     annotations:
@@ -192,19 +196,26 @@ func (r *ManagedClusterForCguReconciler) newClusterGroupUpgrade(
 			continue
 		}
 
-		deployWave, found := cPolicy.GetAnnotations()[ztpDeployWaveAnnotation]
+		policyName, err := utils.GetParentPolicyNameAndNamespace(cPolicy.GetName())
+		if err != nil {
+			r.Log.Info("Ignoring policy with invalid name", "policy", cPolicy.Name)
+			continue
+		}
+		rootNs, rootName := policyName[0], policyName[1]
+
+		rootPolicy := &policiesv1.Policy{}
+		if err := r.Get(ctx, types.NamespacedName{Name: rootName, Namespace: rootNs}, rootPolicy); err != nil {
+			return fmt.Errorf("failed to get root policy %s/%s for child policy %s: %w", rootNs, rootName, cPolicy.GetName(), err)
+		}
+
+		deployWave, found := rootPolicy.GetAnnotations()[ztpDeployWaveAnnotation]
 		if found {
 			deployWaveInt, err := strconv.Atoi(deployWave)
 			if err != nil {
 				// err convert from string to int
-				return fmt.Errorf("%s in policy %s is not an interger: %s", ztpDeployWaveAnnotation, cPolicy.GetName(), err)
+				return fmt.Errorf("%s in policy %s is not an interger: %s", ztpDeployWaveAnnotation, rootName, err)
 			}
-			policyName, err := utils.GetParentPolicyNameAndNamespace(cPolicy.GetName())
-			if err != nil {
-				r.Log.Info("Ignoring policy with invalid name", "policy", cPolicy.Name)
-				continue
-			}
-			policyWaveMap[policyName[1]] = deployWaveInt
+			policyWaveMap[rootName] = deployWaveInt
 		}
 	}
 

--- a/controllers/managedclusterForCGU_controller_test.go
+++ b/controllers/managedclusterForCGU_controller_test.go
@@ -182,6 +182,12 @@ func TestControllerReconciler(t *testing.T) {
 				},
 				&policiesv1.Policy{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:      "common-config-policy",
+						Namespace: "ztp-common",
+					},
+				},
+				&policiesv1.Policy{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "ztp-common.common-sub-policy",
 						Namespace: "testSpoke",
 						Labels:    map[string]string{utils.ChildPolicyLabel: "ztp-common.common-sub-policy"},
@@ -189,9 +195,21 @@ func TestControllerReconciler(t *testing.T) {
 				},
 				&policiesv1.Policy{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:      "common-sub-policy",
+						Namespace: "ztp-common",
+					},
+				},
+				&policiesv1.Policy{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "ztp-group.group-du-config-policy",
 						Namespace: "testSpoke",
 						Labels:    map[string]string{utils.ChildPolicyLabel: "ztp-group.group-du-config-policy"},
+					},
+				},
+				&policiesv1.Policy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "group-du-config-policy",
+						Namespace: "ztp-group",
 					},
 				},
 			},
@@ -224,17 +242,29 @@ func TestControllerReconciler(t *testing.T) {
 				},
 				&policiesv1.Policy{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "ztp-common.common-config-policy",
-						Namespace:   "testSpoke",
-						Labels:      map[string]string{utils.ChildPolicyLabel: "ztp-common.common-config-policy"},
+						Name:      "ztp-common.common-config-policy",
+						Namespace: "testSpoke",
+						Labels:    map[string]string{utils.ChildPolicyLabel: "ztp-common.common-config-policy"},
+					},
+				},
+				&policiesv1.Policy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "common-config-policy",
+						Namespace:   "ztp-common",
 						Annotations: map[string]string{"ran.openshift.io/ztp-deploy-wave": "1"},
 					},
 				},
 				&policiesv1.Policy{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "ztp-common.common-sub-policy",
-						Namespace:   "testSpoke",
-						Labels:      map[string]string{utils.ChildPolicyLabel: "ztp-common.common-sub-policy"},
+						Name:      "ztp-common.common-sub-policy",
+						Namespace: "testSpoke",
+						Labels:    map[string]string{utils.ChildPolicyLabel: "ztp-common.common-sub-policy"},
+					},
+				},
+				&policiesv1.Policy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "common-sub-policy",
+						Namespace:   "ztp-common",
 						Annotations: map[string]string{"ran.openshift.io/ztp-deploy-wave": "20"},
 					},
 				},
@@ -243,6 +273,12 @@ func TestControllerReconciler(t *testing.T) {
 						Name:      "ztp-group.group-du-config-policy",
 						Namespace: "testSpoke",
 						Labels:    map[string]string{utils.ChildPolicyLabel: "ztp-group.group-du-config-policy"},
+					},
+				},
+				&policiesv1.Policy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "group-du-config-policy",
+						Namespace: "ztp-group",
 					},
 				},
 			},
@@ -293,13 +329,23 @@ func TestControllerReconciler(t *testing.T) {
 				},
 				&policiesv1.Policy{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "ztp-common.common-config-policy",
-						Namespace:   "testSpoke",
-						Labels:      map[string]string{utils.ChildPolicyLabel: "ztp-common.common-config-policy"},
+						Name:      "ztp-common.common-config-policy",
+						Namespace: "testSpoke",
+						Labels:    map[string]string{utils.ChildPolicyLabel: "ztp-common.common-config-policy"},
+					},
+				},
+				&policiesv1.Policy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "common-config-policy",
+						Namespace:   "ztp-common",
 						Annotations: map[string]string{"ran.openshift.io/ztp-deploy-wave": "1"},
 					},
 				},
 				&policiesv1.Policy{
+					// This child policy is a copy created by CGU processing (see the
+					// "openshift-cluster-group-upgrades/clusterGroupUpgrade" label) and is
+					// filtered out by GetChildPolicies before the root policy is ever looked
+					// up, so no matching root policy is needed here.
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "ztp-common.common-sub-policy",
 						Namespace: "testSpoke",
@@ -310,9 +356,15 @@ func TestControllerReconciler(t *testing.T) {
 				},
 				&policiesv1.Policy{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "ztp-group.group-du-config-policy",
-						Namespace:   "testSpoke",
-						Labels:      map[string]string{utils.ChildPolicyLabel: "ztp-group.group-du-config-policy"},
+						Name:      "ztp-group.group-du-config-policy",
+						Namespace: "testSpoke",
+						Labels:    map[string]string{utils.ChildPolicyLabel: "ztp-group.group-du-config-policy"},
+					},
+				},
+				&policiesv1.Policy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "group-du-config-policy",
+						Namespace:   "ztp-group",
 						Annotations: map[string]string{"ran.openshift.io/ztp-deploy-wave": "30"},
 					},
 				},
@@ -364,25 +416,43 @@ func TestControllerReconciler(t *testing.T) {
 				},
 				&policiesv1.Policy{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "ztp-common.common-config-policy",
-						Namespace:   "testSpoke",
-						Labels:      map[string]string{utils.ChildPolicyLabel: "ztp-common.common-config-policy"},
+						Name:      "ztp-common.common-config-policy",
+						Namespace: "testSpoke",
+						Labels:    map[string]string{utils.ChildPolicyLabel: "ztp-common.common-config-policy"},
+					},
+				},
+				&policiesv1.Policy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "common-config-policy",
+						Namespace:   "ztp-common",
 						Annotations: map[string]string{"ran.openshift.io/ztp-deploy-wave": "1"},
 					},
 				},
 				&policiesv1.Policy{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "ztp-common.common-sub-4.11-policy",
-						Namespace:   "testSpoke",
-						Labels:      map[string]string{utils.ChildPolicyLabel: "ztp-common.common-sub-4.11-policy"},
+						Name:      "ztp-common.common-sub-4.11-policy",
+						Namespace: "testSpoke",
+						Labels:    map[string]string{utils.ChildPolicyLabel: "ztp-common.common-sub-4.11-policy"},
+					},
+				},
+				&policiesv1.Policy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "common-sub-4.11-policy",
+						Namespace:   "ztp-common",
 						Annotations: map[string]string{"ran.openshift.io/ztp-deploy-wave": "2"},
 					},
 				},
 				&policiesv1.Policy{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "ztp-group.group-du-config-policy",
-						Namespace:   "testSpoke",
-						Labels:      map[string]string{utils.ChildPolicyLabel: "ztp-group.group-du-config-policy"},
+						Name:      "ztp-group.group-du-config-policy",
+						Namespace: "testSpoke",
+						Labels:    map[string]string{utils.ChildPolicyLabel: "ztp-group.group-du-config-policy"},
+					},
+				},
+				&policiesv1.Policy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "group-du-config-policy",
+						Namespace:   "ztp-group",
 						Annotations: map[string]string{"ran.openshift.io/ztp-deploy-wave": "1000000000000000"},
 					},
 				},
@@ -486,6 +556,17 @@ func TestControllerReconcileWithHundredClusters(t *testing.T) {
 	}
 	objs = append(objs, ns)
 
+	// The root policy is shared by all 100 spoke clusters (same name/namespace,
+	// only the child policy namespace changes per cluster), so it only needs to
+	// be added once.
+	objs = append(objs, &policiesv1.Policy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "common-config-policy",
+			Namespace:   "ztp-common",
+			Annotations: map[string]string{"ran.openshift.io/ztp-deploy-wave": "1"},
+		},
+	})
+
 	for i := 1; i <= 100; i++ {
 		name := "spoke" + strconv.Itoa(i)
 		cluster := &clusterv1.ManagedCluster{
@@ -505,10 +586,9 @@ func TestControllerReconcileWithHundredClusters(t *testing.T) {
 
 		policy := &policiesv1.Policy{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "ztp-common.common-config-policy",
-				Namespace:   name,
-				Labels:      map[string]string{utils.ChildPolicyLabel: "ztp-common.common-config-policy"},
-				Annotations: map[string]string{"ran.openshift.io/ztp-deploy-wave": "1"},
+				Name:      "ztp-common.common-config-policy",
+				Namespace: name,
+				Labels:    map[string]string{utils.ChildPolicyLabel: "ztp-common.common-config-policy"},
 			},
 		}
 		objs = append(objs, policy)


### PR DESCRIPTION
### Summary

The `ran.openshift.io/ztp-deploy-wave` annotation used by `ManagedClusterForCguReconciler` to order policies when auto-generating a `ClusterGroupUpgrade` for a newly-ready spoke cluster was being read from the **child policy** (the copy ACM propagates into the managed cluster's namespace), rather than from the **root policy** that the user actually creates and annotates.

This worked in practice because ACM's policy propagator copies annotations from root to child when creating the child policy. However, relying on the child copy is fragile:

- It couples deploy-wave ordering to propagation timing/behavior rather than to the source of truth.
- It's inconsistent with how the annotation `ran.openshift.io/soak-seconds` is handled elsewhere in this codebase, which is read from the root policy.
- If the root policy has `.spec.copyPolicyMetadata: false`, the `ran.openshift.io/ztp-deploy-wave` annotation is not being copied to the child policy.

### Change

`newClusterGroupUpgrade` in `controllers/managedclusterForCGU_controller.go` now:

1. Derives the root policy name/namespace from the child policy name via the existing `utils.GetParentPolicyNameAndNamespace`.
2. Fetches the root Policy object.
3. Reads `ztp-deploy-wave` from the root policy's annotations.

### Behavior on missing root policy

If the root policy cannot be found (e.g. a race between root policy deletion and child policy cleanup by the ACM propagator), `newClusterGroupUpgrade` returns an error. Since this reconciler creates the CGU exactly once per cluster (no further reconcile is triggered afterward), silently skipping would have permanently excluded that policy from the generated CGU with no way to self-correct. Returning an error causes controller-runtime to requeue with backoff, giving the propagator time to settle.

Malformed child policy names (parse failure in `GetParentPolicyNameAndNamespace`) continue to be skipped, unchanged from previous behavior.

### Tests

Updated `controllers/managedclusterForCGU_controller_test.go` fixtures to create the corresponding root Policy objects (previously only child policies were created, with the annotation set directly on them). All existing subtests of `TestControllerReconciler` and `TestControllerReconcileWithHundredClusters` pass.