### PR TITLE
CGU Events: emit event when canary batch upgrade times out.

### DIFF
--- a/controllers/clustergroupupgrade_controller.go
+++ b/controllers/clustergroupupgrade_controller.go
@@ -678,6 +678,7 @@ func (r *ClusterGroupUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.
 						if len(clusterGroupUpgrade.Spec.RemediationStrategy.Canaries) != 0 &&
 							clusterGroupUpgrade.Status.Status.CurrentBatch <= len(clusterGroupUpgrade.Spec.RemediationStrategy.Canaries) {
 							r.Log.Info("Canaries batch timed out")
+							r.sendEventCGUBatchUpgradeTimedout(ctx, clusterGroupUpgrade)
 							utils.SetStatusCondition(
 								&clusterGroupUpgrade.Status.Conditions,
 								utils.ConditionTypes.Progressing,

--- a/deploy/upgrades/upgrade-canary-timeout-fail/cgu-canary-timeout-fail.yaml
+++ b/deploy/upgrades/upgrade-canary-timeout-fail/cgu-canary-timeout-fail.yaml
@@ -1,0 +1,33 @@
+apiVersion: ran.openshift.io/v1alpha1
+kind: ClusterGroupUpgrade
+metadata:
+  name: cgu-canary-timeout-fail
+  namespace: default
+  annotations:
+    cluster-group-upgrades-operator/name-suffix: kuttl
+spec:
+  actions:
+    afterCompletion:
+      addClusterLabels:
+        ztp-done: ''
+      deleteClusterLabels:
+        ztp-running: ''
+      deleteObjects: true
+    beforeEnable:
+      addClusterLabels:
+        ztp-running: ''
+  managedPolicies:
+    - policy1-common-cluster-version-policy
+    - policy2-common-pao-sub-policy
+  enable: false
+  clusters:
+  - spoke1
+  - spoke2
+  - spoke4
+  - spoke6
+  remediationStrategy:
+    canaries:
+    - spoke1
+    - spoke2
+    maxConcurrency: 2
+    timeout: 240

--- a/tests/kuttl/cgu/upgrade-canary-timeout/00-assert.yaml
+++ b/tests/kuttl/cgu/upgrade-canary-timeout/00-assert.yaml
@@ -1,0 +1,82 @@
+apiVersion: ran.openshift.io/v1alpha1
+kind: ClusterGroupUpgrade
+metadata:
+  name: cgu-canary-timeout-fail
+  namespace: default
+spec:
+  clusters:
+  - spoke1
+  - spoke2
+  - spoke4
+  - spoke6
+  enable: false
+  managedPolicies:
+  - policy1-common-cluster-version-policy
+  - policy2-common-pao-sub-policy
+  remediationStrategy:
+    canaries:
+    - spoke1
+    - spoke2
+    maxConcurrency: 2
+    timeout: 240
+status:
+  conditions:
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: 'True'
+    type: ClustersSelected
+  - message: Completed validation
+    reason: ValidationCompleted
+    status: 'True'
+    type: Validated
+  - message: Not enabled
+    reason: NotEnabled
+    status: 'False'
+    type: Progressing
+  managedPoliciesForUpgrade:
+  - name: policy1-common-cluster-version-policy
+    namespace: default
+  - name: policy2-common-pao-sub-policy
+    namespace: default
+  managedPoliciesNs:
+    policy1-common-cluster-version-policy: default
+    policy2-common-pao-sub-policy: default
+  remediationPlan:
+  - - spoke1
+  - - spoke2
+  - - spoke4
+    - spoke6
+  status: {}
+---
+apiVersion: v1
+involvedObject:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  name: cgu-canary-timeout-fail
+  namespace: default
+kind: Event
+message: 'New ClusterGroupUpgrade found: cgu-canary-timeout-fail'
+metadata:
+  annotations:
+    cgu.openshift.io/event-type: global
+  namespace: default
+reason: CguCreated
+reportingComponent: ClusterGroupUpgrade
+type: Normal
+---
+apiVersion: events.k8s.io/v1
+kind: Event
+metadata:
+  annotations:
+    cgu.openshift.io/event-type: global
+  namespace: default
+regarding:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  name: cgu-canary-timeout-fail
+  namespace: default
+note: 'New ClusterGroupUpgrade found: cgu-canary-timeout-fail'
+reason: CguCreated
+reportingController: ClusterGroupUpgrade
+action: BuildingRemediationPlan
+type: Normal

--- a/tests/kuttl/cgu/upgrade-canary-timeout/00-setup.yaml
+++ b/tests/kuttl/cgu/upgrade-canary-timeout/00-setup.yaml
@@ -1,0 +1,46 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+
+commands:
+  - command: oc delete events --all
+    namespaced: true
+  - command: oc apply -f ../../../../deploy/acm/policies/all_policies/policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc apply -f ../../../../deploy/acm/policies/all_policies/policy2-common-pao-sub-policy.yaml
+    namespaced: true
+
+  # Mark all four CGU clusters non-compliant on policy1 so spoke1, spoke2, spoke4, and
+  # spoke6 are included in the remediation plan (the shared patch script omits spoke2
+  # on policy1 and marks spoke6 as compliant).
+  - command: >
+      oc patch policy policy1-common-cluster-version-policy -n default
+      --type=merge --subresource=status
+      -p '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"},{"clustername":"spoke2","clusternamespace":"spoke2","compliant":"NonCompliant"},{"clustername":"spoke4","clusternamespace":"spoke4","compliant":"NonCompliant"},{"clustername":"spoke6","clusternamespace":"spoke6","compliant":"NonCompliant"}]}}'
+    ignoreFailure: false
+
+  # Same as above for policy2: all four spokes must be non-compliant to build the
+  # expected plan [[spoke1], [spoke2], [spoke4, spoke6]] with two canary batches.
+  - command: >
+      oc patch policy policy2-common-pao-sub-policy -n default
+      --type=merge --subresource=status
+      -p '{"status":{"compliant":"NonCompliant","status":[{"clustername":"spoke1","clusternamespace":"spoke1","compliant":"NonCompliant"},{"clustername":"spoke2","clusternamespace":"spoke2","compliant":"NonCompliant"},{"clustername":"spoke4","clusternamespace":"spoke4","compliant":"NonCompliant"},{"clustername":"spoke6","clusternamespace":"spoke6","compliant":"NonCompliant"}]}}'
+    ignoreFailure: false
+
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc apply --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc apply -f ../../../../deploy/upgrades/upgrade-canary-timeout-fail/cgu-canary-timeout-fail.yaml
+    namespaced: true

--- a/tests/kuttl/cgu/upgrade-canary-timeout/01-assert.yaml
+++ b/tests/kuttl/cgu/upgrade-canary-timeout/01-assert.yaml
@@ -1,0 +1,196 @@
+apiVersion: ran.openshift.io/v1alpha1
+kind: ClusterGroupUpgrade
+metadata:
+  name: cgu-canary-timeout-fail
+  namespace: default
+spec:
+  clusters:
+  - spoke1
+  - spoke2
+  - spoke4
+  - spoke6
+  enable: true
+  managedPolicies:
+  - policy1-common-cluster-version-policy
+  - policy2-common-pao-sub-policy
+  remediationStrategy:
+    canaries:
+    - spoke1
+    - spoke2
+    maxConcurrency: 2
+    timeout: 240
+status:
+  conditions:
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: 'True'
+    type: ClustersSelected
+  - message: Completed validation
+    reason: ValidationCompleted
+    status: 'True'
+    type: Validated
+  - message: Remediating non-compliant policies
+    reason: InProgress
+    status: 'True'
+    type: Progressing
+  managedPoliciesForUpgrade:
+  - name: policy1-common-cluster-version-policy
+    namespace: default
+  - name: policy2-common-pao-sub-policy
+    namespace: default
+  managedPoliciesNs:
+    policy1-common-cluster-version-policy: default
+    policy2-common-pao-sub-policy: default
+  placementBindings:
+  - cgu-canary-timeout-fail-policy1-common-cluster-version-policy-placement-kuttl
+  - cgu-canary-timeout-fail-policy2-common-pao-sub-policy-placement-kuttl
+  placements:
+  - cgu-canary-timeout-fail-policy1-common-cluster-version-policy-placement-kuttl
+  - cgu-canary-timeout-fail-policy2-common-pao-sub-policy-placement-kuttl
+  remediationPlan:
+  - - spoke1
+  - - spoke2
+  - - spoke4
+    - spoke6
+  safeResourceNames:
+    default/cgu-canary-timeout-fail-policy1-common-cluster-version-policy-placement: cgu-canary-timeout-fail-policy1-common-cluster-version-policy-placement-kuttl
+    default/cgu-canary-timeout-fail-policy2-common-pao-sub-policy-placement: cgu-canary-timeout-fail-policy2-common-pao-sub-policy-placement-kuttl
+  status:
+    currentBatch: 1
+    currentBatchRemediationProgress:
+      spoke1:
+        policyIndex: 0
+        state: InProgress
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-running: ''
+  name: spoke1
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-running: ''
+  name: spoke2
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-running: ''
+  name: spoke4
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    ztp-running: ''
+  name: spoke6
+---
+apiVersion: v1
+involvedObject:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  name: cgu-canary-timeout-fail
+  namespace: default
+kind: Event
+message: ClusterGroupUpgrade cgu-canary-timeout-fail started remediating policies
+metadata:
+  annotations:
+    cgu.openshift.io/event-type: global
+  namespace: default
+reason: CguStarted
+reportingComponent: ClusterGroupUpgrade
+type: Normal
+---
+apiVersion: v1
+involvedObject:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  name: cgu-canary-timeout-fail
+  namespace: default
+kind: Event
+message: 'ClusterGroupUpgrade cgu-canary-timeout-fail: batch index 1 upgrade started'
+metadata:
+  annotations:
+    cgu.openshift.io/batch-clusters: spoke1
+    cgu.openshift.io/event-type: batch
+  namespace: default
+reason: CguStarted
+reportingComponent: ClusterGroupUpgrade
+type: Normal
+---
+apiVersion: v1
+involvedObject:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  name: cgu-canary-timeout-fail
+  namespace: default
+kind: Event
+message: 'ClusterGroupUpgrade cgu-canary-timeout-fail: cluster spoke1 upgrade started'
+metadata:
+  annotations:
+    cgu.openshift.io/event-type: cluster
+  namespace: default
+reason: CguStarted
+reportingComponent: ClusterGroupUpgrade
+type: Normal
+---
+action: RemediationStarted
+apiVersion: events.k8s.io/v1
+kind: Event
+metadata:
+  annotations:
+    cgu.openshift.io/event-type: global
+  namespace: default
+note: ClusterGroupUpgrade cgu-canary-timeout-fail started remediating policies
+reason: CguStarted
+regarding:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  name: cgu-canary-timeout-fail
+  namespace: default
+reportingController: ClusterGroupUpgrade
+type: Normal
+---
+action: RemediationInBatchStarted
+apiVersion: events.k8s.io/v1
+kind: Event
+metadata:
+  annotations:
+    cgu.openshift.io/batch-clusters: spoke1
+    cgu.openshift.io/event-type: batch
+  namespace: default
+note: 'ClusterGroupUpgrade cgu-canary-timeout-fail: batch index 1 upgrade started'
+reason: CguStarted
+regarding:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  name: cgu-canary-timeout-fail
+  namespace: default
+reportingController: ClusterGroupUpgrade
+type: Normal
+---
+action: RemediationInClusterStarted
+apiVersion: events.k8s.io/v1
+kind: Event
+metadata:
+  annotations:
+    cgu.openshift.io/event-type: cluster
+  namespace: default
+note: 'ClusterGroupUpgrade cgu-canary-timeout-fail: cluster spoke1 upgrade started'
+reason: CguStarted
+regarding:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  name: cgu-canary-timeout-fail
+  namespace: default
+related:
+  apiVersion: cluster.open-cluster-management.io/v1
+  kind: ManagedCluster
+  name: spoke1
+reportingController: ClusterGroupUpgrade
+type: Normal

--- a/tests/kuttl/cgu/upgrade-canary-timeout/01-start-upgrade.yaml
+++ b/tests/kuttl/cgu/upgrade-canary-timeout/01-start-upgrade.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+
+commands:
+  - command: oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu-canary-timeout-fail --patch '{"spec":{"enable":true}}' --type=merge
+    ignoreFailure: false

--- a/tests/kuttl/cgu/upgrade-canary-timeout/02-assert.yaml
+++ b/tests/kuttl/cgu/upgrade-canary-timeout/02-assert.yaml
@@ -1,0 +1,119 @@
+apiVersion: ran.openshift.io/v1alpha1
+kind: ClusterGroupUpgrade
+metadata:
+  name: cgu-canary-timeout-fail
+  namespace: default
+spec:
+  clusters:
+  - spoke1
+  - spoke2
+  - spoke4
+  - spoke6
+  enable: true
+  managedPolicies:
+  - policy1-common-cluster-version-policy
+  - policy2-common-pao-sub-policy
+  remediationStrategy:
+    canaries:
+    - spoke1
+    - spoke2
+    maxConcurrency: 2
+    timeout: 0
+status:
+  conditions:
+  - message: All selected clusters are valid
+    reason: ClusterSelectionCompleted
+    status: "True"
+    type: ClustersSelected
+  - message: Completed validation
+    reason: ValidationCompleted
+    status: "True"
+    type: Validated
+  - message: Policy remediation took too long
+    reason: TimedOut
+    status: "False"
+    type: Progressing
+  - message: Policy remediation took too long
+    reason: TimedOut
+    status: "False"
+    type: Succeeded
+  managedPoliciesForUpgrade:
+  - name: policy1-common-cluster-version-policy
+    namespace: default
+  - name: policy2-common-pao-sub-policy
+    namespace: default
+  remediationPlan:
+  - - spoke1
+  - - spoke2
+  - - spoke4
+    - spoke6
+---
+apiVersion: v1
+involvedObject:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  name: cgu-canary-timeout-fail
+  namespace: default
+kind: Event
+message: 'ClusterGroupUpgrade cgu-canary-timeout-fail: some clusters in the batch index
+  1 timed out remediating policies'
+metadata:
+  annotations:
+    cgu.openshift.io/event-type: batch
+    cgu.openshift.io/timedout-clusters: spoke1
+  namespace: default
+reason: CguTimedout
+reportingComponent: ClusterGroupUpgrade
+type: Warning
+---
+apiVersion: v1
+involvedObject:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  name: cgu-canary-timeout-fail
+  namespace: default
+kind: Event
+message: ClusterGroupUpgrade cgu-canary-timeout-fail timed-out remediating policies
+metadata:
+  annotations:
+    cgu.openshift.io/event-type: global
+  namespace: default
+reason: CguTimedout
+reportingComponent: ClusterGroupUpgrade
+type: Warning
+---
+action: RemediationInBatchTimeout
+apiVersion: events.k8s.io/v1
+kind: Event
+metadata:
+  annotations:
+    cgu.openshift.io/event-type: batch
+    cgu.openshift.io/timedout-clusters: spoke1
+  namespace: default
+note: 'ClusterGroupUpgrade cgu-canary-timeout-fail: some clusters in the batch index
+  1 timed out remediating policies'
+reason: CguTimedout
+regarding:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  name: cgu-canary-timeout-fail
+  namespace: default
+reportingController: ClusterGroupUpgrade
+type: Warning
+---
+action: RemediationTimeout
+apiVersion: events.k8s.io/v1
+kind: Event
+metadata:
+  annotations:
+    cgu.openshift.io/event-type: global
+  namespace: default
+note: ClusterGroupUpgrade cgu-canary-timeout-fail timed-out remediating policies
+reason: CguTimedout
+regarding:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  name: cgu-canary-timeout-fail
+  namespace: default
+reportingController: ClusterGroupUpgrade
+type: Warning

--- a/tests/kuttl/cgu/upgrade-canary-timeout/02-errors.yaml
+++ b/tests/kuttl/cgu/upgrade-canary-timeout/02-errors.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+involvedObject:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  namespace: default
+kind: Event
+message: 'ClusterGroupUpgrade cgu-canary-timeout-fail: batch index 2 upgrade started'
+reason: CguStarted
+---
+apiVersion: v1
+involvedObject:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  namespace: default
+kind: Event
+message: 'ClusterGroupUpgrade cgu-canary-timeout-fail: batch index 3 upgrade started'
+reason: CguStarted
+---
+apiVersion: v1
+involvedObject:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  namespace: default
+kind: Event
+message: 'ClusterGroupUpgrade cgu-canary-timeout-fail: cluster spoke2 upgrade started'
+reason: CguStarted
+---
+apiVersion: v1
+involvedObject:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  namespace: default
+kind: Event
+message: 'ClusterGroupUpgrade cgu-canary-timeout-fail: cluster spoke4 upgrade started'
+reason: CguStarted
+---
+apiVersion: v1
+involvedObject:
+  apiVersion: ran.openshift.io/v1alpha1
+  kind: ClusterGroupUpgrade
+  namespace: default
+kind: Event
+message: 'ClusterGroupUpgrade cgu-canary-timeout-fail: cluster spoke6 upgrade started'
+reason: CguStarted

--- a/tests/kuttl/cgu/upgrade-canary-timeout/02-force-timeout.yaml
+++ b/tests/kuttl/cgu/upgrade-canary-timeout/02-force-timeout.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+
+commands:
+  - command: oc --namespace=default patch clustergroupupgrade.ran.openshift.io/cgu-canary-timeout-fail --patch '{"spec":{"remediationStrategy":{"timeout":0}}}' --type=merge

--- a/tests/kuttl/cgu/upgrade-canary-timeout/03-cleanup.yaml
+++ b/tests/kuttl/cgu/upgrade-canary-timeout/03-cleanup.yaml
@@ -1,0 +1,28 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+
+commands:
+  - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete -f ../../../../deploy/acm/policies/all_policies/policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke1 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke2 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke4 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy1-common-cluster-version-policy.yaml
+    namespaced: true
+  - command: oc delete --namespace=spoke6 -f ../../../../deploy/acm/policies/all_policies/child-policy2-common-pao-sub-policy.yaml
+    namespaced: true
+  - command: oc delete -f ../../../../deploy/upgrades/upgrade-canary-timeout-fail/cgu-canary-timeout-fail.yaml
+    namespaced: true
+  - command: oc delete events --all
+    namespaced: true


### PR DESCRIPTION
A batch timeout event is emitted now when any of the clusters in the canary batch times out during policy remediation.

The event is a normal batch timeout event, with no explicit mention to "canary" or "canaries" clusters.

Added kuttl test case upgrade-canary-timeout.