### PR TITLE
Constrain Renovate gomod updates to each branch's go directive

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -84,6 +84,13 @@
             ]
         },
         {
+            "description": "Only propose Go module updates compatible with each branch's existing go directive. Renovate never bumps the go directive itself (its default), and this skips dependency updates whose new version would require a newer Go than the branch targets. Since the config is read from the default branch but the go directive is read per branch, release branches (e.g. go 1.24) are protected from updates that need a newer toolchain, while main follows its own go version.",
+            "matchManagers": [
+                "gomod"
+            ],
+            "constraintsFiltering": "strict"
+        },
+        {
             "description": "Migrated from Dependabot: enable Go module updates and auto-merge digest/patch/minor once CI passes. Also re-enables minor for gomod, overriding the global minor disable above. Major updates are left as normal PRs for manual review.",
             "matchManagers": [
                 "gomod"


### PR DESCRIPTION
MintMaker reads the Renovate config from the default branch (main) and applies it to every branch it processes, so enabling gomod updates on main also enables them on release branches. That is acceptable, except release branches must not take dependency updates that require a newer Go toolchain than the branch targets (we don't up-version Go on release branches).

Add a global gomod packageRule with constraintsFiltering: "strict". Renovate already refuses to bump the go directive itself by default; this additionally skips dependency updates whose new version would need a newer Go than the branch's go directive allows. The go directive is read per branch, so release branches (e.g. go 1.24) are protected while main follows its own Go version.